### PR TITLE
infra(gitops): simplify preview ApplicationSet generator

### DIFF
--- a/infra/k8s/gitops/applicationsets/branches.yml
+++ b/infra/k8s/gitops/applicationsets/branches.yml
@@ -12,16 +12,8 @@ metadata:
 spec:
   goTemplate: true
   generators:
-    - git:
-        repoURL: https://github.com/ldamasio/robson
-        revision: HEAD
-        directories:
-          - path: charts/*
-        filters:
-          - path: '^(?!main$).*' # exclude main (dummy; adjust with matrix if needed)
     - pullRequest:
         repoURL: https://github.com/ldamasio/robson
-        # Optionally generate from PRs
   template:
     metadata:
       name: 'robson-{{ lower (replace (replace .branch "/" "-") "_" "-") }}'


### PR DESCRIPTION
  Remove unused git directory generator from `robson-branch-previews` ApplicationSet.

  The git directory generator was configured with a dummy filter that excluded
  main branch but served no functional purpose. Preview environments are
  already generated exclusively from pull requests via the pullRequest generator.

  This change removes dead code and clarifies intent: previews = PRs only.

  ## Changes

  - `infra/k8s/gitops/applicationsets/branches.yml`: Remove git directory generator
  - Keep only pullRequest generator (functional)
  - No changes to labels, retry policies, or sync options

  ## Tests/Validation

  After merge, verify:

  ```bash
  # ApplicationSet should be healthy
  kubectl get applicationset robson-branch-previews -n argocd

  # Only PR-based previews should exist (if any PRs open)
  argocd app list --project rbx-previews

  Migrations

  No migration required.

  Backward Compatibility

  Fully backward compatible. Existing preview Applications continue working.
  Only the generator list is simplified; generated resources are unchanged.

  Security & Data

  No secrets, no data access, no security impact.

  Co-Authored-By: Claude Opus 4.6 noreply@anthropic.com

