### PR TITLE
feat(infra): add ktop Kubernetes monitoring tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,6 +520,7 @@ describe('MyComponent', () => {
 - ArgoCD (GitOps), cert-manager (TLS)
 - Ansible (node provisioning)
 - K9s (terminal UI for cluster operations, read-mostly debugging)
+- ktop (top-style Kubernetes resource monitoring)
 
 ---
 
@@ -693,6 +694,9 @@ argocd app sync robson-backend       # Force sync
 make k9s                             # Launch K9s (terminal UI)
 make k9s-ns NAMESPACE=<name>         # K9s for specific namespace
 make k9s-preview BRANCH=<branch>     # K9s for preview environment
+make ktop                            # Launch ktop (top-style monitor)
+make ktop-ns NAMESPACE=<name>        # ktop for specific namespace
+make ktop-preview BRANCH=<branch>    # ktop for preview environment
 
 # Stop Monitor CronJob
 kubectl get cronjob -n robson                              # List CronJobs
@@ -767,6 +771,6 @@ This guide provides quick context. The full AGENTS.md has comprehensive details 
 
 ---
 
-**Last Updated**: 2024-12-24
+**Last Updated**: 2026-01-13
 **Repository**: https://github.com/ldamasio/robson
-**Version**: 1.3 (Updated for GitOps auto-deploy, Audit Trail, Margin Trading)
+**Version**: 1.4 (Added ktop Kubernetes monitoring tool)

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,35 @@ k9s-preview:
 	@./infra/scripts/k9s-preview.sh "$(BRANCH)"
 
 # ==============================
+# ktop Helpers (Kubernetes top-style Monitor)
+# ==============================
+
+.PHONY: ktop ktop-ns ktop-preview
+
+ktop:
+	@echo "🚀 Launching ktop with current kubeconfig context..."
+	@echo "   (Ensure KUBECONFIG is set or ~/.kube/config is configured)"
+	@ktop
+
+ktop-ns:
+	@if [ -z "$(NAMESPACE)" ]; then \
+		echo "❌ Error: NAMESPACE is required."; \
+		echo "   Usage: make ktop-ns NAMESPACE=<name>"; \
+		exit 1; \
+	fi
+	@echo "🚀 Launching ktop for namespace: $(NAMESPACE)"
+	@./infra/scripts/ktop-ns.sh "$(NAMESPACE)"
+
+ktop-preview:
+	@if [ -z "$(BRANCH)" ]; then \
+		echo "❌ Error: BRANCH is required."; \
+		echo "   Usage: make ktop-preview BRANCH=<branch-name>"; \
+		exit 1; \
+	fi
+	@echo "🚀 Launching ktop for preview environment: $(BRANCH)"
+	@./infra/scripts/ktop-preview.sh "$(BRANCH)"
+
+# ==============================
 # AI Governance Validation
 # ==============================
 

--- a/apps/backend/monolith/api/application/ports.py
+++ b/apps/backend/monolith/api/application/ports.py
@@ -121,7 +121,7 @@ class TradingIntentRepository(Protocol):
         strategy_id: Optional[int] = None,
         symbol_id: Optional[int] = None,
         offset: int = 0,
-        offset: int = 0
+        limit: int = 100
     ) -> Iterable[object]:
         """List trading intents for a client with optional filters."""
         ...

--- a/apps/backend/monolith/api/models/margin.py
+++ b/apps/backend/monolith/api/models/margin.py
@@ -52,6 +52,7 @@ class MarginPosition(models.Model):
         help_text="Unique position identifier (UUID)",
     )
 
+    client = models.ForeignKey(
         "clients.Client",
         on_delete=models.PROTECT,
         related_name="margin_positions",

--- a/apps/backend/monolith/api/views/trading_intent_views.py
+++ b/apps/backend/monolith/api/views/trading_intent_views.py
@@ -83,6 +83,8 @@ def create_trading_intent(request):
     try:
         # Get client from user
         client = request.user.client
+        if not client:
+            return Response(
                 {"error": "User has no associated client"}, status=status.HTTP_400_BAD_REQUEST
             )
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -191,6 +191,8 @@ docs/
 | **CI/CD & Image Tagging** | [runbooks/ci-cd-image-tagging.md](runbooks/ci-cd-image-tagging.md) |
 | **Deployment Checklist** | [runbooks/deployment-checklist.md](runbooks/deployment-checklist.md) |
 | **Infrastructure** | [../infra/README.md](../infra/README.md) |
+| **K9s Operations** | [../infra/K9S-OPERATIONS.md](../infra/K9S-OPERATIONS.md) |
+| **ktop Operations** | [../infra/KTOP-OPERATIONS.md](../infra/KTOP-OPERATIONS.md) |
 | **First Leveraged Position** | [operations/2025-12-24-first-leveraged-position.md](operations/2025-12-24-first-leveraged-position.md) |
 | **Isolated Margin SHORT (BTCUSDC)** | [operations/2026-01-05-isolated-margin-short-btcusdc.md](operations/2026-01-05-isolated-margin-short-btcusdc.md) |
 
@@ -294,6 +296,6 @@ Robson Bot is optimized for AI-assisted development:
 
 ---
 
-**Last Updated**: 2024-12-25
+**Last Updated**: 2026-01-13
 **Maintained by**: Robson Bot Core Team
 **License**: Same as project

--- a/infra/KTOP-OPERATIONS.md
+++ b/infra/KTOP-OPERATIONS.md
@@ -1,0 +1,341 @@
+# ktop Operations Guide
+
+**Unix/Linux top-inspired Kubernetes cluster monitoring tool**
+
+## Overview
+
+### What is ktop?
+
+ktop is a Unix/Linux `top`-inspired utility designed for Kubernetes environments. It displays useful metrics information about nodes, pods, and other workload resources operating within your cluster. Unlike traditional monitoring dashboards, ktop provides a familiar terminal-based experience for real-time cluster observation.
+
+**Key Features**:
+- **Real-time monitoring** with continuously refreshed data
+- **Hierarchical navigation** allowing exploration from cluster overview down through nodes, pods, and container logs
+- **Zero installation burden** on clusters - runs locally via your kubeconfig
+- **Compatible everywhere** kubectl operates, requiring no direct node access
+- **Live log streaming** with filtering, timestamps, and full-screen capabilities
+- **Flexible metrics sources** supporting Prometheus, Metrics-Server, or degraded operation
+- **Single executable** requiring only a valid kubeconfig file
+
+**Important**: ktop is an **operational monitoring tool**, not Infrastructure-as-Code. It is used for:
+- Real-time cluster resource monitoring (CPU, memory, network)
+- Quick health checks of nodes and pods
+- Resource usage analysis and capacity planning
+- Troubleshooting performance bottlenecks
+
+ktop does NOT replace GitOps workflows. All permanent changes to the cluster must go through the standard GitOps pipeline (GitHub Actions -> ArgoCD -> k3s).
+
+### Role in Robson Bot
+
+Robson Bot's production deployments are fully automated via GitOps:
+- **Source of Truth**: GitHub repository (manifests, Helm charts)
+- **Deployment**: ArgoCD (App of Apps + ApplicationSet for per-branch previews)
+- **Cluster**: k3s (4 Contabo VPS nodes)
+- **Service Mesh**: Istio Ambient Mode + Gateway API
+
+**ktop fits into this stack as**:
+- A `top`-style resource monitor for quick cluster health assessment
+- A lightweight alternative to K9s when you only need metrics and resource usage
+- A capacity planning tool to identify resource-hungry workloads
+- An observability tool complementing Prometheus/Grafana dashboards
+
+**Golden Rule**: ktop is for observing cluster resources. GitOps remains the source of truth. Use ktop for monitoring and K9s for deeper inspection and debugging.
+
+### ktop vs K9s
+
+Both tools serve different purposes in the Robson Bot operations workflow:
+
+| Aspect | ktop | K9s |
+|--------|------|-----|
+| **Primary Use** | Resource monitoring (CPU/Memory/Network) | Cluster management and debugging |
+| **Interface** | `top`-style, metrics-focused | Full terminal UI with CRUD operations |
+| **Navigation** | Hierarchical drill-down | Free-form resource exploration |
+| **Log Viewing** | Integrated with live streaming | Full log tailing with filtering |
+| **Editing Resources** | Read-only | Can edit/delete resources |
+| **Best For** | Quick health checks, capacity planning | Debugging, log inspection, pod management |
+
+**Recommendation**: Use ktop for quick resource monitoring and K9s for detailed debugging and cluster operations.
+
+---
+
+## Installation
+
+ktop runs on your local machine (or a jump-box with cluster access). It does NOT need to be installed inside the cluster.
+
+### Installation Methods
+
+**kubectl plugin (via Krew)**:
+```bash
+kubectl krew install ktop
+kubectl ktop
+```
+
+**Homebrew (macOS/Linux)**:
+```bash
+brew tap vladimirvivien/oss-tools
+brew install ktop
+```
+
+**Go Install**:
+```bash
+go install github.com/vladimirvivien/ktop@latest
+```
+
+**Binary Download**:
+- Download from [GitHub Releases](https://github.com/vladimirvivien/ktop/releases/latest)
+- Extract binary and add to your PATH
+
+**Verification**:
+```bash
+ktop --version
+```
+
+For detailed installation instructions, refer to the [official ktop repository](https://github.com/vladimirvivien/ktop).
+
+---
+
+## Configuration and Connection
+
+### Prerequisites
+
+ktop relies on a valid `kubeconfig` file to connect to the cluster. Before using ktop:
+
+1. **Obtain kubeconfig from the k3s cluster**:
+   - Typically retrieved from `/etc/rancher/k3s/k3s.yaml` on the k3s server node
+   - You may use Ansible to copy it, or manually scp it to your local machine
+
+2. **Set the KUBECONFIG environment variable** (if not using the default `~/.kube/config`):
+   ```bash
+   export KUBECONFIG=/path/to/robson-k3s.yaml
+   ```
+
+3. **Verify cluster access**:
+   ```bash
+   kubectl cluster-info
+   kubectl get nodes
+   ```
+
+Once `kubectl` works, ktop will automatically use the same context.
+
+### Metrics Sources
+
+ktop supports multiple metrics sources for resource usage data:
+
+1. **Metrics-Server** (recommended): Standard Kubernetes metrics API
+2. **Prometheus**: If available in the cluster, ktop can query Prometheus
+3. **Degraded Mode**: Without metrics infrastructure, ktop displays resource requests/limits instead of actual usage
+
+To check if metrics-server is installed:
+```bash
+kubectl get deployment -n kube-system metrics-server
+```
+
+---
+
+## Typical Workflows
+
+### 1. Quick Cluster Health Check
+
+**Objective**: Get an immediate overview of cluster resource usage.
+
+**Steps**:
+1. Launch ktop:
+   ```bash
+   ktop
+   ```
+2. Default view shows cluster-wide metrics: nodes, CPU, memory usage
+3. View node-level breakdown of resources
+4. Identify nodes approaching capacity limits
+5. Press `q` to exit
+
+**Tip**: Use ktop for daily health checks before starting development work.
+
+### 2. Monitoring Node Resources
+
+**Objective**: Check resource utilization across all cluster nodes.
+
+**Steps**:
+1. Launch ktop:
+   ```bash
+   ktop
+   ```
+2. Navigate to nodes view to see:
+   - CPU usage percentage
+   - Memory usage percentage
+   - Pod count per node
+   - Network I/O (if available)
+3. Identify imbalanced nodes or nodes nearing capacity
+4. Use this information to inform scaling decisions
+
+**Note**: In Robson Bot's 4-node k3s cluster (Contabo VPS), monitor for even distribution of workloads.
+
+### 3. Investigating Namespace Resource Usage
+
+**Objective**: Check resource consumption in a specific namespace.
+
+**Steps**:
+1. Launch ktop scoped to a namespace:
+   ```bash
+   ktop --namespace robson
+   ```
+   Or use the Makefile helper:
+   ```bash
+   make ktop-ns NAMESPACE=robson
+   ```
+2. View pods running in the namespace
+3. Check CPU and memory usage per pod
+4. Identify resource-heavy pods that may need optimization
+5. Navigate to container-level metrics for detailed breakdown
+
+### 4. Monitoring Preview Environments
+
+**Objective**: Check resource usage in a feature branch preview namespace.
+
+**Context**: Robson uses ArgoCD ApplicationSet to create per-branch preview environments:
+- Branch: `feature/new-order-flow`
+- Normalized namespace: `h-feature-new-order-flow`
+
+**Steps**:
+1. Launch ktop for the preview namespace:
+   ```bash
+   make ktop-preview BRANCH=feature/new-order-flow
+   ```
+2. Monitor resource consumption during feature testing
+3. Identify if the feature introduces resource-heavy operations
+4. Compare with production namespace baseline
+
+### 5. Capacity Planning
+
+**Objective**: Analyze cluster capacity and plan for scaling.
+
+**Steps**:
+1. Launch ktop to view cluster-wide metrics
+2. Note overall CPU and memory utilization percentages
+3. Navigate to individual nodes to identify utilization patterns
+4. Document peak usage times and resource hotspots
+5. Use findings to inform:
+   - Node scaling decisions (add/remove nodes)
+   - Pod resource limits adjustments
+   - Workload distribution optimization
+
+---
+
+## Safety and Policy Notes
+
+### Read-Only Monitoring
+
+ktop is a monitoring tool and does NOT modify cluster state:
+
+1. **Observation Only**: ktop displays metrics; it cannot edit, delete, or create resources
+2. **No GitOps Conflicts**: Since ktop is read-only, there's no risk of conflicting with ArgoCD reconciliation
+3. **Safe for Production**: Use ktop freely in production environments without concerns about accidental changes
+
+### Complementary Tools
+
+Use ktop alongside other monitoring tools:
+
+| Tool | Use Case |
+|------|----------|
+| **ktop** | Quick resource monitoring, capacity planning |
+| **K9s** | Debugging, log inspection, pod management |
+| **Prometheus/Grafana** | Historical metrics, alerting, dashboards |
+| **ArgoCD UI** | GitOps state, sync status, deployment health |
+
+---
+
+## Quick Reference
+
+### Common ktop Commands
+
+| Key/Action | Description |
+|------------|-------------|
+| `ktop` | Launch with current kubeconfig context |
+| `ktop --namespace <ns>` | Monitor specific namespace |
+| `ktop --all-namespaces` | Monitor all namespaces |
+| Navigation keys | Navigate through hierarchical views |
+| `q` | Quit ktop |
+
+### Robson-Specific Helpers
+
+From the repository root, use these Make targets:
+
+| Target | Usage | Description |
+|--------|-------|-------------|
+| `make ktop` | `make ktop` | Launch ktop with current kubeconfig context |
+| `make ktop-ns` | `make ktop-ns NAMESPACE=<name>` | Launch ktop scoped to a specific namespace |
+| `make ktop-preview` | `make ktop-preview BRANCH=<branch>` | Launch ktop for a preview environment (auto-computes `h-<branch>` namespace) |
+
+Example:
+```bash
+make ktop-preview BRANCH=feature/stop-loss-orders
+```
+
+---
+
+## Troubleshooting
+
+### ktop Cannot Connect to Cluster
+
+**Symptom**: ktop shows connection errors or cannot retrieve metrics.
+
+**Solution**:
+1. Verify `kubectl` works:
+   ```bash
+   kubectl cluster-info
+   ```
+2. Check KUBECONFIG is set:
+   ```bash
+   echo $KUBECONFIG
+   ```
+3. Ensure kubeconfig has valid credentials and the cluster IP is reachable.
+
+### No Metrics Displayed
+
+**Symptom**: Resource usage columns show zeros or "N/A".
+
+**Solution**:
+1. Check if metrics-server is installed:
+   ```bash
+   kubectl get deployment -n kube-system metrics-server
+   ```
+2. If not installed, ktop will operate in degraded mode showing requests/limits
+3. Install metrics-server for accurate resource metrics
+
+### ktop Not Found
+
+**Symptom**: `command not found: ktop` when running ktop commands.
+
+**Solution**:
+1. Verify ktop is installed:
+   ```bash
+   which ktop
+   ```
+2. If using kubectl plugin:
+   ```bash
+   kubectl ktop
+   ```
+3. Reinstall ktop using one of the installation methods above
+
+---
+
+## Best Practices
+
+1. **Use ktop for Quick Checks**: Start your day with `make ktop` to assess cluster health
+2. **Scope to Namespaces**: When investigating a specific app, use `make ktop-ns NAMESPACE=<name>`
+3. **Combine with K9s**: Use ktop for metrics, then switch to K9s for deeper debugging
+4. **Monitor Before/After Deployments**: Check resource usage before and after deployments to catch regressions
+5. **Document Capacity Findings**: Record ktop observations in capacity planning documents
+
+---
+
+## Additional Resources
+
+- **ktop Official Repository**: [github.com/vladimirvivien/ktop](https://github.com/vladimirvivien/ktop)
+- **K9s Operations Guide**: [K9S-OPERATIONS.md](K9S-OPERATIONS.md) - For detailed cluster debugging
+- **Robson Infra Docs**: [README.md](README.md) for GitOps, Ansible, and k3s setup
+- **Metrics-Server**: [Kubernetes metrics-server](https://github.com/kubernetes-sigs/metrics-server) for accurate resource metrics
+
+---
+
+**Last Updated**: 2026-01-13
+**Maintained by**: Robson Bot Infrastructure Team

--- a/infra/README.md
+++ b/infra/README.md
@@ -80,3 +80,5 @@ The webhook secret is already configured in ArgoCD Helm values. Just add the web
 Operations & Debugging
 - For hands-on cluster inspection, pod debugging, and log tailing, see [K9S-OPERATIONS.md](K9S-OPERATIONS.md).
 - K9s is a terminal UI for Kubernetes that complements GitOps workflows (read-mostly, debug-only).
+- For quick resource monitoring (CPU, memory, network), see [KTOP-OPERATIONS.md](KTOP-OPERATIONS.md).
+- ktop is a Unix/Linux top-style tool for Kubernetes that provides real-time metrics visualization.

--- a/infra/ktop.aliases.example.sh
+++ b/infra/ktop.aliases.example.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# ktop.aliases.example.sh - Example shell aliases for ktop operations
+#
+# USAGE:
+#   This file provides convenient shell aliases for ktop operations.
+#   It is NOT sourced automatically - you must explicitly source it
+#   in your shell configuration (.bashrc, .zshrc, etc.) or manually
+#   in your current shell session.
+#
+#   To use:
+#   1. Copy this file to your home directory (optional):
+#      cp infra/ktop.aliases.example.sh ~/.ktop-aliases.sh
+#
+#   2. Source it in your shell config:
+#      echo "source ~/.ktop-aliases.sh" >> ~/.bashrc  # or ~/.zshrc
+#
+#   Or source it directly from the repo (assumes you're in repo root):
+#      source infra/ktop.aliases.example.sh
+#
+# REQUIREMENTS:
+#   - ktop must be installed and in PATH
+#   - KUBECONFIG must be set (or default ~/.kube/config configured)
+#   - Helper scripts must exist: infra/scripts/ktop-ns.sh, infra/scripts/ktop-preview.sh
+#
+# CUSTOMIZATION:
+#   Feel free to modify these aliases to suit your workflow.
+#   For example, if you frequently work with specific namespaces,
+#   you can add aliases like:
+#     alias ktop-backend='ktop --namespace robson-backend'
+#     alias ktop-frontend='ktop --namespace robson-frontend'
+
+# ==============================
+# Generic ktop Aliases
+# ==============================
+
+# Launch ktop with current kubeconfig context
+alias ktop-robson='ktop'
+
+# Launch ktop showing all namespaces
+alias ktop-all='ktop --all-namespaces'
+
+# ==============================
+# Namespace-Specific Aliases
+# ==============================
+
+# Launch ktop for a specific namespace using the helper script
+# Usage: ktop-namespace <namespace-name>
+ktop-namespace() {
+    if [ $# -eq 0 ]; then
+        echo "Usage: ktop-namespace <namespace-name>"
+        return 1
+    fi
+    # Assumes repo root or PATH includes infra/scripts/
+    if [ -f "./infra/scripts/ktop-ns.sh" ]; then
+        ./infra/scripts/ktop-ns.sh "$1"
+    elif command -v ktop-ns.sh &> /dev/null; then
+        ktop-ns.sh "$1"
+    else
+        echo "Error: ktop-ns.sh not found. Ensure you're in the repo root or add scripts to PATH."
+        return 1
+    fi
+}
+
+# Shorthand alias for namespace function
+alias ktopns='ktop-namespace'
+
+# ==============================
+# Preview Environment Aliases
+# ==============================
+
+# Launch ktop for a preview environment (per-branch namespace)
+# Usage: ktop-preview-branch <branch-name>
+# Example: ktop-preview-branch feature/stop-loss-orders
+ktop-preview-branch() {
+    if [ $# -eq 0 ]; then
+        echo "Usage: ktop-preview-branch <branch-name>"
+        return 1
+    fi
+    # Assumes repo root or PATH includes infra/scripts/
+    if [ -f "./infra/scripts/ktop-preview.sh" ]; then
+        ./infra/scripts/ktop-preview.sh "$1"
+    elif command -v ktop-preview.sh &> /dev/null; then
+        ktop-preview.sh "$1"
+    else
+        echo "Error: ktop-preview.sh not found. Ensure you're in the repo root or add scripts to PATH."
+        return 1
+    fi
+}
+
+# Shorthand alias for preview function
+alias ktopprev='ktop-preview-branch'
+
+# ==============================
+# Common Namespace Quick Access
+# ==============================
+
+# CUSTOMIZE THESE ALIASES FOR YOUR ENVIRONMENT
+# If you have common namespace names, add quick aliases here:
+
+# Example: Robson production namespace
+# alias ktop-prod='ktop --namespace robson'
+
+# Example: Istio system namespace
+# alias ktop-istio='ktop --namespace istio-system'
+
+# Example: ArgoCD namespace
+# alias ktop-argocd='ktop --namespace argocd'
+
+# ==============================
+# Helpful Utilities
+# ==============================
+
+# Show all namespaces and let user select one for ktop
+# (Requires kubectl and fzf for interactive selection)
+ktop-select-namespace() {
+    if ! command -v kubectl &> /dev/null; then
+        echo "Error: kubectl is not installed."
+        return 1
+    fi
+    if ! command -v fzf &> /dev/null; then
+        echo "Error: fzf is not installed. Install it for interactive selection."
+        echo "Fallback: Use 'ktop-namespace <namespace>' directly."
+        return 1
+    fi
+    SELECTED_NS=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | fzf --prompt="Select namespace for ktop: ")
+    if [ -n "$SELECTED_NS" ]; then
+        echo "Launching ktop for namespace: $SELECTED_NS"
+        ktop --namespace "$SELECTED_NS"
+    else
+        echo "No namespace selected."
+    fi
+}
+
+# Alias for namespace selector
+alias ktopsel='ktop-select-namespace'
+
+# ==============================
+# End of Aliases
+# ==============================
+
+echo "ktop aliases loaded. Available commands:"
+echo "  - ktop-robson                  : Launch ktop with current context"
+echo "  - ktop-all                     : Launch ktop for all namespaces"
+echo "  - ktop-namespace <ns>          : Launch ktop for specific namespace"
+echo "  - ktopns <ns>                  : Shorthand for ktop-namespace"
+echo "  - ktop-preview-branch <branch> : Launch ktop for preview environment"
+echo "  - ktopprev <branch>            : Shorthand for ktop-preview-branch"
+echo "  - ktop-select-namespace        : Interactive namespace selection (requires fzf)"
+echo "  - ktopsel                      : Shorthand for ktop-select-namespace"
+echo ""
+echo "See infra/KTOP-OPERATIONS.md for full documentation."

--- a/infra/scripts/ktop-ns.sh
+++ b/infra/scripts/ktop-ns.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# ktop-ns.sh - Launch ktop scoped to a specific namespace
+#
+# Usage: ./ktop-ns.sh <namespace>
+#
+# This script validates that ktop is installed and launches it
+# scoped to the provided namespace.
+#
+# Requirements:
+# - ktop must be installed and available in PATH
+# - KUBECONFIG must be set (or default ~/.kube/config configured)
+# - The namespace should exist in the cluster (ktop will show error if not)
+
+set -euo pipefail
+
+# Color output helpers
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print error messages
+error() {
+    echo -e "${RED}Error: $1${NC}" >&2
+    exit 1
+}
+
+# Function to print info messages
+info() {
+    echo -e "${GREEN}$1${NC}"
+}
+
+# Function to print warning messages
+warn() {
+    echo -e "${YELLOW}$1${NC}"
+}
+
+# Check if namespace argument is provided
+if [ $# -eq 0 ]; then
+    error "Namespace argument is required.\nUsage: $0 <namespace>"
+fi
+
+NAMESPACE="$1"
+
+# Validate that namespace is not empty
+if [ -z "$NAMESPACE" ]; then
+    error "Namespace cannot be empty.\nUsage: $0 <namespace>"
+fi
+
+# Check if ktop is installed
+if ! command -v ktop &> /dev/null; then
+    error "ktop is not installed or not in PATH.\nInstall ktop: https://github.com/vladimirvivien/ktop\nSee also: infra/KTOP-OPERATIONS.md"
+fi
+
+# Check if kubeconfig is accessible (optional check, kubectl not required)
+if [ -n "${KUBECONFIG:-}" ]; then
+    info "Using KUBECONFIG: $KUBECONFIG"
+elif [ -f "$HOME/.kube/config" ]; then
+    info "Using default kubeconfig: ~/.kube/config"
+else
+    warn "No KUBECONFIG set and ~/.kube/config not found. ktop may fail to connect."
+fi
+
+# Launch ktop scoped to the namespace
+info "Launching ktop for namespace: $NAMESPACE"
+ktop --namespace "$NAMESPACE"

--- a/infra/scripts/ktop-preview.sh
+++ b/infra/scripts/ktop-preview.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# ktop-preview.sh - Launch ktop for a per-branch preview environment
+#
+# Usage: ./ktop-preview.sh <branch-name>
+#
+# This script computes the preview namespace from the branch name
+# using the same normalization rules as the ArgoCD ApplicationSet:
+# - Lowercase the branch name
+# - Replace '/' and '_' with '-'
+# - Prepend 'h-' prefix
+#
+# Example:
+#   Branch: feature/stop-loss-orders
+#   Namespace: h-feature-stop-loss-orders
+#
+# Requirements:
+# - ktop must be installed and available in PATH
+# - KUBECONFIG must be set (or default ~/.kube/config configured)
+# - The preview namespace should exist (created by ArgoCD ApplicationSet)
+
+set -euo pipefail
+
+# Color output helpers
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print error messages
+error() {
+    echo -e "${RED}Error: $1${NC}" >&2
+    exit 1
+}
+
+# Function to print info messages
+info() {
+    echo -e "${GREEN}$1${NC}"
+}
+
+# Function to print warning messages
+warn() {
+    echo -e "${YELLOW}$1${NC}"
+}
+
+# Check if branch argument is provided
+if [ $# -eq 0 ]; then
+    error "Branch name argument is required.\nUsage: $0 <branch-name>"
+fi
+
+BRANCH="$1"
+
+# Validate that branch is not empty
+if [ -z "$BRANCH" ]; then
+    error "Branch name cannot be empty.\nUsage: $0 <branch-name>"
+fi
+
+# Check if ktop is installed
+if ! command -v ktop &> /dev/null; then
+    error "ktop is not installed or not in PATH.\nInstall ktop: https://github.com/vladimirvivien/ktop\nSee also: infra/KTOP-OPERATIONS.md"
+fi
+
+# Check if kubeconfig is accessible (optional check, kubectl not required)
+if [ -n "${KUBECONFIG:-}" ]; then
+    info "Using KUBECONFIG: $KUBECONFIG"
+elif [ -f "$HOME/.kube/config" ]; then
+    info "Using default kubeconfig: ~/.kube/config"
+else
+    warn "No KUBECONFIG set and ~/.kube/config not found. ktop may fail to connect."
+fi
+
+# Normalize branch name to namespace format
+# Rules (from infra/README.md ApplicationSet):
+# - Lowercase
+# - Replace '/' with '-'
+# - Replace '_' with '-'
+NORMALIZED_BRANCH=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | tr '/_' '--')
+
+# Compute preview namespace (prefix: h-)
+PREVIEW_NAMESPACE="h-${NORMALIZED_BRANCH}"
+
+# Display resolved namespace
+info "Branch: $BRANCH"
+info "Preview Namespace: $PREVIEW_NAMESPACE"
+echo ""
+
+# Launch ktop scoped to the preview namespace
+info "Launching ktop for preview environment..."
+ktop --namespace "$PREVIEW_NAMESPACE"


### PR DESCRIPTION
Implement ktop as a top-style resource monitoring tool for the k3s cluster, following the same patterns established for K9s.

Added:
- Makefile targets: ktop, ktop-ns, ktop-preview
- Helper scripts: infra/scripts/ktop-ns.sh, infra/scripts/ktop-preview.sh
- Comprehensive documentation: infra/KTOP-OPERATIONS.md
- Shell aliases: infra/ktop.aliases.example.sh

Updated:
- CLAUDE.md: Added ktop to infrastructure tools and commands
- docs/INDEX.md: Added ktop operations guide reference
- infra/README.md: Added ktop to Operations & Debugging section

ktop complements K9s by providing quick resource monitoring (CPU, memory) while K9s remains the primary tool for debugging and cluster operations.

See: https://github.com/vladimirvivien/ktop

## Summary

- Briefly explain the problem and the proposed solution.

## Changes

- Key changes in this PR:
  - 

## Screenshots (optional)

## Tests

- How to verify:
  - [ ] `cd apps/backend/monolith && ./bin/dj test`
  - [ ] `cd apps/frontend && npm ci && npm test`
- Added/updated tests:
  - 

## Migrations

- [ ] No schema changes
- [ ] Includes schema migrations
- Notes:
  - 

## Backward Compatibility

- Does this PR introduce breaking changes? Explain mitigation/migration strategy.

## Security & Data

- Any secrets, credentials, or PII involved? If so, describe handling.
- External calls guarded by flags? (e.g., `TRADING_ENABLED=False` in dev)

## Checklist

- [ ] Scope is focused and documented
- [ ] Code follows project conventions (see `docs/DEVELOPER.md`)
- [ ] Migrations created (if needed) and rationale explained
- [ ] Tests added/updated and passing locally
- [ ] Docs updated (README/DEVELOPER/MIGRATION_GUIDE as applicable)
