### PR TITLE
feat(exchange): enable Binance testnet wiring with safe fallback

### DIFF
--- a/v2/robsond/src/daemon.rs
+++ b/v2/robsond/src/daemon.rs
@@ -258,6 +258,57 @@ impl Daemon<BinanceExchangeAdapter, MemoryStore> {
             pg_pool: None,
         }
     }
+
+    /// Create a Binance daemon with optional projection recovery and shared pool.
+    #[cfg(feature = "postgres")]
+    pub fn new_binance_with_recovery(
+        config: Config,
+        client: Arc<BinanceRestClient>,
+        projection_recovery: Option<Arc<dyn ProjectionRecovery>>,
+        pg_pool: Option<Arc<sqlx::PgPool>>,
+    ) -> Self {
+        use robson_domain::RiskConfig;
+
+        let exchange = Arc::new(BinanceExchangeAdapter::new(client));
+        let journal = Arc::new(IntentJournal::new());
+        let store = Arc::new(MemoryStore::new());
+        let executor = Arc::new(Executor::new(exchange, journal, store.clone()));
+        let event_bus = Arc::new(EventBus::new(1000));
+
+        let query_recorder: Arc<dyn QueryRecorder> =
+            if let (Some(pool), Some(tenant_id)) = (&pg_pool, config.projection.tenant_id) {
+                Arc::new(EventLogQueryRecorder::new(
+                    (**pool).clone(),
+                    tenant_id,
+                    config.projection.stream_key.clone(),
+                ))
+            } else {
+                default_query_recorder()
+            };
+        let risk_config = RiskConfig::new(dec!(10000)).unwrap();
+        let engine = Engine::new(risk_config);
+
+        let mut pm = PositionManager::new(
+            engine,
+            executor,
+            store.clone(),
+            event_bus.clone(),
+            query_recorder,
+        );
+        if let (Some(pool), Some(tenant_id)) = (&pg_pool, config.projection.tenant_id) {
+            pm = pm.with_event_log((**pool).clone(), tenant_id);
+        }
+        let position_manager = Arc::new(RwLock::new(pm));
+
+        Self {
+            config,
+            position_manager,
+            event_bus,
+            store,
+            projection_recovery,
+            pg_pool,
+        }
+    }
 }
 
 impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {

--- a/v2/robsond/src/main.rs
+++ b/v2/robsond/src/main.rs
@@ -30,9 +30,9 @@
 #[cfg(feature = "postgres")]
 mod db;
 
-#[cfg(feature = "postgres")]
 use std::sync::Arc;
 
+use robson_connectors::BinanceRestClient;
 use robsond::{Config, Daemon};
 use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
@@ -65,6 +65,11 @@ async fn main() -> anyhow::Result<()> {
         api_port = config.api.port,
         "Robson v2 Daemon"
     );
+
+    // Select exchange adapter based on Binance credentials.
+    // Reuses position_monitor.binance_api_key/secret from config (same env vars).
+    let has_binance_creds = config.position_monitor.binance_api_key.is_some()
+        && config.position_monitor.binance_api_secret.is_some();
 
     // Create daemon with optional projection recovery (wiring layer)
     #[cfg(feature = "postgres")]
@@ -126,14 +131,39 @@ async fn main() -> anyhow::Result<()> {
             (None, None)
         };
 
-        let daemon = Daemon::new_stub_with_recovery(config, projection_recovery, pg_pool);
-        daemon.run().await?;
+        if has_binance_creds {
+            info!("Exchange: Binance (testnet)");
+            let (api_key, api_secret) = (
+                config.position_monitor.binance_api_key.clone().unwrap(),
+                config.position_monitor.binance_api_secret.clone().unwrap(),
+            );
+            let client = Arc::new(BinanceRestClient::testnet(api_key, api_secret));
+            let daemon =
+                Daemon::new_binance_with_recovery(config, client, projection_recovery, pg_pool);
+            daemon.run().await?;
+        } else {
+            info!("Exchange: Stub (no Binance credentials)");
+            let daemon = Daemon::new_stub_with_recovery(config, projection_recovery, pg_pool);
+            daemon.run().await?;
+        }
     }
 
     #[cfg(not(feature = "postgres"))]
     {
-        let daemon = Daemon::new_stub(config);
-        daemon.run().await?;
+        if has_binance_creds {
+            info!("Exchange: Binance (testnet)");
+            let (api_key, api_secret) = (
+                config.position_monitor.binance_api_key.clone().unwrap(),
+                config.position_monitor.binance_api_secret.clone().unwrap(),
+            );
+            let client = Arc::new(BinanceRestClient::testnet(api_key, api_secret));
+            let daemon = Daemon::new_binance(config, client);
+            daemon.run().await?;
+        } else {
+            info!("Exchange: Stub (no Binance credentials)");
+            let daemon = Daemon::new_stub(config);
+            daemon.run().await?;
+        }
     }
 
     Ok(())

--- a/v2/robsond/src/main.rs
+++ b/v2/robsond/src/main.rs
@@ -66,10 +66,15 @@ async fn main() -> anyhow::Result<()> {
         "Robson v2 Daemon"
     );
 
-    // Select exchange adapter based on Binance credentials.
+    // Select exchange adapter based on Binance credentials and environment marker.
     // Reuses position_monitor.binance_api_key/secret from config (same env vars).
+    // ROBSON_BINANCE_USE_TESTNET is a birth-time environment marker set in the
+    // ConfigMap — never a runtime toggle. See ADR-0003.
     let has_binance_creds = config.position_monitor.binance_api_key.is_some()
         && config.position_monitor.binance_api_secret.is_some();
+    let use_testnet = std::env::var("ROBSON_BINANCE_USE_TESTNET")
+        .unwrap_or_default()
+        == "true";
 
     // Create daemon with optional projection recovery (wiring layer)
     #[cfg(feature = "postgres")]
@@ -131,7 +136,7 @@ async fn main() -> anyhow::Result<()> {
             (None, None)
         };
 
-        if has_binance_creds {
+        if has_binance_creds && use_testnet {
             info!("Exchange: Binance (testnet)");
             let (api_key, api_secret) = (
                 config.position_monitor.binance_api_key.clone().unwrap(),
@@ -142,7 +147,15 @@ async fn main() -> anyhow::Result<()> {
                 Daemon::new_binance_with_recovery(config, client, projection_recovery, pg_pool);
             daemon.run().await?;
         } else {
-            info!("Exchange: Stub (no Binance credentials)");
+            if has_binance_creds && !use_testnet {
+                tracing::error!(
+                    "Binance credentials present but ROBSON_BINANCE_USE_TESTNET is not set. \
+                     Refusing to connect to Binance production. Falling back to StubExchange. \
+                     Set ROBSON_BINANCE_USE_TESTNET=true to enable testnet, or remove credentials."
+                );
+            } else {
+                info!("Exchange: Stub (no Binance credentials)");
+            }
             let daemon = Daemon::new_stub_with_recovery(config, projection_recovery, pg_pool);
             daemon.run().await?;
         }
@@ -150,7 +163,7 @@ async fn main() -> anyhow::Result<()> {
 
     #[cfg(not(feature = "postgres"))]
     {
-        if has_binance_creds {
+        if has_binance_creds && use_testnet {
             info!("Exchange: Binance (testnet)");
             let (api_key, api_secret) = (
                 config.position_monitor.binance_api_key.clone().unwrap(),
@@ -160,7 +173,15 @@ async fn main() -> anyhow::Result<()> {
             let daemon = Daemon::new_binance(config, client);
             daemon.run().await?;
         } else {
-            info!("Exchange: Stub (no Binance credentials)");
+            if has_binance_creds && !use_testnet {
+                tracing::error!(
+                    "Binance credentials present but ROBSON_BINANCE_USE_TESTNET is not set. \
+                     Refusing to connect to Binance production. Falling back to StubExchange. \
+                     Set ROBSON_BINANCE_USE_TESTNET=true to enable testnet, or remove credentials."
+                );
+            } else {
+                info!("Exchange: Stub (no Binance credentials)");
+            }
             let daemon = Daemon::new_stub(config);
             daemon.run().await?;
         }


### PR DESCRIPTION
## Contexto

Implementa o wiring do robsond para usar Binance testnet de forma segura, alinhado com o ambiente isolado robson-testnet.

## Comportamento

- Sem credenciais → StubExchange
- Credenciais + ROBSON_BINANCE_USE_TESTNET=true → Binance testnet
- Credenciais sem flag → StubExchange + erro explícito

## Segurança

- Nenhum caminho para Binance real
- BinanceRestClient::new(...) removido
- fallback explícito evita execução acidental

## Status

- Build OK
- Testes OK (347 passing)
- Pronto para integração com rbx-infra testnet