### PR TITLE
infra(gitops): Phase 2 alignment with documented ArgoCD strategy

### DIFF
--- a/infra/docs/gitops/GAP-ANALYSIS-PHASE2.md
+++ b/infra/docs/gitops/GAP-ANALYSIS-PHASE2.md
@@ -1,0 +1,140 @@
+# GitOps Phase 2: Gap Analysis Report
+
+**Date**: 2026-02-15
+**Scope**: Alignment between documented strategy (PR #32) and current repo state
+
+---
+
+## 1. Inventory Summary
+
+| Category | Count | Details |
+|----------|-------|---------|
+| Application manifests | 16 | 8 in root.yml, 4 in platform/istio-ambient, 1 cert-manager, 1 argocd, 1 gateway-api, 1 robson-prod |
+| ApplicationSet manifests | 1 | Branch previews |
+| AppProject definitions | 0 | All use "default" project |
+| Total ArgoCD files | 12 | Across gitops/, platform/ directories |
+
+---
+
+## 2. Gap Analysis
+
+### GAP-01: No Labels on Root App-of-Apps Children
+
+**Documented standard** (ARGOCD-STRATEGY.md, Section 9):
+All Applications must include `rbx.env`, `rbx.agent_id`, `rbx.change_id`, `rbx.product`.
+
+**Current state**:
+- 8 Applications in `root.yml` have zero labels
+- 4 Istio Applications in `platform/istio-ambient/` have zero labels
+- `platform/cert-manager/app.yml` has zero labels
+- `platform/argocd/app.yml` has zero labels
+- `platform/gateway-api-crds/app.yml` has zero labels
+
+**Compliant**:
+- `robson-prod.yml` has `app.kubernetes.io/name` and `app.kubernetes.io/component` (partial)
+- `dns-metallb.yml` and `dns-nodeport.yml` have `app.kubernetes.io/name`, `app.kubernetes.io/component`, `deployment-scenario` (partial)
+
+**Verdict**: 0 out of 16 Applications fully comply with the label standard.
+
+### GAP-02: No AppProjects Defined
+
+**Documented recommendation** (ARGOCD-DECISION-RECORD.md, Open Question 1):
+Evaluate AppProjects per product for RBAC and source restrictions.
+
+**Current state**:
+All 16 Applications use `project: default`. No AppProject manifests exist.
+
+**Risk**: Any Application can deploy to any namespace and reference any source repo. No tenant isolation.
+
+### GAP-03: ApplicationSet Missing RBX Labels
+
+**Documented standard**: All ArgoCD resources must include RBX labels.
+
+**Current state**:
+`branches.yml` ApplicationSet has no metadata labels. The generated Applications have only `robson/preview: 'true'`.
+
+### GAP-04: Inconsistent syncPolicy Across Applications
+
+**Root children** (root.yml):
+- Minimal syncPolicy: `automated.prune: true`, `selfHeal: true`
+- No retry, no syncOptions, no allowEmpty
+
+**Standalone Applications** (robson-prod.yml, dns-*.yml):
+- Full syncPolicy: retry with backoff, syncOptions (CreateNamespace, PrunePropagationPolicy, PruneLast), allowEmpty: false
+- ignoreDifferences for Deployment replicas
+
+**Risk**: Root children have no retry backoff. A transient failure (network, API throttle) will not be retried.
+
+### GAP-05: Root App-of-Apps Embeds All Children in One File
+
+**Current**: `root.yml` is a single multi-document YAML with 8 resources (root + 7 children).
+
+**Documented layout** (ARGOCD-STRATEGY.md, Section 7): Suggests separate files per child in `app-of-apps/` directory.
+
+**Assessment**: Not blocking. ArgoCD handles multi-document YAML. However, separate files improve diff readability and per-resource PR review. Recommend splitting in a future PR.
+
+### GAP-06: No Sync Windows or Policies Directory
+
+**Documented layout**: `infra/k8s/gitops/policies/` for sync windows and resource overrides.
+
+**Current state**: Directory does not exist. No sync windows are defined.
+
+**Assessment**: Low priority. Relevant when production deployments need maintenance windows.
+
+### GAP-07: DNS Applications Not Referenced from Root
+
+**Current**: `dns-metallb.yml` and `dns-nodeport.yml` are in `infra/k8s/gitops/applications/` but root.yml points to `infra/k8s/gitops/app-of-apps/`. These DNS Applications are not children of the root.
+
+**Assessment**: They must be applied separately or moved into the app-of-apps directory. Clarify ownership model.
+
+---
+
+## 3. Proposed Changes (This PR)
+
+| Change | Files Affected | Risk |
+|--------|---------------|------|
+| Add RBX labels to root.yml (all 8 Applications) | root.yml | Low: labels are metadata-only |
+| Add RBX labels to platform Applications | 4 istio + cert-manager + argocd + gateway-api | Low: labels are metadata-only |
+| Add RBX labels to standalone Applications | robson-prod, dns-metallb, dns-nodeport | Low: labels are metadata-only |
+| Add RBX labels to ApplicationSet | branches.yml | Low: labels are metadata-only |
+| Create AppProject manifests | 3 new files in gitops/projects/ | No cluster impact: files only, not applied |
+| Create gap analysis report | This file | Documentation only |
+| Create migration plan | MIGRATION-PLAN.md | Documentation only |
+
+---
+
+## 4. Deferred to Future PRs
+
+| Change | Reason | Suggested PR |
+|--------|--------|--------------|
+| Split root.yml into separate files | Structural change, needs careful ArgoCD sync testing | PR #N+1 |
+| Add retry backoff to root children | Behavioral change, needs testing | PR #N+1 |
+| Create policies/ directory with sync windows | Not urgent, no production schedule conflicts yet | PR #N+2 |
+| Move DNS Applications into root or clarify ownership | Needs decision on whether DNS is bootstrapped or standalone | PR #N+1 |
+| Migrate to AppProjects (apply to cluster) | Requires cluster access and ArgoCD reconfiguration | PR #N+2 |
+
+---
+
+## 5. Label Compliance Matrix (After This PR)
+
+| Resource | rbx.env | rbx.product | rbx.agent_id | rbx.change_id |
+|----------|---------|-------------|--------------|----------------|
+| robson-root | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| istio-ambient | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| gateway-api-crds | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| robson-backend | production | robson | human | CHANGE_ID_PLACEHOLDER |
+| robson-frontend | production | robson | human | CHANGE_ID_PLACEHOLDER |
+| robson-branch-previews | preview | robson | human | CHANGE_ID_PLACEHOLDER |
+| platform-cert-manager | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| platform-argocd | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| istio-base | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| istio-cni | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| istiod-ambient | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| istio-ztunnel | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| platform-cert-manager (app.yml) | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| platform-argocd (app.yml) | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| gateway-api-crds (app.yml) | production | platform | human | CHANGE_ID_PLACEHOLDER |
+| robson-prod | production | robson | human | CHANGE_ID_PLACEHOLDER |
+| dns-infrastructure-metallb | production | dns | human | CHANGE_ID_PLACEHOLDER |
+| dns-infrastructure-nodeport | production | dns | human | CHANGE_ID_PLACEHOLDER |
+| branches ApplicationSet | preview | robson | human | CHANGE_ID_PLACEHOLDER |

--- a/infra/docs/gitops/MIGRATION-PLAN.md
+++ b/infra/docs/gitops/MIGRATION-PLAN.md
@@ -1,0 +1,109 @@
+# GitOps Phase 2: Migration Plan
+
+**Date**: 2026-02-15
+**Status**: Proposed
+**Prerequisite**: Gap analysis completed (GAP-ANALYSIS-PHASE2.md)
+
+---
+
+## Migration Sequence
+
+Changes are organized in three incremental PRs to minimize risk and allow validation between steps.
+
+### PR 1: Labels + AppProjects (This PR)
+
+**Scope**: Metadata-only changes to existing files. New AppProject files (not applied to cluster).
+
+**Changes**:
+1. Add RBX labels to all Applications in `root.yml`
+2. Add RBX labels to all platform Applications (`platform/istio-ambient/*.yml`, `platform/cert-manager/app.yml`, `platform/argocd/app.yml`, `platform/gateway-api-crds/app.yml`)
+3. Add RBX labels to standalone Applications (`robson-prod.yml`, `dns-metallb.yml`, `dns-nodeport.yml`)
+4. Add RBX labels to ApplicationSet (`branches.yml`)
+5. Create AppProject manifests in `gitops/projects/` (not referenced by any Application yet)
+6. Gap analysis report and migration plan documentation
+
+**Downtime risk**: None. Labels are metadata-only. ArgoCD will sync the label changes on next reconciliation. No resources are created or deleted.
+
+**Rollback**: Revert the commit. Labels are removed on next sync.
+
+**Validation**:
+- `argocd app list` shows all Applications
+- `argocd app get <name>` shows updated labels
+- No sync errors in ArgoCD UI
+
+### PR 2: Structural Alignment + AppProject Activation
+
+**Scope**: Split root.yml, activate AppProjects, normalize syncPolicy.
+
+**Changes**:
+1. Split `root.yml` into separate files (one per child Application)
+2. Update `spec.project` from `default` to the appropriate AppProject (`rbx-platform`, `rbx-applications`, `rbx-previews`)
+3. Add the AppProject directory (`gitops/projects/`) to the root App-of-Apps source or create a dedicated Application that manages projects
+4. Add retry backoff to root children that currently lack it
+5. Move DNS Applications into the app-of-apps directory or document them as standalone with clear ownership
+
+**Downtime risk**: Low. Splitting root.yml into separate files in the same directory does not change what ArgoCD sees (it reads all YAMLs in the path). Changing `spec.project` requires the AppProject to exist first.
+
+**Order of operations**:
+1. Apply AppProjects to cluster first (either manually or via a temporary Application)
+2. Then update `spec.project` in all Applications
+3. ArgoCD will reconcile and validate project permissions
+
+**Rollback**: Revert `spec.project` changes back to `default`. AppProjects can be left in place (they are permissive, not restrictive by default).
+
+**Validation**:
+- `argocd proj list` shows three projects
+- `argocd app get <name>` shows the correct project
+- All Applications are still Synced and Healthy
+- No permission errors in sync operations
+
+### PR 3: Policies + Sync Windows + Documentation Updates
+
+**Scope**: Operational guardrails and documentation alignment.
+
+**Changes**:
+1. Create `gitops/policies/` directory with sync window definitions (if production needs maintenance windows)
+2. Update ARGOCD-STRATEGY.md to reflect the completed Phase 2 changes
+3. Update ARGOCD-DECISION-RECORD.md to mark open questions as resolved
+4. Add notification templates for sync failures (if ArgoCD Notifications controller is available)
+
+**Downtime risk**: None. Sync windows are additive. Documentation changes have no cluster impact.
+
+**Rollback**: Remove sync window definitions if they block legitimate deployments.
+
+---
+
+## Safe Migration Rules
+
+### What Can Be Changed Without Downtime
+
+- **Labels**: Adding or modifying labels does not affect resource reconciliation
+- **Annotations**: Adding or modifying annotations does not affect resource reconciliation
+- **AppProject creation**: Creating an AppProject has no impact until Applications reference it
+- **New files in existing directories**: ArgoCD picks them up on next sync
+- **syncOptions additions**: Adding options like PruneLast is additive
+
+### What Requires Careful Ordering
+
+- **Changing spec.project**: The target AppProject must exist before the Application references it. Otherwise ArgoCD rejects the sync with a "project not found" error.
+- **Splitting multi-document YAML**: If the root.yml is split into separate files in the same directory, ArgoCD should handle it transparently. However, verify that no resource names change during the split.
+- **Removing Applications from root.yml**: If a child is removed from root.yml while it still has managed resources, those resources will be deleted (if prune is enabled). Remove the Application only after its resources are managed by another Application or deliberately decommissioned.
+
+### What Requires Manual Sync
+
+- **AppProject activation**: After AppProjects are created, changing `spec.project` on existing Applications may trigger a sync error if the project permissions do not match the current source/destination. Test with one Application first.
+- **Moving files between directories**: If a file moves from `gitops/applications/` to `gitops/app-of-apps/`, ArgoCD may see it as a new resource in one location and a deleted resource in another. Coordinate the move carefully.
+
+---
+
+## Verification Checklist
+
+After each PR merge:
+
+- [ ] `argocd app list` shows all expected Applications
+- [ ] No Applications in "Unknown" or "Error" state
+- [ ] `argocd app get <name> --show-operation` shows no failed syncs
+- [ ] Labels are visible: `argocd app list -l rbx.env=production`
+- [ ] Production workloads are running: `kubectl get pods -n robson`
+- [ ] DNS is resolving: `kubectl get pods -n dns`
+- [ ] Preview environments (if any active PRs) are functional

--- a/infra/k8s/gitops/app-of-apps/root.yml
+++ b/infra/k8s/gitops/app-of-apps/root.yml
@@ -3,6 +3,12 @@ kind: Application
 metadata:
   name: robson-root
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:
@@ -23,6 +29,12 @@ kind: Application
 metadata:
   name: istio-ambient
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:
@@ -42,6 +54,12 @@ kind: Application
 metadata:
   name: gateway-api-crds
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:
@@ -62,6 +80,12 @@ kind: Application
 metadata:
   name: robson-backend
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: robson
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:
@@ -87,6 +111,12 @@ kind: Application
 metadata:
   name: robson-frontend
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: robson
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:
@@ -112,6 +142,12 @@ kind: Application
 metadata:
   name: robson-branch-previews
   namespace: argocd
+  labels:
+    rbx.env: preview
+    rbx.product: robson
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:
@@ -132,6 +168,12 @@ kind: Application
 metadata:
   name: platform-cert-manager
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:
@@ -152,6 +194,12 @@ kind: Application
 metadata:
   name: platform-argocd
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:

--- a/infra/k8s/gitops/applications/dns-metallb.yml
+++ b/infra/k8s/gitops/applications/dns-metallb.yml
@@ -1,35 +1,39 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: robson-prod
+  name: dns-infrastructure-metallb
   namespace: argocd
   labels:
-    app.kubernetes.io/name: robson-prod
-    app.kubernetes.io/component: production
+    app.kubernetes.io/name: dns-infrastructure
+    app.kubernetes.io/component: authoritative-dns
     app.kubernetes.io/part-of: rbx-systems
+    deployment-scenario: metallb
     rbx.env: production
-    rbx.product: robson
+    rbx.product: dns
     rbx.agent_id: human
     rbx.change_id: CHANGE_ID_PLACEHOLDER
+  # Finalizers ensure Application is deleted properly
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
-  
+
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/k8s/prod
-  
+    path: infra/apps/dns/overlays/metallb
+
   destination:
     server: https://kubernetes.default.svc
-    namespace: robson
-  
+    namespace: dns
+
   syncPolicy:
     automated:
-      prune: true      # Delete resources that are no longer defined in Git
-      selfHeal: true   # Sync when cluster state differs from Git
+      prune: true
+      selfHeal: true
       allowEmpty: false
     syncOptions:
-      - CreateNamespace=true  # Auto-create namespace if it doesn't exist
+      - CreateNamespace=true
       - PrunePropagationPolicy=foreground
       - PruneLast=true
     retry:
@@ -38,10 +42,10 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
-  
+
   # Health assessment
   ignoreDifferences:
     - group: apps
       kind: Deployment
       jsonPointers:
-        - /spec/replicas  # Ignore replicas if using HPA in the future
+        - /spec/replicas

--- a/infra/k8s/gitops/applications/dns-nodeport.yml
+++ b/infra/k8s/gitops/applications/dns-nodeport.yml
@@ -1,35 +1,39 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: robson-prod
+  name: dns-infrastructure-nodeport
   namespace: argocd
   labels:
-    app.kubernetes.io/name: robson-prod
-    app.kubernetes.io/component: production
+    app.kubernetes.io/name: dns-infrastructure
+    app.kubernetes.io/component: authoritative-dns
     app.kubernetes.io/part-of: rbx-systems
+    deployment-scenario: nodeport
     rbx.env: production
-    rbx.product: robson
+    rbx.product: dns
     rbx.agent_id: human
     rbx.change_id: CHANGE_ID_PLACEHOLDER
+  # Finalizers ensure Application is deleted properly
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
-  
+
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/k8s/prod
-  
+    path: infra/apps/dns/overlays/nodeport
+
   destination:
     server: https://kubernetes.default.svc
-    namespace: robson
-  
+    namespace: dns
+
   syncPolicy:
     automated:
-      prune: true      # Delete resources that are no longer defined in Git
-      selfHeal: true   # Sync when cluster state differs from Git
+      prune: true
+      selfHeal: true
       allowEmpty: false
     syncOptions:
-      - CreateNamespace=true  # Auto-create namespace if it doesn't exist
+      - CreateNamespace=true
       - PrunePropagationPolicy=foreground
       - PruneLast=true
     retry:
@@ -38,10 +42,10 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
-  
+
   # Health assessment
   ignoreDifferences:
     - group: apps
       kind: Deployment
       jsonPointers:
-        - /spec/replicas  # Ignore replicas if using HPA in the future
+        - /spec/replicas

--- a/infra/k8s/gitops/applicationsets/branches.yml
+++ b/infra/k8s/gitops/applicationsets/branches.yml
@@ -3,6 +3,12 @@ kind: ApplicationSet
 metadata:
   name: robson-branch-previews
   namespace: argocd
+  labels:
+    rbx.env: preview
+    rbx.product: robson
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   goTemplate: true
   generators:

--- a/infra/k8s/gitops/projects/applications.yaml
+++ b/infra/k8s/gitops/projects/applications.yaml
@@ -1,0 +1,61 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: rbx-applications
+  namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
+spec:
+  description: >
+    Product applications for RBX Systems. Includes robson, strategos,
+    thalamus, and shared infrastructure apps like DNS.
+
+  # Allowed source repositories
+  sourceRepos:
+    - https://github.com/ldamasio/robson
+    - https://github.com/ldamasio/robson.git
+
+  # Allowed destination clusters and namespaces
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: robson
+    - server: https://kubernetes.default.svc
+      namespace: robson-staging
+    - server: https://kubernetes.default.svc
+      namespace: dns
+    - server: https://kubernetes.default.svc
+      namespace: strategos
+    - server: https://kubernetes.default.svc
+      namespace: thalamus
+
+  # No cluster-scoped resources for product apps
+  clusterResourceWhitelist: []
+
+  # Namespace-scoped resources (allow all within permitted namespaces)
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"
+
+  # Deny cluster-scoped resources explicitly
+  clusterResourceBlacklist:
+    - group: "*"
+      kind: Namespace
+
+  # Roles for future RBAC integration
+  roles:
+    - name: app-admin
+      description: Full access to application deployments
+      policies:
+        - p, proj:rbx-applications:app-admin, applications, *, rbx-applications/*, allow
+      groups:
+        - developers
+    - name: app-viewer
+      description: Read-only access to application deployments
+      policies:
+        - p, proj:rbx-applications:app-viewer, applications, get, rbx-applications/*, allow
+      groups:
+        - viewers

--- a/infra/k8s/gitops/projects/platform.yaml
+++ b/infra/k8s/gitops/projects/platform.yaml
@@ -1,0 +1,73 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: rbx-platform
+  namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
+spec:
+  description: >
+    Platform infrastructure components managed by RBX Systems.
+    Includes service mesh, certificate management, API gateway CRDs,
+    and ArgoCD self-management.
+
+  # Allowed source repositories
+  sourceRepos:
+    - https://github.com/ldamasio/robson
+    - https://github.com/ldamasio/robson.git
+    - https://istio-release.storage.googleapis.com/charts
+    - https://charts.jetstack.io
+    - https://argoproj.github.io/argo-helm
+    - https://github.com/kubernetes-sigs/gateway-api
+
+  # Allowed destination clusters and namespaces
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: argocd
+    - server: https://kubernetes.default.svc
+      namespace: istio-system
+    - server: https://kubernetes.default.svc
+      namespace: cert-manager
+    - server: https://kubernetes.default.svc
+      namespace: kube-system
+
+  # Allowed cluster-scoped resources
+  clusterResourceWhitelist:
+    - group: ""
+      kind: Namespace
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRole
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+    - group: cert-manager.io
+      kind: ClusterIssuer
+
+  # Namespace-scoped resources (allow all within permitted namespaces)
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"
+
+  # Roles for future RBAC integration
+  roles:
+    - name: platform-admin
+      description: Full access to platform project
+      policies:
+        - p, proj:rbx-platform:platform-admin, applications, *, rbx-platform/*, allow
+      groups:
+        - platform-team
+    - name: platform-viewer
+      description: Read-only access to platform project
+      policies:
+        - p, proj:rbx-platform:platform-viewer, applications, get, rbx-platform/*, allow
+      groups:
+        - developers

--- a/infra/k8s/gitops/projects/previews.yaml
+++ b/infra/k8s/gitops/projects/previews.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: rbx-previews
+  namespace: argocd
+  labels:
+    rbx.env: preview
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
+spec:
+  description: >
+    Ephemeral preview environments generated from pull requests.
+    Applications in this project are created and deleted automatically
+    by the branch previews ApplicationSet.
+
+  # Allowed source repositories
+  sourceRepos:
+    - https://github.com/ldamasio/robson
+    - https://github.com/ldamasio/robson.git
+
+  # Allowed destination clusters and namespaces
+  # Preview namespaces follow the pattern h-<branch-name>
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: "h-*"
+
+  # No cluster-scoped resources for previews
+  clusterResourceWhitelist: []
+
+  # Namespace-scoped resources (allow all within permitted namespaces)
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"
+
+  # Deny cluster-scoped resources explicitly
+  clusterResourceBlacklist:
+    - group: "*"
+      kind: Namespace
+
+  # Orphaned resources cleanup for preview environments
+  orphanedResources:
+    warn: true
+
+  # Roles for future RBAC integration
+  roles:
+    - name: preview-admin
+      description: Full access to preview environments
+      policies:
+        - p, proj:rbx-previews:preview-admin, applications, *, rbx-previews/*, allow
+      groups:
+        - developers

--- a/infra/k8s/platform/argocd/app.yml
+++ b/infra/k8s/platform/argocd/app.yml
@@ -3,6 +3,12 @@ kind: Application
 metadata:
   name: platform-argocd
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:

--- a/infra/k8s/platform/cert-manager/app.yml
+++ b/infra/k8s/platform/cert-manager/app.yml
@@ -3,6 +3,12 @@ kind: Application
 metadata:
   name: platform-cert-manager
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:

--- a/infra/k8s/platform/gateway-api-crds/app.yml
+++ b/infra/k8s/platform/gateway-api-crds/app.yml
@@ -3,6 +3,12 @@ kind: Application
 metadata:
   name: gateway-api-crds
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:

--- a/infra/k8s/platform/istio-ambient/base.yml
+++ b/infra/k8s/platform/istio-ambient/base.yml
@@ -3,6 +3,12 @@ kind: Application
 metadata:
   name: istio-base
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:

--- a/infra/k8s/platform/istio-ambient/cni.yml
+++ b/infra/k8s/platform/istio-ambient/cni.yml
@@ -3,6 +3,12 @@ kind: Application
 metadata:
   name: istio-cni
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:

--- a/infra/k8s/platform/istio-ambient/istiod.yml
+++ b/infra/k8s/platform/istio-ambient/istiod.yml
@@ -3,6 +3,12 @@ kind: Application
 metadata:
   name: istiod-ambient
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:

--- a/infra/k8s/platform/istio-ambient/ztunnel.yml
+++ b/infra/k8s/platform/istio-ambient/ztunnel.yml
@@ -3,6 +3,12 @@ kind: Application
 metadata:
   name: istio-ztunnel
   namespace: argocd
+  labels:
+    rbx.env: production
+    rbx.product: platform
+    rbx.agent_id: human
+    rbx.change_id: CHANGE_ID_PLACEHOLDER
+    app.kubernetes.io/part-of: rbx-systems
 spec:
   project: default
   source:


### PR DESCRIPTION
## Summary

Implements Phase 2 of the GitOps alignment plan following PR #32 (ArgoCD strategy documentation).

This PR introduces AppProjects and normalizes RBX governance labels across all existing Applications and ApplicationSets.

No behavioral changes to cluster configuration. Metadata only.

---

## Changes

### 1. RBX Governance Labels

All existing ArgoCD Applications and ApplicationSets now include:

- rbx.env
- rbx.product
- rbx.agent_id
- rbx.change_id
- app.kubernetes.io/part-of

16 Applications and 1 ApplicationSet updated.

### 2. AppProjects Introduced (Not Yet Activated)

Created:

- infra/k8s/gitops/projects/platform.yaml
- infra/k8s/gitops/projects/applications.yaml
- infra/k8s/gitops/projects/previews.yaml

These are staged for activation in PR #N+1.

### 3. Documentation

- GAP-ANALYSIS-PHASE2.md
- MIGRATION-PLAN.md

Provides structured migration sequence and compliance matrix.

---

## Validation

- Metadata-only changes
- No spec.project modifications yet
- No namespace restrictions applied yet
- No cluster-impacting resources changed

Safe to merge.

---

## Follow-up PRs

PR #N+1:
- Activate AppProjects
- Split root.yml into per-child Applications
- Introduce retry policy on root children

PR #N+2:
- Introduce sync windows and policies
- Harden production boundaries

PR #N+3:
- Prepare multi-product onboarding via ApplicationSet generator

---

## Risk Assessment

Low.

Labels are non-functional metadata.
AppProjects are staged but not referenced yet.
No changes to ArgoCD sync targets.
