### PR TITLE
docs(gitops): ArgoCD strategy for RBX Systems

### DIFF
--- a/infra/docs/gitops/ARGOCD-DECISION-RECORD.md
+++ b/infra/docs/gitops/ARGOCD-DECISION-RECORD.md
@@ -1,0 +1,155 @@
+# ADR: Argo CD GitOps Organization Strategy
+
+**ID**: ADR-GITOPS-001
+**Status**: Accepted
+**Date**: 2026-02-15
+**Authors**: Platform Engineering, RBX Systems
+**Supersedes**: None
+
+---
+
+## Context
+
+RBX Systems operates a k3s Kubernetes cluster across four VPS nodes, hosting multiple products (robson, strategos, thalamus) and shared platform infrastructure. Argo CD is already deployed and managing production workloads through a combination of:
+
+- A root App-of-Apps (`infra/k8s/gitops/app-of-apps/root.yml`) that bootstraps nine child Applications covering platform components and product deployments.
+- An ApplicationSet (`infra/k8s/gitops/applicationsets/branches.yml`) that generates preview environments from pull requests.
+- Individual Application manifests for production and DNS deployments.
+
+As the platform grows to support additional products and potentially additional clusters, we need a clear decision on how to organize Argo CD resources. The two primary patterns (App-of-Apps and ApplicationSet) can serve overlapping purposes, and without a clear strategy, teams risk duplicating management of the same resources, creating sync conflicts, or over-engineering the setup.
+
+The current state works but is not documented. Engineers make ad-hoc decisions about whether to add a new Application YAML or modify an ApplicationSet. This ADR establishes the rules.
+
+---
+
+## Decision
+
+**RBX Systems adopts a coexistence model where App-of-Apps and ApplicationSet serve distinct, non-overlapping roles.**
+
+### App-of-Apps Scope
+
+The root App-of-Apps manages:
+
+1. **Platform bootstrap**: Argo CD self-management, cert-manager, Istio Ambient, Gateway API CRDs.
+2. **ApplicationSet resources**: The ApplicationSet controller definitions themselves are children of the root App-of-Apps.
+3. **Singleton Applications**: One-off services that do not follow a repeatable pattern.
+
+The root App-of-Apps is the entry point. It is the first thing installed (after Argo CD bootstrap) and the last thing removed.
+
+### ApplicationSet Scope
+
+ApplicationSets manage:
+
+1. **Branch preview environments**: Using the PR generator (already in place).
+2. **Multi-product deployments**: Using git directory generators when more than one product shares the same deployment pattern (triggered when strategos or thalamus reach production).
+3. **Multi-environment deployments**: Using list or matrix generators when more than two environments are needed for the same product.
+4. **Multi-cluster deployments**: Using cluster generators when a second cluster is added.
+
+### Ownership Rule
+
+**A Kubernetes resource is managed by exactly one Argo CD Application.** That Application is created either by the App-of-Apps (explicit YAML) or by an ApplicationSet (generated). Never both.
+
+### Migration Path
+
+When a group of singleton Applications becomes large enough (more than five following the same pattern) or spans multiple environments (more than two), migrate them from explicit Application YAMLs to an ApplicationSet. Remove the old Application YAMLs from the App-of-Apps directory and add the ApplicationSet manifest instead.
+
+---
+
+## Alternatives Considered
+
+### Alternative 1: App-of-Apps Only
+
+Use explicit Application YAMLs for everything. No ApplicationSets.
+
+**Rejected because**:
+- Does not scale. With three products, three environments, and potential multi-cluster, the number of YAML files grows multiplicatively.
+- Requires manual file creation for every new combination of product and environment.
+- Branch previews would require a custom controller or CI script instead of the built-in PR generator.
+
+### Alternative 2: ApplicationSet Only
+
+Use ApplicationSets for everything. No App-of-Apps.
+
+**Rejected because**:
+- Platform components (cert-manager, Istio, Argo CD self-management) are heterogeneous. Forcing them into a template adds complexity without reducing repetition.
+- Loses the clarity of explicit bootstrap. The root App-of-Apps is easy to read and audit.
+- ApplicationSet requires the controller to be running, which creates a chicken-and-egg problem for bootstrapping Argo CD itself.
+
+### Alternative 3: Separate Repos per Product
+
+Each product gets its own GitOps repository with its own Argo CD configuration.
+
+**Rejected because**:
+- Adds operational overhead for a small team.
+- Platform components need to be duplicated or managed in a third repo.
+- Cross-product consistency becomes harder to enforce.
+- The current single-repo model (`robson`) works well for the team size and product count.
+
+### Alternative 4: Kustomize Overlays Instead of ApplicationSet
+
+Use Kustomize overlays to generate per-environment manifests, and keep App-of-Apps pointing to each overlay.
+
+**Rejected because**:
+- Solves the environment dimension but not the product dimension.
+- Does not provide automatic discovery of new directories or branches.
+- ApplicationSet is a native Argo CD feature with better lifecycle management (prune, sync, health) than Kustomize-generated files consumed by App-of-Apps.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Clear ownership**: Every resource has exactly one managing Application. No sync conflicts.
+- **Incremental adoption**: The strategy does not require immediate changes. Phase 2 and beyond activate only when triggered by growth.
+- **Reduced duplication**: ApplicationSet eliminates repetitive YAML when patterns emerge.
+- **Auditability**: The root App-of-Apps provides a human-readable inventory of what runs on the cluster.
+- **Branch previews for free**: The existing ApplicationSet pattern scales without modification.
+- **Multi-cluster ready**: The cluster generator path is documented and ready when needed.
+
+### Negative
+
+- **Two mental models**: Engineers must understand both App-of-Apps and ApplicationSet. Mitigated by clear documentation and decision criteria.
+- **Migration effort**: Moving from explicit Applications to ApplicationSet requires careful cutover to avoid resource deletion during the transition. Mitigated by documenting the migration procedure.
+- **Template debugging**: ApplicationSet templates with Go syntax are harder to debug than explicit YAML. Mitigated by keeping templates simple and testing with `argocd appset generate`.
+- **Prune risk**: ApplicationSet with auto-prune can delete resources if a generator stops matching. Mitigated by understanding prune behavior and using `preserveResourcesOnDeletion` where appropriate.
+
+---
+
+## Review Criteria
+
+This decision should be revisited when any of the following conditions are met:
+
+| Trigger | Threshold | Action |
+|---------|-----------|--------|
+| Product count in production | Reaches 3 | Evaluate if the git directory generator covers all products cleanly |
+| Environment count per product | Exceeds 4 | Evaluate matrix generator or merge generator for complexity |
+| Cluster count | Reaches 2 | Activate multi-cluster ApplicationSet. Validate cluster generator behavior |
+| Agent-authored PRs | More than 10 per month | Evaluate if git file generator is needed for agent deployment descriptors |
+| Sync conflicts | Any occurrence | Investigate ownership overlap. One resource, one owner |
+| ApplicationSet count | Exceeds 10 | Evaluate if ApplicationSets themselves should be managed by an ApplicationSet (meta-pattern) |
+
+**Scheduled review**: Every 6 months or when a trigger is hit, whichever comes first.
+
+---
+
+## Open Questions
+
+1. **AppProject boundaries**: Should each product have its own Argo CD AppProject to enforce RBAC and source restrictions? Current setup uses the default project. This becomes important when multiple teams manage different products.
+
+2. **Secret management**: Argo CD does not manage secrets natively. The current approach uses Kubernetes Secrets committed to Git (with limited sensitive data) or created manually. Evaluate Sealed Secrets, External Secrets Operator, or SOPS integration as the secret count grows.
+
+3. **Sync windows**: Should production have maintenance windows where Argo CD does not auto-sync? Currently, auto-sync is always on. This may need revisiting if deployments cause user-facing disruptions during peak hours.
+
+4. **Notification integration**: Argo CD supports notifications (Slack, email) on sync events. Evaluate adding notifications for failed syncs and drift detection.
+
+5. **Image updater**: Argo CD Image Updater can watch container registries and update image tags without CI commits. Evaluate whether this simplifies the current `sed`-based manifest update workflow or introduces unacceptable indirection.
+
+---
+
+## References
+
+- [ARGOCD-STRATEGY.md](./ARGOCD-STRATEGY.md) (companion strategy document)
+- [EXAMPLES.md](./EXAMPLES.md) (YAML examples)
+- [ADR-0004: GitOps Preview Environments](../../../docs/adr/ADR-0004-gitops-preview-environments.md)
+- [ADR-0011: GitOps Automatic Manifest Updates](../../../docs/adr/ADR-0011-gitops-automatic-manifest-updates.md)

--- a/infra/docs/gitops/ARGOCD-STRATEGY.md
+++ b/infra/docs/gitops/ARGOCD-STRATEGY.md
@@ -1,0 +1,407 @@
+# ArgoCD GitOps Strategy for RBX Systems
+
+**Status**: Living document
+**Owner**: Platform Engineering
+**Last updated**: 2026-02-15
+
+---
+
+## 1. Objective
+
+RBX Systems uses GitOps with Argo CD as the single mechanism for applying Kubernetes manifests to production clusters. This document defines the strategy for organizing Argo CD resources across all RBX products (robson, strategos, thalamus) and shared infrastructure running on k3s across four VPS nodes.
+
+**Core principle**: Git is the source of truth. No manual `kubectl apply` in production. Every change enters through a pull request, gets reviewed, and reaches the cluster via Argo CD synchronization.
+
+---
+
+## 2. Core Concepts
+
+### Application
+
+The fundamental unit in Argo CD. An Application connects a Git source (repository + path + revision) to a Kubernetes destination (cluster + namespace). It defines what to deploy, where to deploy it, and how to synchronize.
+
+### App-of-Apps
+
+A pattern where one Argo CD Application manages other Application manifests. The "root" Application points to a directory containing child Application YAMLs. Argo CD reads those YAMLs and creates the child Applications automatically.
+
+**Characteristics**:
+- Each child Application is an explicit YAML file
+- Full control over every Application definition
+- Changes require editing or adding individual YAML files
+- Good for small, well-known sets of Applications
+
+### ApplicationSet
+
+An Argo CD controller that generates Applications from templates combined with generators. Instead of writing N Application YAMLs by hand, you write one template and a generator that produces N Applications from data sources (Git directories, lists, pull requests, cluster selectors).
+
+**Characteristics**:
+- One template produces many Applications
+- Generators discover targets automatically (directories, branches, clusters)
+- Reduces repetition at the cost of abstraction
+- Good for scaling across many apps or environments
+
+### Generators
+
+Data sources that feed an ApplicationSet template. Common generators:
+
+| Generator | Source | Use Case |
+|-----------|--------|----------|
+| Git Directory | Directories in a repo path | One Application per service directory |
+| Git File | JSON/YAML files in a repo | One Application per config file |
+| List | Inline key-value pairs | Explicit environment or cluster list |
+| Pull Request | Open PRs from GitHub/GitLab | Preview environments per branch |
+| Cluster | Registered Argo CD clusters | Deploy to all clusters |
+| Matrix | Combination of two generators | Cross-product (apps x environments) |
+| Merge | Overlay of two generators | Base config + per-target overrides |
+
+### Templates
+
+The Application blueprint inside an ApplicationSet. Uses Go template syntax with variables from the generator. One template, combined with generator output, produces one Application per generated entry.
+
+---
+
+## 3. Recommended Strategy: Coexistence with Clear Roles
+
+RBX Systems adopts a **coexistence model** where App-of-Apps and ApplicationSet serve different purposes in the same cluster.
+
+### App-of-Apps: Bootstrap and Boundaries
+
+App-of-Apps handles:
+
+- **Cluster bootstrap**: The root Application that brings Argo CD to life and installs foundational platform components (cert-manager, Istio, Gateway API CRDs, Argo CD itself).
+- **Platform boundary**: A clear, auditable list of platform-level services that rarely change and require explicit review.
+- **One-off Applications**: Services that do not follow a repeatable pattern (custom CRDs, external integrations, singleton infrastructure).
+
+The root Application at `infra/k8s/gitops/app-of-apps/root.yml` already fulfills this role today. It manages nine child Applications including Istio Ambient, cert-manager, Gateway API CRDs, and Argo CD self-management.
+
+### ApplicationSet: Scale and Standardization
+
+ApplicationSet handles:
+
+- **Multi-product deployment**: Generating Applications for robson, strategos, and thalamus from a shared template.
+- **Multi-environment deployment**: Producing staging, production, and preview instances from a single definition.
+- **Branch previews**: The existing `branches.yml` ApplicationSet already generates preview environments per pull request.
+- **Future multi-cluster**: When RBX Systems expands beyond one k3s cluster, ApplicationSet with cluster generators will deploy across clusters without manual Application creation.
+
+### How They Interact
+
+```
+Root App-of-Apps (bootstrap)
+├── Platform: cert-manager, Istio, Gateway API, ArgoCD (explicit Applications)
+├── Product ApplicationSets (one per pattern)
+│   ├── Branch Previews ApplicationSet (PR generator)
+│   ├── Product Environments ApplicationSet (git directory or list generator)
+│   └── DNS ApplicationSet (list generator, when > 2 DNS configs)
+└── One-off Applications (singleton services, custom integrations)
+```
+
+The root App-of-Apps references ApplicationSet manifests as children. Argo CD creates the ApplicationSet resources, which then generate their own Applications. There is no conflict because:
+
+1. The root manages ApplicationSet **resources** (the controller definitions)
+2. The ApplicationSets manage the **generated Applications** (the actual deployments)
+3. No resource is managed by both patterns simultaneously
+
+---
+
+## 4. Decision Criteria
+
+### When to Use App-of-Apps
+
+| Criterion | Threshold |
+|-----------|-----------|
+| Number of managed Applications | Fewer than 5 of the same type |
+| Environment count | 1 or 2 environments |
+| Change frequency | Rarely changes (platform components) |
+| Uniqueness | Each Application has distinct configuration |
+| Auditability requirement | Need to see exact definition in a single file |
+
+**Use App-of-Apps when** you need explicit control and the set of Applications is small, stable, and heterogeneous.
+
+### When to Use ApplicationSet
+
+| Criterion | Threshold |
+|-----------|-----------|
+| Number of similar Applications | More than 5 following the same pattern |
+| Environment count | More than 2 environments |
+| Products sharing the same template | More than 1 product (robson + strategos) |
+| Branch preview environments | Any number (PR generator) |
+| Cluster count | 2 or more clusters |
+| Automated PR workflows | Agents or CI opening PRs that create Applications |
+
+**Use ApplicationSet when** you have repeatable patterns and the cost of maintaining individual YAML files exceeds the cost of template abstraction.
+
+### RBX Systems Specific Thresholds
+
+- **Today (1 cluster, 1 product in production)**: App-of-Apps for platform bootstrap. ApplicationSet for branch previews. Individual Applications for DNS and production.
+- **When strategos or thalamus enter production**: Migrate product deployments to an ApplicationSet with git directory generator.
+- **When a second cluster is added**: ApplicationSet with cluster generator becomes the default for all product deployments.
+- **When agents begin opening PRs for deployments**: ApplicationSet with PR or git file generator ensures new entries are picked up automatically.
+
+---
+
+## 5. Anti-patterns
+
+### Dual Management
+
+Never manage the same Kubernetes resource from both an App-of-Apps child and an ApplicationSet-generated Application. This causes sync loops, unexpected deletions, and drift. One resource, one owner.
+
+### Over-templating Early
+
+Do not introduce ApplicationSet for two Applications. The overhead of template debugging, generator configuration, and reduced readability is not justified until you have at least five similar Applications or three environments.
+
+### Ignoring Prune Behavior
+
+ApplicationSet with `automated.prune: true` will delete Applications (and their resources) when the generator stops producing them. For example, removing a directory that a git directory generator was watching will delete the corresponding Application and all its resources. Understand prune behavior before enabling it.
+
+### Mixing Helm Values in Templates
+
+Keep Helm values in `values.yaml` files committed to Git, not inline in ApplicationSet templates. Inline values are hard to diff, review, and override per environment.
+
+### Manual kubectl in Production
+
+Any change applied via `kubectl apply` or `kubectl edit` directly will be reverted by Argo CD self-heal. This is by design. All changes must go through Git.
+
+### Circular Self-management Without Bootstrap
+
+Argo CD managing its own installation requires a bootstrap step. The first install must be done via Helm or `kubectl apply`. After that, Argo CD can manage itself through an Application pointing to its own chart. Do not skip the initial bootstrap.
+
+---
+
+## 6. Adoption Roadmap
+
+### Phase 1: Current State (Complete)
+
+- Root App-of-Apps manages platform components
+- Individual Applications for robson production and DNS
+- ApplicationSet for branch preview environments
+- CI/CD updates manifests with SHA-tagged images
+
+### Phase 2: Documentation and Structure (In Progress)
+
+- Document the strategy (this file)
+- Organize `infra/k8s/gitops/` with clear directory separation
+- Establish labeling standards for audit
+
+### Phase 3: Multi-product ApplicationSet
+
+**Trigger**: Second product (strategos or thalamus) enters production.
+
+- Create a git directory generator ApplicationSet that scans `infra/k8s/products/`
+- Each product gets a subdirectory with its manifests or Helm values
+- The root App-of-Apps adds the new ApplicationSet as a child
+
+### Phase 4: Environment Matrix
+
+**Trigger**: More than two environments need the same product.
+
+- Introduce a matrix generator combining products and environments
+- Use merge generator for per-environment overrides (resource limits, replicas, feature flags)
+
+### Phase 5: Multi-cluster
+
+**Trigger**: Second k3s cluster is provisioned.
+
+- Register the new cluster in Argo CD
+- Add cluster generator to the product ApplicationSet
+- Evaluate cluster-scoped vs namespace-scoped Application distribution
+
+### Phase 6: Agent-driven Deployments
+
+**Trigger**: Automated agents begin proposing deployment changes via PR.
+
+- Standardize PR labels for agent-authored changes
+- ApplicationSet with git file generator reads deployment descriptors committed by agents
+- Review workflow includes automated validation gates
+
+---
+
+## 7. Suggested Directory Structure
+
+```
+infra/
+├── k8s/
+│   ├── gitops/
+│   │   ├── app-of-apps/
+│   │   │   └── root.yml                  # Bootstrap: platform + ApplicationSet refs
+│   │   ├── applications/
+│   │   │   ├── robson-prod.yml            # Explicit singleton Applications
+│   │   │   ├── dns-metallb.yml
+│   │   │   └── dns-nodeport.yml
+│   │   ├── applicationsets/
+│   │   │   ├── branches.yml              # PR preview generator
+│   │   │   ├── products.yml              # (Phase 3) Git directory generator
+│   │   │   └── environments.yml          # (Phase 4) List or matrix generator
+│   │   ├── policies/
+│   │   │   ├── sync-windows.yml          # Maintenance windows
+│   │   │   └── resource-overrides.yml    # Custom health checks
+│   │   └── rbac/
+│   │       ├── project-robson.yml        # AppProject for robson
+│   │       ├── project-strategos.yml     # AppProject for strategos
+│   │       └── project-platform.yml      # AppProject for platform components
+│   ├── platform/                          # Platform service manifests
+│   │   ├── argocd/
+│   │   ├── cert-manager/
+│   │   ├── gateway-api-crds/
+│   │   └── istio-ambient/
+│   ├── prod/                              # Production manifests (robson)
+│   ├── staging/                           # Staging manifests
+│   └── products/                          # (Phase 3) Per-product directories
+│       ├── robson/
+│       │   ├── prod/values.yaml
+│       │   └── staging/values.yaml
+│       ├── strategos/
+│       │   └── prod/values.yaml
+│       └── thalamus/
+│           └── prod/values.yaml
+├── charts/                                # Helm charts
+│   ├── robson-backend/
+│   └── robson-frontend/
+├── apps/                                  # Infrastructure apps (DNS, etc.)
+│   └── dns/
+└── docs/
+    └── gitops/
+        ├── ARGOCD-STRATEGY.md             # This file
+        ├── ARGOCD-DECISION-RECORD.md      # ADR
+        ├── EXAMPLES.md                    # YAML examples
+        ├── RUNBOOK-GITOPS-CHANGES.md      # Change runbook
+        └── GLOSSARY.md                    # Term definitions
+```
+
+---
+
+## 8. Operations
+
+### Adding a New Application
+
+**For a singleton (unique configuration)**:
+
+1. Create an Application YAML in `infra/k8s/gitops/applications/`
+2. Reference it from the root App-of-Apps if it should be bootstrapped automatically
+3. Open a PR, get review, merge
+4. Argo CD syncs the root, discovers the new child, creates the Application
+
+**For a product following the standard pattern (Phase 3+)**:
+
+1. Create a directory under `infra/k8s/products/<product-name>/`
+2. Add a `values.yaml` or Kustomize overlay
+3. The git directory generator ApplicationSet detects the new directory automatically
+4. Open a PR, get review, merge
+5. Argo CD creates the Application on next sync
+
+### Adding a New Environment
+
+**With list generator**:
+
+1. Edit the ApplicationSet that uses a list generator
+2. Add a new entry to the list with environment-specific values
+3. Open a PR, get review, merge
+4. The ApplicationSet generates a new Application for the environment
+
+**With git directory generator**:
+
+1. Create a subdirectory for the environment under the product directory
+2. The generator discovers it automatically
+3. Open a PR, get review, merge
+
+### Adding a New Cluster
+
+1. Register the cluster in Argo CD: `argocd cluster add <context-name>`
+2. If using a cluster generator ApplicationSet, the new cluster is picked up automatically
+3. If using explicit Applications, duplicate and modify the destination for the new cluster
+4. Verify with `argocd app list` that Applications target the correct cluster
+
+---
+
+## 9. Label Standards for Audit
+
+All Argo CD Applications and ApplicationSets must include the following labels for traceability:
+
+```yaml
+metadata:
+  labels:
+    rbx.change_id: "PR-42"           # PR number or ticket ID that introduced the change
+    rbx.agent_id: "human"            # "human", "ci-bot", "claude-code", or agent identifier
+    rbx.env: "production"            # Target environment: production, staging, preview
+    rbx.product: "robson"            # Product name: robson, strategos, thalamus, platform
+    app.kubernetes.io/managed-by: "argocd"
+    app.kubernetes.io/part-of: "rbx-systems"
+```
+
+**Rules**:
+
+- `rbx.change_id` is set by the PR author or CI pipeline. For agent-authored PRs, this is the PR number.
+- `rbx.agent_id` identifies who created the change. Human engineers use "human". CI pipelines use their bot name. AI agents use their identifier.
+- `rbx.env` matches the target environment. Preview environments use "preview".
+- `rbx.product` groups Applications by business domain.
+
+These labels enable queries like:
+
+```bash
+# All Applications for robson in production
+argocd app list -l rbx.product=robson,rbx.env=production
+
+# All changes made by CI bot
+argocd app list -l rbx.agent_id=ci-bot
+
+# All Applications from a specific PR
+argocd app list -l rbx.change_id=PR-42
+```
+
+---
+
+## 10. PR Workflow Integration
+
+### Human Engineers
+
+1. Create a feature branch
+2. Modify manifests or Helm values under `infra/`
+3. Open a PR against `main`
+4. CI validates YAML syntax and runs dry-run diff (if configured)
+5. Reviewer approves
+6. Merge to `main`
+7. Argo CD detects the change (via webhook, under 30 seconds) and syncs
+
+### AI Agents
+
+Agents proposing infrastructure changes must follow the same PR workflow with additional constraints:
+
+1. Agent creates a branch with prefix `agent/` (e.g., `agent/update-robson-replicas`)
+2. Agent commits changes with `rbx.agent_id` in the commit message trailer
+3. Agent opens a PR with the label `agent-authored`
+4. A human reviewer must approve before merge (agents cannot approve their own PRs)
+5. After merge, the standard GitOps flow applies
+
+**Agent PR template**:
+
+```markdown
+## Summary
+[Agent-generated description of the change]
+
+## Change Type
+- [ ] Application configuration
+- [ ] New Application
+- [ ] ApplicationSet modification
+- [ ] Platform component update
+
+## Risk Assessment
+- [ ] Low: cosmetic or non-functional change
+- [ ] Medium: configuration change with rollback path
+- [ ] High: structural change affecting sync behavior
+
+## Labels
+- rbx.agent_id: <agent-identifier>
+- rbx.change_id: <this-PR-number>
+```
+
+---
+
+## 11. References
+
+- [Argo CD Documentation](https://argo-cd.readthedocs.io/)
+- [ApplicationSet Controller](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/)
+- [App-of-Apps Pattern](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/)
+- [ADR-0004: GitOps Preview Environments](../../docs/adr/ADR-0004-gitops-preview-environments.md)
+- [ADR-0011: GitOps Automatic Manifest Updates](../../../docs/adr/ADR-0011-gitops-automatic-manifest-updates.md)
+- [ARGOCD-DECISION-RECORD.md](./ARGOCD-DECISION-RECORD.md)
+- [EXAMPLES.md](./EXAMPLES.md)
+- [RUNBOOK-GITOPS-CHANGES.md](./RUNBOOK-GITOPS-CHANGES.md)

--- a/infra/docs/gitops/EXAMPLES.md
+++ b/infra/docs/gitops/EXAMPLES.md
@@ -1,0 +1,302 @@
+# Argo CD Configuration Examples
+
+Minimal, complete YAML examples for RBX Systems GitOps patterns. No secrets are included.
+
+---
+
+## 1. App-of-Apps Bootstrap
+
+The root Application that bootstraps all other Applications and ApplicationSets.
+
+```yaml
+# infra/k8s/gitops/app-of-apps/root.yml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rbx-root
+  namespace: argocd
+  labels:
+    rbx.product: platform
+    rbx.env: production
+    rbx.agent_id: human
+    app.kubernetes.io/part-of: rbx-systems
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ldamasio/robson.git
+    targetRevision: main
+    path: infra/k8s/gitops/app-of-apps
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+```
+
+The `app-of-apps/` directory contains child Application YAMLs. When a new YAML is added to that directory and merged, the root Application syncs and creates the child.
+
+### Child Application Example
+
+```yaml
+# infra/k8s/gitops/app-of-apps/cert-manager.yml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: platform-cert-manager
+  namespace: argocd
+  labels:
+    rbx.product: platform
+    rbx.env: production
+    rbx.agent_id: human
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ldamasio/robson.git
+    targetRevision: main
+    path: infra/k8s/platform/cert-manager
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+```
+
+---
+
+## 2. ApplicationSet: Git Directory Generator
+
+Generates one Application per subdirectory under `infra/k8s/products/`. When a new product directory is added, a new Application is created automatically.
+
+```yaml
+# infra/k8s/gitops/applicationsets/products.yml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: rbx-products
+  namespace: argocd
+  labels:
+    rbx.product: platform
+    rbx.env: production
+    rbx.agent_id: human
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: https://github.com/ldamasio/robson.git
+        revision: main
+        directories:
+          - path: infra/k8s/products/*
+  template:
+    metadata:
+      name: "rbx-{{ .path.basename }}"
+      namespace: argocd
+      labels:
+        rbx.product: "{{ .path.basename }}"
+        rbx.env: production
+        rbx.agent_id: ci-bot
+        app.kubernetes.io/part-of: rbx-systems
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/ldamasio/robson.git
+        targetRevision: main
+        path: "{{ .path.path }}"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{ .path.basename }}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 3
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 2m
+```
+
+**Directory structure that feeds this generator**:
+
+```
+infra/k8s/products/
+├── robson/
+│   ├── deployment.yml
+│   ├── service.yml
+│   └── ingress.yml
+├── strategos/
+│   ├── deployment.yml
+│   ├── service.yml
+│   └── ingress.yml
+└── thalamus/
+    ├── deployment.yml
+    └── service.yml
+```
+
+Each subdirectory produces one Application: `rbx-robson`, `rbx-strategos`, `rbx-thalamus`.
+
+---
+
+## 3. ApplicationSet: List Generator for Environments
+
+Generates one Application per environment from an explicit list. Useful when environments have different cluster endpoints or namespace conventions.
+
+```yaml
+# infra/k8s/gitops/applicationsets/environments.yml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: rbx-robson-envs
+  namespace: argocd
+  labels:
+    rbx.product: robson
+    rbx.agent_id: human
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - env: production
+            namespace: robson
+            cluster: https://kubernetes.default.svc
+            values_file: values-prod.yaml
+          - env: staging
+            namespace: robson-staging
+            cluster: https://kubernetes.default.svc
+            values_file: values-staging.yaml
+  template:
+    metadata:
+      name: "robson-{{ .env }}"
+      namespace: argocd
+      labels:
+        rbx.product: robson
+        rbx.env: "{{ .env }}"
+        rbx.agent_id: human
+        app.kubernetes.io/part-of: rbx-systems
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/ldamasio/robson.git
+        targetRevision: main
+        path: infra/charts/robson-backend
+        helm:
+          valueFiles:
+            - "{{ .values_file }}"
+      destination:
+        server: "{{ .cluster }}"
+        namespace: "{{ .namespace }}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 3
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 2m
+```
+
+This produces two Applications: `robson-production` and `robson-staging`, each pointing to the same Helm chart but with different values files.
+
+---
+
+## 4. Recommended Repository Layout
+
+```
+infra/
+├── k8s/
+│   ├── gitops/                           # Argo CD resource definitions
+│   │   ├── app-of-apps/
+│   │   │   ├── root.yml                  # Root Application (entry point)
+│   │   │   ├── cert-manager.yml          # Platform: cert-manager
+│   │   │   ├── istio-ambient.yml         # Platform: Istio
+│   │   │   ├── gateway-api-crds.yml      # Platform: Gateway API
+│   │   │   ├── argocd.yml               # Platform: Argo CD self-management
+│   │   │   ├── robson-prod.yml           # Product: robson (until Phase 3)
+│   │   │   └── applicationsets.yml       # References the applicationsets/ dir
+│   │   │
+│   │   ├── applicationsets/
+│   │   │   ├── branches.yml              # PR preview generator
+│   │   │   ├── products.yml              # (Phase 3) Git dir generator
+│   │   │   └── environments.yml          # (Phase 4) List generator
+│   │   │
+│   │   ├── policies/
+│   │   │   └── sync-windows.yml          # Maintenance windows (optional)
+│   │   │
+│   │   └── rbac/
+│   │       ├── project-robson.yml        # AppProject for robson
+│   │       └── project-platform.yml      # AppProject for platform
+│   │
+│   ├── platform/                         # Platform component manifests
+│   │   ├── argocd/
+│   │   ├── cert-manager/
+│   │   ├── gateway-api-crds/
+│   │   └── istio-ambient/
+│   │
+│   ├── prod/                             # Robson production manifests
+│   ├── staging/                          # Robson staging manifests
+│   │
+│   └── products/                         # (Phase 3) Per-product manifests
+│       ├── robson/
+│       ├── strategos/
+│       └── thalamus/
+│
+├── charts/                               # Helm charts (source for Helm Applications)
+│   ├── robson-backend/
+│   │   ├── Chart.yaml
+│   │   ├── values.yaml                   # Default values
+│   │   ├── values-prod.yaml              # Production overrides
+│   │   ├── values-staging.yaml           # Staging overrides
+│   │   └── templates/
+│   └── robson-frontend/
+│
+├── apps/                                 # Infrastructure applications (DNS, etc.)
+│
+└── docs/
+    └── gitops/
+        ├── ARGOCD-STRATEGY.md
+        ├── ARGOCD-DECISION-RECORD.md
+        ├── EXAMPLES.md                   # This file
+        ├── RUNBOOK-GITOPS-CHANGES.md
+        └── GLOSSARY.md
+```
+
+### Key Points
+
+- `gitops/app-of-apps/` contains explicit Application YAMLs for the root and its platform children.
+- `gitops/applicationsets/` contains ApplicationSet definitions. The root App-of-Apps has a child that points to this directory.
+- `platform/` contains the actual manifests for infrastructure services.
+- `prod/` and `staging/` contain product deployment manifests (current approach).
+- `products/` is the future home for per-product directories consumed by the git directory generator.
+- `charts/` contains Helm charts referenced by Applications and ApplicationSets.
+
+---
+
+## References
+
+- [ARGOCD-STRATEGY.md](./ARGOCD-STRATEGY.md)
+- [ARGOCD-DECISION-RECORD.md](./ARGOCD-DECISION-RECORD.md)
+- [Argo CD ApplicationSet Generators](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators/)

--- a/infra/docs/gitops/GLOSSARY.md
+++ b/infra/docs/gitops/GLOSSARY.md
@@ -1,0 +1,52 @@
+# GitOps Glossary for RBX Systems
+
+Short definitions of terms used across the GitOps documentation.
+
+---
+
+| Term | Definition |
+|------|------------|
+| **Application** | The core Argo CD resource. Connects a Git source (repo, path, revision) to a Kubernetes destination (cluster, namespace). One Application manages one set of resources. |
+| **ApplicationSet** | An Argo CD resource that generates multiple Applications from a template and one or more generators. Reduces repetition when many Applications follow the same pattern. |
+| **App-of-Apps** | A pattern where one Application manages other Application manifests. The parent points to a directory containing child Application YAMLs. Used for bootstrapping and organizing platform components. |
+| **Auto-sync** | Argo CD feature that automatically applies changes when Git diverges from the cluster state. Controlled by `syncPolicy.automated` in the Application spec. |
+| **Bootstrap** | The initial installation step that brings Argo CD into the cluster. Done once via Helm or kubectl. After bootstrap, Argo CD can manage itself. |
+| **Cluster generator** | An ApplicationSet generator that produces entries from registered Argo CD clusters. Used for multi-cluster deployments. |
+| **Drift** | The difference between the desired state in Git and the actual state in the cluster. Argo CD detects drift and can auto-correct it (self-heal). |
+| **Finalizer** | A Kubernetes mechanism that runs cleanup logic before a resource is deleted. Argo CD uses `resources-finalizer.argocd.argoproj.io` to delete managed resources when an Application is removed. |
+| **Generator** | A data source inside an ApplicationSet that produces entries (key-value pairs). Each entry, combined with the template, creates one Application. Types: git directory, git file, list, pull request, cluster, matrix, merge. |
+| **Git directory generator** | Produces one entry per subdirectory at a given path in a Git repository. Adding a new directory automatically creates a new Application. |
+| **GitOps** | An operational model where Git is the single source of truth for infrastructure and application configuration. Changes are applied by reconciling Git state with cluster state. |
+| **Health check** | Argo CD's assessment of whether a managed resource is functioning correctly. Built-in checks exist for Deployments, StatefulSets, Services, and other resource types. Custom checks can be defined. |
+| **List generator** | Produces entries from an inline list of key-value pairs. Used when targets are known and enumerable (environments, clusters). |
+| **Matrix generator** | Combines two generators to produce a cross-product of entries. Example: products x environments. |
+| **Merge generator** | Overlays entries from one generator onto another. Used for base configuration with per-target overrides. |
+| **PR generator** | An ApplicationSet generator that produces entries from open pull requests in a Git repository. Used for preview environments. |
+| **Prune** | The Argo CD action of deleting resources from the cluster that no longer exist in Git. Enabled by `automated.prune: true` in sync policy. |
+| **Reconciliation** | The process where Argo CD compares Git state with cluster state and determines what actions to take (create, update, delete). |
+| **Self-heal** | Argo CD feature that reverts manual changes made directly to the cluster, restoring the state defined in Git. Enabled by `automated.selfHeal: true`. |
+| **Source of truth** | The authoritative location for configuration. In GitOps, this is always the Git repository. Cluster state is derived, not authoritative. |
+| **Sync** | The act of applying the desired state from Git to the cluster. Can be automatic (auto-sync) or manual (triggered by a user). |
+| **Sync window** | A time-based policy that controls when Argo CD is allowed to sync. Used to prevent deployments during maintenance or peak hours. |
+| **Template** | The Application blueprint inside an ApplicationSet. Uses Go template syntax with variables from generator entries. |
+| **Webhook** | An HTTP callback from GitHub to Argo CD that notifies of new commits. Eliminates polling delay (3 minutes) and triggers near-instant sync. |
+
+---
+
+## RBX-specific Terms
+
+| Term | Definition |
+|------|------------|
+| **rbx.change_id** | Label identifying the PR or ticket that introduced a change. Format: `PR-<number>` or ticket ID. |
+| **rbx.agent_id** | Label identifying who authored the change. Values: `human`, `ci-bot`, `claude-code`, or other agent identifiers. |
+| **rbx.env** | Label for the target environment. Values: `production`, `staging`, `preview`. |
+| **rbx.product** | Label for the business domain. Values: `robson`, `strategos`, `thalamus`, `platform`. |
+| **Root Application** | The top-level App-of-Apps that bootstraps all platform components and ApplicationSets. Located at `infra/k8s/gitops/app-of-apps/root.yml`. |
+| **Break-glass** | Emergency procedure allowing direct cluster changes outside the standard PR workflow. Requires authorization and post-incident documentation. |
+
+---
+
+## References
+
+- [ARGOCD-STRATEGY.md](./ARGOCD-STRATEGY.md)
+- [RUNBOOK-GITOPS-CHANGES.md](./RUNBOOK-GITOPS-CHANGES.md)

--- a/infra/docs/gitops/RUNBOOK-GITOPS-CHANGES.md
+++ b/infra/docs/gitops/RUNBOOK-GITOPS-CHANGES.md
@@ -1,0 +1,254 @@
+# Runbook: GitOps Production Changes
+
+Step-by-step procedures for making changes to RBX Systems production infrastructure through the GitOps workflow.
+
+---
+
+## 1. Standard Change Flow
+
+### Step 1: Create a Branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b <type>/<short-description>
+```
+
+Use conventional branch prefixes: `feat/`, `fix/`, `chore/`, `infra/`.
+
+### Step 2: Make Changes
+
+Edit the relevant manifests under `infra/`. Common change locations:
+
+| Change Type | Path |
+|-------------|------|
+| Application image tag | `infra/k8s/prod/*.yml` (automated by CI for app code) |
+| Helm values | `infra/charts/<chart>/values.yaml` |
+| New Application | `infra/k8s/gitops/applications/<name>.yml` |
+| New ApplicationSet | `infra/k8s/gitops/applicationsets/<name>.yml` |
+| Platform component | `infra/k8s/platform/<component>/` |
+| New product directory | `infra/k8s/products/<product>/` |
+
+### Step 3: Validate Locally
+
+Before pushing, check YAML syntax:
+
+```bash
+# Validate YAML syntax
+yamllint infra/k8s/gitops/**/*.yml
+
+# If using Helm, template locally
+helm template infra/charts/robson-backend/ -f infra/charts/robson-backend/values.yaml
+
+# If using Kustomize
+kubectl kustomize infra/k8s/prod/
+```
+
+### Step 4: Open a Pull Request
+
+```bash
+git add infra/
+git commit -m "infra(<scope>): <description>"
+git push origin <branch-name>
+gh pr create --title "infra: <description>" --body "## Summary\n<what and why>"
+```
+
+### Step 5: Review
+
+The reviewer checks:
+
+- YAML syntax and structure
+- Correct namespace and cluster destination
+- Labels include `rbx.change_id`, `rbx.agent_id`, `rbx.env`
+- No secrets or credentials in plain text
+- Sync policy is appropriate (auto vs manual)
+- Resource limits and requests are set
+
+### Step 6: Merge
+
+After approval, merge the PR to `main`. Squash merge is preferred for clean history.
+
+### Step 7: Argo CD Synchronization
+
+After merge to `main`:
+
+1. **Webhook delivery** (under 30 seconds): GitHub sends a webhook to Argo CD at `https://argocd.robson.rbx.ia.br/api/webhook`.
+2. **Argo CD detects the change**: Compares the new Git state with the cluster state.
+3. **Auto-sync executes**: If `syncPolicy.automated` is enabled, Argo CD applies the changes.
+4. **Health check**: Argo CD monitors resource health (Deployments, StatefulSets, Jobs).
+
+### Step 8: Verify
+
+```bash
+# Check Application sync status
+argocd app get <app-name>
+
+# Check all Applications
+argocd app list
+
+# Watch sync progress
+argocd app wait <app-name> --sync --health --timeout 120
+```
+
+In the Argo CD web UI at `https://argocd.robson.rbx.ia.br`:
+- Application should show "Synced" and "Healthy"
+- Resource tree should show all resources green
+
+---
+
+## 2. Troubleshooting
+
+### Application Stuck in "OutOfSync"
+
+**Symptoms**: Application shows OutOfSync but auto-sync does not trigger.
+
+**Checks**:
+1. Verify `syncPolicy.automated` is set in the Application spec
+2. Check for sync errors: `argocd app get <app-name> --show-operation`
+3. Check Argo CD controller logs: `kubectl logs -n argocd -l app.kubernetes.io/name=argocd-application-controller --tail=50`
+4. Force a manual sync: `argocd app sync <app-name>`
+
+### Application Shows "Degraded"
+
+**Symptoms**: Resources deployed but health check fails.
+
+**Checks**:
+1. Check pod status: `kubectl get pods -n <namespace>`
+2. Check pod events: `kubectl describe pod <pod-name> -n <namespace>`
+3. Check container logs: `kubectl logs <pod-name> -n <namespace> --tail=50`
+4. Common causes: image pull errors, resource quota exceeded, readiness probe failing
+
+### Webhook Not Triggering Sync
+
+**Symptoms**: Changes merged but Argo CD does not detect them for up to 3 minutes (polling interval).
+
+**Checks**:
+1. Verify webhook delivery in GitHub: Repository Settings > Webhooks > Recent Deliveries
+2. Check for HTTP errors (403, 404, 500)
+3. Verify Argo CD server is reachable from GitHub
+4. If webhook is broken, Argo CD falls back to polling (default 3-minute interval)
+
+### Sync Conflict Between Applications
+
+**Symptoms**: Two Applications trying to manage the same resource. One shows "OutOfSync" or resources flicker.
+
+**Resolution**:
+1. Identify which Applications manage the conflicting resource
+2. Remove the resource from one Application's source path
+3. Ensure the ownership rule: one resource, one Application
+
+### Prune Deleted a Resource Unexpectedly
+
+**Symptoms**: A resource disappears after sync because it was removed from Git.
+
+**Resolution**:
+1. If intentional: no action needed
+2. If unintentional: restore the manifest from Git history and re-commit
+3. To prevent: use `syncOptions: [Prune=false]` for sensitive resources, or annotate resources with `argocd.argoproj.io/sync-options: Prune=false`
+
+### Image Tag Not Updated
+
+**Symptoms**: CI built a new image but the deployment still runs the old tag.
+
+**Checks**:
+1. Verify CI updated the manifest: `git log --oneline -5 infra/k8s/prod/`
+2. Check for `[skip ci]` commit from the bot
+3. Run the GitOps sync checker manually: `gh workflow run gitops-sync-checker.yml`
+4. Verify the image exists on DockerHub: `docker manifest inspect ldamasio/rbs-backend-prod:sha-<hash>`
+
+---
+
+## 3. Rollback Procedure
+
+### Option A: Git Revert (Preferred)
+
+```bash
+# Find the commit that introduced the bad change
+git log --oneline -10
+
+# Revert the commit
+git revert <commit-hash>
+
+# Push the revert
+git push origin main
+```
+
+Argo CD syncs the reverted state automatically.
+
+### Option B: Manual Sync to Previous Revision
+
+```bash
+# Sync to a specific Git commit
+argocd app sync <app-name> --revision <good-commit-hash>
+```
+
+Note: This is temporary. The next auto-sync will bring the Application back to HEAD. Use Git revert for a permanent fix.
+
+### Option C: Disable Auto-sync Temporarily
+
+```bash
+# Disable auto-sync
+argocd app set <app-name> --sync-policy none
+
+# Fix the issue in Git
+# ...
+
+# Re-enable auto-sync
+argocd app set <app-name> --sync-policy automated --self-heal --auto-prune
+```
+
+---
+
+## 4. Break-glass Policy
+
+In exceptional circumstances where the standard PR workflow cannot be followed (cluster outage, security incident, time-critical fix):
+
+### Authorization
+
+- Requires verbal or written approval from at least one platform engineer
+- The engineer performing the action must document it immediately after
+
+### Permitted Actions
+
+- Direct `kubectl apply` of a specific manifest to restore service
+- Manual Argo CD sync or rollback via CLI or UI
+- Temporary disabling of auto-sync on a specific Application
+
+### Post-incident Requirements
+
+1. Create a follow-up PR within 24 hours that captures the change in Git
+2. Ensure Git and cluster state are reconciled (no drift)
+3. Document the incident: what happened, what was done, and why the standard flow was bypassed
+4. Review whether the break-glass scenario reveals a gap in the standard workflow
+
+### Boundaries
+
+- Break-glass does not authorize bulk changes across multiple Applications
+- Break-glass does not authorize changes to Argo CD RBAC or credentials
+- All break-glass actions must be logged and traceable
+
+---
+
+## 5. Quick Reference
+
+| Task | Command |
+|------|---------|
+| List all Applications | `argocd app list` |
+| Get Application details | `argocd app get <name>` |
+| Manual sync | `argocd app sync <name>` |
+| Sync with prune | `argocd app sync <name> --prune` |
+| Watch sync progress | `argocd app wait <name> --sync --health` |
+| View sync history | `argocd app history <name>` |
+| Diff (what would change) | `argocd app diff <name>` |
+| Disable auto-sync | `argocd app set <name> --sync-policy none` |
+| Re-enable auto-sync | `argocd app set <name> --sync-policy automated --self-heal --auto-prune` |
+| View ApplicationSets | `kubectl get applicationsets -n argocd` |
+| Generate ApplicationSet preview | `argocd appset generate <file.yml>` |
+
+---
+
+## References
+
+- [ARGOCD-STRATEGY.md](./ARGOCD-STRATEGY.md)
+- [ARGOCD-DECISION-RECORD.md](./ARGOCD-DECISION-RECORD.md)
+- [EXAMPLES.md](./EXAMPLES.md)


### PR DESCRIPTION
## Summary

Adds GitOps documentation clarifying how RBX Systems will organize Argo CD using a coexistence model:
App-of-Apps for bootstrap and boundaries, and ApplicationSet for scale and standardization.

This PR records decision criteria, adoption phases, and operational runbooks aligned with PR-first change management.

## Changes

- Added `infra/docs/gitops/ARGOCD-STRATEGY.md`
- Added `infra/docs/gitops/ARGOCD-DECISION-RECORD.md` (ADR-GITOPS-001, Accepted)
- Added `infra/docs/gitops/EXAMPLES.md`
- Added `infra/docs/gitops/RUNBOOK-GITOPS-CHANGES.md`
- Added `infra/docs/gitops/GLOSSARY.md`

## Validation

- Documentation only
- No manifests applied, no cluster changes
- No secrets added

## Follow-ups

- Confirm alignment with current cluster configuration and existing Argo CD structure
- Decide AppProjects strategy and secret management approach
- Apply label standards to existing Application manifests
