### PR TITLE
infra(gitops): activate AppProjects and restructure app-of-apps root

### DIFF
--- a/infra/docs/gitops/VALIDATION-PHASE3.md
+++ b/infra/docs/gitops/VALIDATION-PHASE3.md
@@ -1,0 +1,216 @@
+# GitOps Phase 3: Validation Checklist
+
+**Date**: 2026-02-15
+**Scope**: AppProject activation, root App-of-Apps restructure, retry policies
+
+---
+
+## Pre-Merge Validation (Review Only)
+
+### 1. Verify AppProject Permissions
+
+For each Application, confirm the target AppProject allows:
+
+| Application | Project | sourceRepo | dest namespace | cluster resources |
+|---|---|---|---|---|
+| `istio-ambient` | rbx-platform | github.com/ldamasio/robson | argocd | CRDs, Webhooks |
+| `gateway-api-crds` | rbx-platform | github.com/ldamasio/robson | argocd | CRDs |
+| `platform-cert-manager` | rbx-platform | github.com/ldamasio/robson | argocd | ClusterIssuer |
+| `robson-backend` | rbx-applications | github.com/ldamasio/robson | robson | ClusterIssuer |
+| `robson-frontend` | rbx-applications | github.com/ldamasio/robson | robson | none |
+| `robson-prod` | rbx-applications | github.com/ldamasio/robson | robson | ClusterIssuer |
+| `dns-*` | rbx-applications | github.com/ldamasio/robson | dns | none |
+| preview apps | rbx-previews | github.com/ldamasio/robson | h-* | Namespace |
+
+### 2. Verify No Circular Dependencies
+
+- `rbx-projects` Application uses `project: default` (always exists)
+- `robson-root` Application uses `project: default` (always exists)
+- `platform-argocd` Application uses `project: default` (no ArgoCD self-mgmt risk)
+- All other Applications depend on AppProjects created by `rbx-projects`
+- Retry policies (limit: 5, backoff 10s→3m) provide ordering tolerance
+
+### 3. Verify Split Consistency
+
+All child Applications from the old monolithic `root.yml` must appear as
+individual files in `infra/k8s/gitops/app-of-apps/`. No Application name
+has changed - ArgoCD treats this as an update, not a create+delete.
+
+---
+
+## Post-Merge Validation
+
+### Immediate (0-5 minutes after merge)
+
+```bash
+# 1. Verify AppProjects were created
+kubectl get appprojects -n argocd
+# Expected: default, rbx-platform, rbx-applications, rbx-previews
+
+# 2. List all Applications and their sync status
+argocd app list
+# Expected: All Applications in Synced/Healthy state
+
+# 3. Verify project assignments
+argocd app list -o wide
+# Check the PROJECT column matches the mapping table above
+
+# 4. Check for permission errors in any Application
+argocd app get robson-prod --show-operation
+argocd app get istio-ambient --show-operation
+argocd app get robson-backend --show-operation
+argocd app get dns-infrastructure-metallb --show-operation
+
+# 5. Verify production pods are running
+kubectl get pods -n robson
+kubectl get pods -n argocd
+```
+
+### Extended (5-15 minutes)
+
+```bash
+# 6. Verify retry policies are working (check sync history)
+argocd app get robson-root --show-operation
+
+# 7. Check for any degraded Applications
+argocd app list --status Degraded
+argocd app list --status Unknown
+
+# 8. Verify ApplicationSet is generating preview apps correctly
+kubectl get applicationsets -n argocd
+argocd app list -l robson/preview=true
+
+# 9. Check ArgoCD logs for errors
+kubectl logs -n argocd -l app.kubernetes.io/name=argocd-application-controller --tail=100
+```
+
+---
+
+## Detecting Common Issues
+
+### Forbidden sourceRepo
+
+**Symptom**: Application shows `ComparisonError` with message like:
+```
+application repo https://... is not permitted in project rbx-applications
+```
+
+**Diagnosis**:
+```bash
+argocd proj get rbx-applications -o yaml | grep -A 20 sourceRepos
+```
+
+**Fix**: Add the missing repo to the AppProject's `sourceRepos` list.
+
+### Forbidden Destination Namespace
+
+**Symptom**: Application shows `ComparisonError` with message like:
+```
+application destination {namespace} is not permitted in project rbx-applications
+```
+
+**Diagnosis**:
+```bash
+argocd proj get rbx-applications -o yaml | grep -A 20 destinations
+```
+
+**Fix**: Add the missing namespace to the AppProject's `destinations` list.
+
+### Forbidden Cluster Resource
+
+**Symptom**: Sync fails with:
+```
+resource ClusterIssuer is not permitted in project rbx-applications
+```
+
+**Diagnosis**:
+```bash
+argocd proj get rbx-applications -o yaml | grep -A 20 clusterResourceWhitelist
+```
+
+**Fix**: Add the resource kind to the AppProject's `clusterResourceWhitelist`.
+
+### Project Not Found
+
+**Symptom**: Application shows error:
+```
+application references project rbx-platform which does not exist
+```
+
+**Cause**: The `rbx-projects` Application hasn't synced yet.
+
+**Fix**: Wait for retry (up to 3 minutes with backoff). If persistent:
+```bash
+argocd app sync rbx-projects
+```
+
+---
+
+## Rollback Procedure
+
+### Quick Rollback (Git Revert)
+
+```bash
+# Revert the merge commit
+git revert HEAD
+git push origin main
+
+# ArgoCD will auto-sync within 3 minutes, restoring:
+# - All Applications back to project: default
+# - Monolithic root.yml
+# - Original standalone Application files
+```
+
+### Manual Rollback (Emergency)
+
+If ArgoCD is unresponsive or in a bad state:
+
+```bash
+# 1. Force-set all Applications back to default project
+for app in $(argocd app list -o name); do
+  argocd app set "$app" --project default
+done
+
+# 2. Delete AppProjects (optional, safe - they're permissive not restrictive)
+kubectl delete appproject rbx-platform rbx-applications rbx-previews -n argocd
+
+# 3. Verify all Applications are syncing
+argocd app list
+```
+
+### Nuclear Option (ArgoCD Lockout Recovery)
+
+If the ArgoCD UI is inaccessible and CLI fails:
+
+```bash
+# 1. Direct kubectl edit to reset project
+kubectl edit application robson-root -n argocd
+# Change spec.project to "default"
+
+# 2. Restart ArgoCD controllers
+kubectl rollout restart deployment argocd-application-controller -n argocd
+kubectl rollout restart deployment argocd-server -n argocd
+
+# 3. Wait for reconciliation
+kubectl get applications -n argocd -w
+```
+
+---
+
+## Project Assignment Reference
+
+| Application | Project | Rationale |
+|---|---|---|
+| `robson-root` | default | Root must stay in default to avoid lockout |
+| `rbx-projects` | default | Manages AppProjects, avoids circular dependency |
+| `platform-argocd` | default | ArgoCD self-management, deferred to future migration |
+| `istio-ambient` | rbx-platform | Platform infrastructure |
+| `gateway-api-crds` | rbx-platform | Platform infrastructure |
+| `platform-cert-manager` | rbx-platform | Platform infrastructure |
+| `robson-branch-previews` | rbx-platform | Manages ApplicationSet (platform concern) |
+| `robson-backend` | rbx-applications | Product application |
+| `robson-frontend` | rbx-applications | Product application |
+| `robson-prod` | rbx-applications | Product application (production manifests) |
+| `dns-infrastructure-metallb` | rbx-applications | Product application (DNS) |
+| `dns-infrastructure-nodeport` | rbx-applications | Product application (DNS) |
+| Preview apps (generated) | rbx-previews | Ephemeral branch environments |

--- a/infra/k8s/gitops/app-of-apps/dns-metallb.yml
+++ b/infra/k8s/gitops/app-of-apps/dns-metallb.yml
@@ -1,47 +1,49 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: robson-prod
+  name: dns-infrastructure-metallb
   namespace: argocd
   labels:
-    app.kubernetes.io/name: robson-prod
-    app.kubernetes.io/component: production
+    app.kubernetes.io/name: dns-infrastructure
+    app.kubernetes.io/component: authoritative-dns
     app.kubernetes.io/part-of: rbx-systems
+    deployment-scenario: metallb
     rbx.env: production
-    rbx.product: robson
+    rbx.product: dns
     rbx.agent_id: human
     rbx.change_id: CHANGE_ID_PLACEHOLDER
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
-  
+  project: rbx-applications
+
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/k8s/prod
-  
+    path: infra/apps/dns/overlays/metallb
+
   destination:
     server: https://kubernetes.default.svc
-    namespace: robson
-  
+    namespace: dns
+
   syncPolicy:
     automated:
-      prune: true      # Delete resources that are no longer defined in Git
-      selfHeal: true   # Sync when cluster state differs from Git
+      prune: true
+      selfHeal: true
       allowEmpty: false
     syncOptions:
-      - CreateNamespace=true  # Auto-create namespace if it doesn't exist
+      - CreateNamespace=true
       - PrunePropagationPolicy=foreground
       - PruneLast=true
     retry:
       limit: 5
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
         maxDuration: 3m
-  
-  # Health assessment
+
   ignoreDifferences:
     - group: apps
       kind: Deployment
       jsonPointers:
-        - /spec/replicas  # Ignore replicas if using HPA in the future
+        - /spec/replicas

--- a/infra/k8s/gitops/app-of-apps/dns-nodeport.yml
+++ b/infra/k8s/gitops/app-of-apps/dns-nodeport.yml
@@ -12,11 +12,10 @@ metadata:
     rbx.product: dns
     rbx.agent_id: human
     rbx.change_id: CHANGE_ID_PLACEHOLDER
-  # Finalizers ensure Application is deleted properly
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: rbx-applications
 
   source:
     repoURL: https://github.com/ldamasio/robson
@@ -39,11 +38,10 @@ spec:
     retry:
       limit: 5
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
         maxDuration: 3m
 
-  # Health assessment
   ignoreDifferences:
     - group: apps
       kind: Deployment

--- a/infra/k8s/gitops/app-of-apps/platform-argocd.yml
+++ b/infra/k8s/gitops/app-of-apps/platform-argocd.yml
@@ -1,9 +1,10 @@
-# Root App-of-Apps: manages all child Applications in this directory.
-# MUST stay in project: default to avoid lockout.
+# ArgoCD self-management Application.
+# Stays in project: default intentionally. Do NOT move to rbx-platform
+# until ArgoCD RBAC and self-management migration is fully planned.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: robson-root
+  name: platform-argocd
   namespace: argocd
   labels:
     rbx.env: production
@@ -16,7 +17,7 @@ spec:
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/k8s/gitops/app-of-apps
+    path: infra/k8s/platform/argocd
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/infra/k8s/gitops/app-of-apps/platform-cert-manager.yml
+++ b/infra/k8s/gitops/app-of-apps/platform-cert-manager.yml
@@ -1,9 +1,7 @@
-# Root App-of-Apps: manages all child Applications in this directory.
-# MUST stay in project: default to avoid lockout.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: robson-root
+  name: platform-cert-manager
   namespace: argocd
   labels:
     rbx.env: production
@@ -12,11 +10,11 @@ metadata:
     rbx.change_id: CHANGE_ID_PLACEHOLDER
     app.kubernetes.io/part-of: rbx-systems
 spec:
-  project: default
+  project: rbx-platform
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/k8s/gitops/app-of-apps
+    path: infra/k8s/platform/cert-manager
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/infra/k8s/gitops/app-of-apps/platform-gateway-api.yml
+++ b/infra/k8s/gitops/app-of-apps/platform-gateway-api.yml
@@ -1,9 +1,7 @@
-# Root App-of-Apps: manages all child Applications in this directory.
-# MUST stay in project: default to avoid lockout.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: robson-root
+  name: gateway-api-crds
   namespace: argocd
   labels:
     rbx.env: production
@@ -12,11 +10,11 @@ metadata:
     rbx.change_id: CHANGE_ID_PLACEHOLDER
     app.kubernetes.io/part-of: rbx-systems
 spec:
-  project: default
+  project: rbx-platform
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/k8s/gitops/app-of-apps
+    path: infra/k8s/platform/gateway-api-crds
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/infra/k8s/gitops/app-of-apps/platform-istio.yml
+++ b/infra/k8s/gitops/app-of-apps/platform-istio.yml
@@ -1,9 +1,7 @@
-# Root App-of-Apps: manages all child Applications in this directory.
-# MUST stay in project: default to avoid lockout.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: robson-root
+  name: istio-ambient
   namespace: argocd
   labels:
     rbx.env: production
@@ -12,11 +10,11 @@ metadata:
     rbx.change_id: CHANGE_ID_PLACEHOLDER
     app.kubernetes.io/part-of: rbx-systems
 spec:
-  project: default
+  project: rbx-platform
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/k8s/gitops/app-of-apps
+    path: infra/k8s/platform/istio-ambient
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/infra/k8s/gitops/app-of-apps/projects-manager.yml
+++ b/infra/k8s/gitops/app-of-apps/projects-manager.yml
@@ -1,9 +1,10 @@
-# Root App-of-Apps: manages all child Applications in this directory.
-# MUST stay in project: default to avoid lockout.
+# Manages AppProject resources via GitOps.
+# MUST stay in project: default to avoid circular dependency.
+# AppProjects must exist before Applications can reference them.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: robson-root
+  name: rbx-projects
   namespace: argocd
   labels:
     rbx.env: production
@@ -16,7 +17,7 @@ spec:
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/k8s/gitops/app-of-apps
+    path: infra/k8s/gitops/projects
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/infra/k8s/gitops/app-of-apps/robson-backend.yml
+++ b/infra/k8s/gitops/app-of-apps/robson-backend.yml
@@ -1,25 +1,28 @@
-# Root App-of-Apps: manages all child Applications in this directory.
-# MUST stay in project: default to avoid lockout.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: robson-root
+  name: robson-backend
   namespace: argocd
   labels:
     rbx.env: production
-    rbx.product: platform
+    rbx.product: robson
     rbx.agent_id: human
     rbx.change_id: CHANGE_ID_PLACEHOLDER
     app.kubernetes.io/part-of: rbx-systems
 spec:
-  project: default
+  project: rbx-applications
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/k8s/gitops/app-of-apps
+    path: infra/charts/robson-backend
+    helm:
+      values: |
+        host: api.robson.rbx.ia.br
+        gateway:
+          className: istio
   destination:
     server: https://kubernetes.default.svc
-    namespace: argocd
+    namespace: robson
   syncPolicy:
     automated:
       prune: true

--- a/infra/k8s/gitops/app-of-apps/robson-frontend.yml
+++ b/infra/k8s/gitops/app-of-apps/robson-frontend.yml
@@ -1,25 +1,28 @@
-# Root App-of-Apps: manages all child Applications in this directory.
-# MUST stay in project: default to avoid lockout.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: robson-root
+  name: robson-frontend
   namespace: argocd
   labels:
     rbx.env: production
-    rbx.product: platform
+    rbx.product: robson
     rbx.agent_id: human
     rbx.change_id: CHANGE_ID_PLACEHOLDER
     app.kubernetes.io/part-of: rbx-systems
 spec:
-  project: default
+  project: rbx-applications
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/k8s/gitops/app-of-apps
+    path: infra/charts/robson-frontend
+    helm:
+      values: |
+        host: app.robson.rbx.ia.br
+        gateway:
+          className: istio
   destination:
     server: https://kubernetes.default.svc
-    namespace: argocd
+    namespace: robson
   syncPolicy:
     automated:
       prune: true

--- a/infra/k8s/gitops/app-of-apps/robson-previews.yml
+++ b/infra/k8s/gitops/app-of-apps/robson-previews.yml
@@ -1,22 +1,24 @@
-# Root App-of-Apps: manages all child Applications in this directory.
-# MUST stay in project: default to avoid lockout.
+# Manages the ApplicationSet that generates branch preview environments.
+# Assigned to rbx-platform because it deploys an ApplicationSet CRD
+# resource to the argocd namespace (platform-level concern).
+# The generated preview Applications use rbx-previews project.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: robson-root
+  name: robson-branch-previews
   namespace: argocd
   labels:
-    rbx.env: production
-    rbx.product: platform
+    rbx.env: preview
+    rbx.product: robson
     rbx.agent_id: human
     rbx.change_id: CHANGE_ID_PLACEHOLDER
     app.kubernetes.io/part-of: rbx-systems
 spec:
-  project: default
+  project: rbx-platform
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/k8s/gitops/app-of-apps
+    path: infra/k8s/gitops/applicationsets
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/infra/k8s/gitops/app-of-apps/robson-prod.yml
+++ b/infra/k8s/gitops/app-of-apps/robson-prod.yml
@@ -1,31 +1,27 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: dns-infrastructure-metallb
+  name: robson-prod
   namespace: argocd
   labels:
-    app.kubernetes.io/name: dns-infrastructure
-    app.kubernetes.io/component: authoritative-dns
+    app.kubernetes.io/name: robson-prod
+    app.kubernetes.io/component: production
     app.kubernetes.io/part-of: rbx-systems
-    deployment-scenario: metallb
     rbx.env: production
-    rbx.product: dns
+    rbx.product: robson
     rbx.agent_id: human
     rbx.change_id: CHANGE_ID_PLACEHOLDER
-  # Finalizers ensure Application is deleted properly
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: rbx-applications
 
   source:
     repoURL: https://github.com/ldamasio/robson
     targetRevision: main
-    path: infra/apps/dns/overlays/metallb
+    path: infra/k8s/prod
 
   destination:
     server: https://kubernetes.default.svc
-    namespace: dns
+    namespace: robson
 
   syncPolicy:
     automated:
@@ -39,11 +35,10 @@ spec:
     retry:
       limit: 5
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
         maxDuration: 3m
 
-  # Health assessment
   ignoreDifferences:
     - group: apps
       kind: Deployment

--- a/infra/k8s/gitops/applications/README.md
+++ b/infra/k8s/gitops/applications/README.md
@@ -1,84 +1,25 @@
-# ArgoCD Applications
+# ArgoCD Standalone Applications (Legacy)
 
-This directory contains ArgoCD Application manifests for deploying Robson components.
+> **Migration Notice**: All Application manifests have been moved to
+> `infra/k8s/gitops/app-of-apps/` as part of the Phase 3 GitOps migration.
+> They are now managed by the root App-of-Apps pattern.
 
-## Structure
+## What moved
 
-```
-applications/
-├── README.md              # This file
-└── robson-prod.yaml       # Production application
-```
+| Application | Old Location | New Location |
+|---|---|---|
+| `robson-prod` | `applications/robson-prod.yml` | `app-of-apps/robson-prod.yml` |
+| `dns-infrastructure-metallb` | `applications/dns-metallb.yml` | `app-of-apps/dns-metallb.yml` |
+| `dns-infrastructure-nodeport` | `applications/dns-nodeport.yml` | `app-of-apps/dns-nodeport.yml` |
 
-## Current Architecture: Simple Application (Not App-of-Apps)
+## Why
 
-We're using a **single Application** that points directly to `infra/k8s/prod/`.
-
-**Why not App-of-Apps?**
-- Simplicity for initial deployment
-- Easier to understand and debug
-- Sufficient for small-to-medium projects
-- Can be migrated later if needed
-
-## Deploying for the First Time
-
-### Prerequisites
-
-1. ArgoCD installed in the cluster
-2. Namespace and secrets created
-3. Image tags updated in manifests (from `sha-CHANGEME` to actual SHA)
-
-### Apply the Application
-
-```bash
-kubectl apply -f infra/k8s/gitops/applications/robson-prod.yml
-```
-
-### Verify
-
-```bash
-# Check ArgoCD Application
-argocd app get robson-prod
-
-# Check Kubernetes resources
-kubectl get all -n robson
-```
-
-## Sync Policy
-
-The application uses **automated sync** with:
-
-- **prune: true** - Removes resources deleted from Git
-- **selfHeal: true** - Reverts manual changes in cluster
-- **CreateNamespace: true** - Auto-creates namespace if missing
-
-## Updating the Application
-
-To deploy a new version:
-
-1. Update image tags in `infra/k8s/prod/*.yml`
-2. Commit and push to main
-3. ArgoCD syncs automatically within ~3 minutes
-
-## Troubleshooting
-
-See [ArgoCD Initial Setup Guide](../../docs/runbooks/argocd-initial-setup.md) for:
-
-- Common issues and solutions
-- Rollback procedures
-- Monitoring commands
-
-## Future Evolution
-
-When the project grows, consider:
-
-- **App-of-Apps pattern**: Split into multiple Applications
-- **ApplicationSets**: For preview environments
-- **Projects**: Separate prod/staging/dev
-- **Sync waves**: Control deployment order
+Previously, standalone Applications in this directory required manual
+`kubectl apply` to update. By moving them into the `app-of-apps/` directory,
+they are now automatically managed by the root App-of-Apps and benefit from
+GitOps-driven reconciliation.
 
 ## References
 
-- [ArgoCD Documentation](https://argo-cd.readthedocs.io/)
-- [Initial Setup Guide](../../docs/runbooks/argocd-initial-setup.md)
-- [CI/CD Tagging Strategy](../../docs/runbooks/ci-cd-image-tagging.md)
+- [Phase 3 Validation Checklist](../../docs/gitops/VALIDATION-PHASE3.md)
+- [Migration Plan](../../docs/gitops/MIGRATION-PLAN.md)

--- a/infra/k8s/gitops/applicationsets/branches.yml
+++ b/infra/k8s/gitops/applicationsets/branches.yml
@@ -28,7 +28,7 @@ spec:
       labels:
         robson/preview: 'true'
     spec:
-      project: default
+      project: rbx-previews
       source:
         repoURL: https://github.com/ldamasio/robson
         targetRevision: '{{ .branch }}'
@@ -55,6 +55,12 @@ spec:
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
       ignoreDifferences:
         - group: ""
           kind: Secret

--- a/infra/k8s/gitops/projects/applications.yaml
+++ b/infra/k8s/gitops/projects/applications.yaml
@@ -32,18 +32,15 @@ spec:
     - server: https://kubernetes.default.svc
       namespace: thalamus
 
-  # No cluster-scoped resources for product apps
-  clusterResourceWhitelist: []
+  # Cluster-scoped resources needed by product apps
+  clusterResourceWhitelist:
+    - group: cert-manager.io
+      kind: ClusterIssuer
 
   # Namespace-scoped resources (allow all within permitted namespaces)
   namespaceResourceWhitelist:
     - group: "*"
       kind: "*"
-
-  # Deny cluster-scoped resources explicitly
-  clusterResourceBlacklist:
-    - group: "*"
-      kind: Namespace
 
   # Roles for future RBAC integration
   roles:

--- a/infra/k8s/gitops/projects/previews.yaml
+++ b/infra/k8s/gitops/projects/previews.yaml
@@ -26,18 +26,15 @@ spec:
     - server: https://kubernetes.default.svc
       namespace: "h-*"
 
-  # No cluster-scoped resources for previews
-  clusterResourceWhitelist: []
+  # Cluster-scoped resources needed by preview environments
+  clusterResourceWhitelist:
+    - group: ""
+      kind: Namespace
 
   # Namespace-scoped resources (allow all within permitted namespaces)
   namespaceResourceWhitelist:
     - group: "*"
       kind: "*"
-
-  # Deny cluster-scoped resources explicitly
-  clusterResourceBlacklist:
-    - group: "*"
-      kind: Namespace
 
   # Orphaned resources cleanup for preview environments
   orphanedResources:


### PR DESCRIPTION
- Create rbx-projects manager Application (project default) for AppProjects
- Move child Applications to dedicated files under app-of-apps
- Assign projects: rbx-platform, rbx-applications; keep root and platform-argocd in default
- Update branch previews ApplicationSet template to project rbx-previews and add retry policy
- Adjust AppProjects to allow ClusterIssuer (apps) and Namespace (previews)
- Add validation checklist for Phase 3

## Summary

- Briefly explain the problem and the proposed solution.

## Changes

- Key changes in this PR:
  - 

## Screenshots (optional)

## Tests

- How to verify:
  - [ ] `cd apps/backend/monolith && ./bin/dj test`
  - [ ] `cd apps/frontend && npm ci && npm test`
- Added/updated tests:
  - 

## Migrations

- [ ] No schema changes
- [ ] Includes schema migrations
- Notes:
  - 

## Backward Compatibility

- Does this PR introduce breaking changes? Explain mitigation/migration strategy.

## Security & Data

- Any secrets, credentials, or PII involved? If so, describe handling.
- External calls guarded by flags? (e.g., `TRADING_ENABLED=False` in dev)

## Checklist

- [ ] Scope is focused and documented
- [ ] Code follows project conventions (see `docs/DEVELOPER.md`)
- [ ] Migrations created (if needed) and rationale explained
- [ ] Tests added/updated and passing locally
- [ ] Docs updated (README/DEVELOPER/MIGRATION_GUIDE as applicable)
