### PR TITLE
chore(frontend): pivot deploy to k3s in-cluster

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,67 +1,60 @@
-name: "Frontend Deploy"
+name: "Frontend Build & Publish"
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/frontend-v2/**"
+      - ".github/workflows/frontend-deploy.yml"
   workflow_dispatch:
     inputs:
-      environment:
-        description: "Target environment"
-        type: choice
-        options:
-          - production
-      dry_run:
-        description: "Dry run (skip sync, show what would change)"
-        type: boolean
-        default: true
+      tag_suffix:
+        description: "Optional tag suffix (e.g. rc1)"
+        required: false
+        type: string
 
 jobs:
-  deploy:
+  build-and-push:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      PUBLIC_ROBSON_API_BASE: ${{ vars.PUBLIC_ROBSON_API_BASE_PROD }}
-
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          node-version: "20"
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          version: 9
+          images: ghcr.io/${{ github.repository_owner }}/robson-frontend-v2
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.event.inputs.tag_suffix }},enable=${{ github.event.inputs.tag_suffix != '' }}
 
-      - name: Install dependencies
-        working-directory: apps/frontend-v2
-        run: pnpm install --frozen-lockfile
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/frontend-v2
+          file: apps/frontend-v2/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PUBLIC_ROBSON_API_BASE=${{ vars.PUBLIC_ROBSON_API_BASE_PROD }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Type check
-        working-directory: apps/frontend-v2
-        run: pnpm run check
-
-      - name: Unit tests
-        working-directory: apps/frontend-v2
-        run: pnpm run test
-
-      - name: Build
-        working-directory: apps/frontend-v2
-        run: pnpm run build
-
-      - name: Configure AWS CLI for Contabo
-        run: |
-          aws configure set aws_access_key_id "${{ secrets.AWS_ACCESS_KEY_ID }}" --profile contabo
-          aws configure set aws_secret_access_key "${{ secrets.AWS_SECRET_ACCESS_KEY }}" --profile contabo
-          aws configure set region eu-central-1 --profile contabo
-
-      - name: Sync to S3
-        working-directory: apps/frontend-v2
-        run: |
-          ARGS=(--profile contabo --endpoint-url https://eu2.contabostorage.com --delete)
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            ARGS+=(--dryrun)
-          fi
-          aws s3 sync build/ s3://robson-app/ "${ARGS[@]}"
+      - name: Image digest
+        run: echo "Image digest ${{ steps.meta.outputs.digest }}"

--- a/apps/frontend-v2/.dockerignore
+++ b/apps/frontend-v2/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+build
+.svelte-kit
+.env
+.env.*
+!.env.example
+tests/e2e
+playwright-report
+test-results
+.git

--- a/apps/frontend-v2/Dockerfile
+++ b/apps/frontend-v2/Dockerfile
@@ -1,0 +1,27 @@
+# Stage 1: build
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && corepack prepare pnpm@9 --activate
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+ARG PUBLIC_ROBSON_API_BASE
+ENV PUBLIC_ROBSON_API_BASE=$PUBLIC_ROBSON_API_BASE
+
+RUN pnpm run build
+
+# Stage 2: runtime
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/build /usr/share/nginx/html
+
+EXPOSE 8080
+
+HEALTHCHECK CMD wget -q -O /dev/null http://127.0.0.1:8080/healthz || exit 1
+
+USER nginx

--- a/apps/frontend-v2/README.md
+++ b/apps/frontend-v2/README.md
@@ -55,4 +55,7 @@ Source of truth: `brand-voltage/` at repo root.
 
 ## Deploy
 
-See `docs/runbooks/frontend-deploy.md` for the full deploy procedure. The GitHub Actions workflow `Frontend Deploy` (workflow_dispatch only) builds and syncs to the Contabo S3 bucket `robson-app`. Prerequisites B1–B5 must be satisfied by the operator before the first run; see runbook.
+Production deployment: container in k3s rbx-infra cluster,
+image at `ghcr.io/ldamasio/robson-frontend-v2`, ArgoCD-managed.
+
+See `docs/runbooks/frontend-deploy.md` for the full deploy procedure. The GitHub Actions workflow `Frontend Build & Publish` builds the Docker image on push to main (or workflow_dispatch) and pushes to GHCR. ArgoCD reconciles the deployment in rbx-infra. Prerequisites B1–B7 must be satisfied by the operator before the first deployment; see runbook.

--- a/apps/frontend-v2/nginx.conf
+++ b/apps/frontend-v2/nginx.conf
@@ -1,0 +1,46 @@
+server {
+  listen 8080;
+  listen [::]:8080;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # Health endpoint for k8s probes
+  location = /healthz {
+    access_log off;
+    add_header Content-Type text/plain;
+    return 200 "ok\n";
+  }
+
+  # Long cache for versioned assets (Vite hashes in filenames)
+  location /_app/ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    try_files $uri =404;
+  }
+
+  # Short cache for HTML (always fetch latest)
+  location = /index.html {
+    expires -1;
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+    try_files $uri =404;
+  }
+
+  # SPA fallback: client-side routes land on index.html
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  # Security headers
+  add_header X-Frame-Options "DENY" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
+  # Compression
+  gzip on;
+  gzip_types text/plain text/css application/javascript application/json
+            image/svg+xml font/woff2 font/woff;
+  gzip_min_length 1024;
+  gzip_comp_level 6;
+}

--- a/docs/adr/ADR-0028-hosting-pivot-k3s.md
+++ b/docs/adr/ADR-0028-hosting-pivot-k3s.md
@@ -1,0 +1,45 @@
+# ADR-0028: Hosting Pivot — Contabo S3 → k3s In-Cluster
+
+**Date:** 2026-04-25
+**Status:** Accepted
+
+## Context
+
+FE-P1 code-complete landed on main with a Contabo Object Storage deployment target. During operator provisioning, Contabo S3 revealed several limitations:
+
+- No native website hosting (no index/error document support)
+- Tenant-wide credentials (no per-bucket IAM scoping)
+- No ACL management via UI
+- TLS termination mismatch on custom domain CNAMEs
+
+The operator provisioned a Contabo bucket but the limitations made it unsuitable for a production SPA frontend.
+
+## Decision
+
+Pivot frontend hosting from Contabo S3 static to k3s in-cluster deployment:
+
+- Frontend becomes a containerized nginx:alpine serving the SvelteKit static build
+- Container image published to ghcr.io (`ghcr.io/ldamasio/robson-frontend-v2`)
+- ArgoCD GitOps manages the deployment in rbx-infra
+- TLS via cert-manager + Let's Encrypt (resolves the TLS gap from the previous runbook B4)
+- No CDN initially; Cloudflare can be added later if global latency matters
+
+## Consequences
+
+**Preserved:**
+- Bearer-token auth (ADR-0025 A1.2) unchanged
+- Host-based locale default (rbx.ia.br → pt-BR, rbxsystems.ch → en)
+- Dual-domain architecture
+- FE-P1 stack already on main — only deploy mechanism changes
+
+**New:**
+- Dockerfile + nginx.conf added to apps/frontend-v2/
+- GitHub Actions workflow rewritten: builds Docker image, pushes to GHCR
+- k8s skeleton manifests in docs/k8s/frontend/ for operator to copy into rbx-infra
+- ArgoCD reconciles on image tag update (no kubectl in CI)
+- Health endpoint `/healthz` for k8s probes
+
+**Trade-offs:**
+- Higher operational complexity (container + k8s vs static files)
+- nginx serves from memory/disk in-cluster, no edge caching
+- GHCR as registry dependency (free tier, GitHub-native)

--- a/docs/k8s/frontend/README.md
+++ b/docs/k8s/frontend/README.md
@@ -1,0 +1,19 @@
+# Frontend k8s Manifests (Reference Skeletons)
+
+These are **reference skeletons** — do NOT apply from this repo.
+
+Operator copies these files into the rbx-infra GitOps tree and adjusts:
+
+- `<NAMESPACE>` → actual namespace (e.g. `robson`)
+- `<CLUSTER_ISSUER>` → ClusterIssuer name (e.g. `letsencrypt-prod`)
+- `<INGRESS_CLASS>` → ingress class (e.g. `nginx` or omit if default)
+- `<IMAGE_PULL_SECRET>` → image pull secret name (or remove if GHCR public)
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| deployment.yaml | 2-replica Deployment serving static build via nginx |
+| service.yaml | ClusterIP Service, port 80 → 8080 |
+| ingress.yaml | Ingress with TLS for both domains |
+| kustomization.yaml | Kustomize resource list + common labels |

--- a/docs/k8s/frontend/deployment.yaml
+++ b/docs/k8s/frontend/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: robson-frontend-v2
+  namespace: <NAMESPACE>  # adjust
+  labels:
+    app: robson-frontend-v2
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: robson-frontend-v2
+  template:
+    metadata:
+      labels:
+        app: robson-frontend-v2
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/ldamasio/robson-frontend-v2:latest
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false  # nginx writes /var/cache
+            capabilities:
+              drop: ["ALL"]
+      imagePullSecrets: []  # adjust: add - name: <IMAGE_PULL_SECRET> if GHCR private

--- a/docs/k8s/frontend/ingress.yaml
+++ b/docs/k8s/frontend/ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: robson-frontend-v2
+  namespace: <NAMESPACE>  # adjust
+  annotations:
+    cert-manager.io/cluster-issuer: <CLUSTER_ISSUER>  # adjust, e.g. letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # kubernetes.io/ingress.class: <INGRESS_CLASS>  # uncomment and adjust if needed
+spec:
+  tls:
+    - hosts:
+        - robson.rbx.ia.br
+      secretName: robson-frontend-tls-rbx-ia-br
+    - hosts:
+        - robson.rbxsystems.ch
+      secretName: robson-frontend-tls-rbxsystems-ch
+  rules:
+    - host: robson.rbx.ia.br
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: robson-frontend-v2
+                port:
+                  number: 80
+    - host: robson.rbxsystems.ch
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: robson-frontend-v2
+                port:
+                  number: 80

--- a/docs/k8s/frontend/kustomization.yaml
+++ b/docs/k8s/frontend/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: robson-frontend-v2
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/docs/k8s/frontend/service.yaml
+++ b/docs/k8s/frontend/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: robson-frontend-v2
+  namespace: <NAMESPACE>  # adjust
+  labels:
+    app: robson-frontend-v2
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app: robson-frontend-v2

--- a/docs/runbooks/frontend-deploy.md
+++ b/docs/runbooks/frontend-deploy.md
@@ -1,83 +1,104 @@
-# Frontend Deploy Runbook
+# Frontend Deploy Runbook (k3s in-cluster)
 
-**Scope:** apps/frontend-v2 → Contabo S3 (bucket `robson-app`) → public domains `robson.rbx.ia.br` + `robson.rbxsystems.ch`
+**Scope:** apps/frontend-v2 → ghcr.io/ldamasio/robson-frontend-v2
+→ k3s rbx-infra cluster → public domains robson.rbx.ia.br
+(pt-BR) + robson.rbxsystems.ch (en).
 
-## Prerequisites (must be satisfied before first run)
+## Architecture
 
-### B1 — Contabo bucket `robson-app`
+- SvelteKit static build wrapped in nginx:alpine container
+- Image published to ghcr.io on push to main (or
+  workflow_dispatch)
+- ArgoCD Application in rbx-infra watches the image and syncs
+  deployment to k3s
+- Ingress with cert-manager + Let's Encrypt for TLS
+- Backend (robsond) is at api.robson.rbx.ia.br (separate
+  subdomain, CORS allows the two frontend origins)
 
-- Create in Contabo Object Storage (EU region).
-- Enable website hosting: `index=index.html`, `error=index.html` (SPA fallback).
-- Grant public-read on objects.
-- Endpoint: `https://eu2.contabostorage.com`
+## Prerequisites (operator)
 
-### B2 — GitHub Actions secrets
+### B1 — GHCR access (replaces Contabo bucket)
+- Repo Settings → Actions → Workflow permissions:
+  "Read and write permissions" enabled
+- GHCR package visibility: public (read) — set after first push
+  via GitHub UI Packages → robson-frontend-v2 → Visibility
 
-Repository-level secrets:
+### B2 — GitHub variable
+- `PUBLIC_ROBSON_API_BASE_PROD` = `https://api.robson.rbx.ia.br`
+  (set via `gh variable set`)
 
-- `AWS_ACCESS_KEY_ID` — Contabo S3 access key (deploy-only IAM)
-- `AWS_SECRET_ACCESS_KEY` — Contabo S3 secret
+### B3 — k8s manifests in rbx-infra
+Operator copies skeleton from `docs/k8s/frontend/` in this repo
+into rbx-infra at the appropriate GitOps path. Adjust namespace,
+ClusterIssuer name, ingress class, and image pull secret to
+match cluster reality. Required objects:
+- Namespace (or reuse robson namespace)
+- Deployment with 2 replicas, image
+  `ghcr.io/ldamasio/robson-frontend-v2:latest`, port 8080
+- Service ClusterIP port 80 → 8080
+- Ingress with TLS, cert-manager.io/cluster-issuer annotation,
+  two hosts (rbx.ia.br + rbxsystems.ch), each with TLS
+- Certificate (or rely on ingress shim if cluster uses
+  ingress-shim from cert-manager)
 
-Repository-level variables:
+### B4 — Image pull secret (only if package private)
+- If GHCR package private: create dockerconfigjson Secret in
+  namespace, attach via deployment.spec.imagePullSecrets
+- If public: skip — k3s pulls anonymously
 
-- `PUBLIC_ROBSON_API_BASE_PROD` — public URL where robsond is reachable (e.g., `https://api.robson.rbx.ia.br`)
+### B5 — DNS via rbx-infra dns-tofu-env.sh
+- robson.rbx.ia.br      A or CNAME → cluster ingress IP/hostname
+- robson.rbxsystems.ch  A or CNAME → cluster ingress IP/hostname
+- api.robson.rbx.ia.br  A or CNAME → cluster ingress IP/hostname
+  (already exists if backend already public)
 
-### B3 — DNS CNAMEs (via rbx-infra tofu)
+### B6 — ArgoCD Application
+- Application manifest in rbx-infra ArgoCD GitOps tree
+- source.repoURL = rbx-infra repo, path = path of frontend
+  manifests
+- destination.namespace = chosen namespace
+- syncPolicy.automated.prune + selfHeal recommended
 
-- `robson.rbx.ia.br` CNAME `robson-app.eu2.contabostorage.com`
-- `robson.rbxsystems.ch` CNAME `robson-app.eu2.contabostorage.com`
-
-Use `dns-tofu-env.sh` wrapper per project DNS secrets pattern.
-
-### B4 — TLS strategy (decision pending, ADR-0025 open item)
-
-Option A: accept Contabo TLS with domain mismatch warning (MVP-fast)
-Option B: Cloudflare free tier in front, TLS via Cloudflare
-
-Until decided, site reachable by IP path but browser TLS warning expected on custom domain.
-
-### B5 — Backend CORS + public reachability
-
-`robsond` must:
-
-- Respond to requests from Origin `https://robson.rbx.ia.br` and `https://robson.rbxsystems.ch`
-- Accept Bearer token on REST + `?token=` query param on SSE (EventSource limitation)
-- Be reachable from the public domain set in `PUBLIC_ROBSON_API_BASE_PROD`
+### B7 — Backend CORS
+- robsond must allow origins:
+    https://robson.rbx.ia.br
+    https://robson.rbxsystems.ch
+- Methods: GET, POST, DELETE, OPTIONS
+- Headers: Authorization, Content-Type
+- SSE accept ?token= query param (already true in code)
 
 ## How to deploy
 
-```bash
-gh workflow run "Frontend Deploy" \
-  --ref main \
-  -f environment=production \
-  -f dry_run=true
-```
+First-time:
+1. Set var `PUBLIC_ROBSON_API_BASE_PROD`.
+2. Push commit to main touching apps/frontend-v2/**.
+3. Workflow builds + pushes image to ghcr.io.
+4. Apply k8s manifests via ArgoCD (sync the Application).
+5. cert-manager emits cert (1–3min).
+6. curl -I https://robson.rbx.ia.br → 200.
 
-Inspect the dry run output; if it looks correct, re-run with `-f dry_run=false`.
+Subsequent deploys:
+- Push to main → image rebuilt → ArgoCD reconciles latest tag.
+- Or pin to specific sha tag via ArgoCD UI for canary/rollback.
 
 ## Rollback
 
-**Option 1 (recommended):** redeploy previous commit.
-
-```bash
-git checkout <previous-commit>
-gh workflow run "Frontend Deploy" -f dry_run=false
-```
-
-**Option 2 (emergency):** remove bucket contents and point DNS back to legacy host. Requires human access to Contabo console.
+- ArgoCD UI: pin Application image to previous sha-XXXXXXX tag.
+- Or revert commit on main → workflow rebuilds → ArgoCD syncs.
+- Or kubectl rollout undo deployment/robson-frontend-v2 -n <ns>
+  (last-resort manual).
 
 ## Verification after deploy
 
-```bash
-curl -I https://robson.rbx.ia.br           # 200 + text/html
-curl -I https://robson.rbxsystems.ch       # 200 + text/html
-```
+    curl -I https://robson.rbx.ia.br
+    curl -I https://robson.rbxsystems.ch
+    curl -I https://robson.rbx.ia.br/healthz   # 200 ok
+    # Browser: cold load /login, paste real token, redirect to
+    # /dashboard, observe SSE events.
 
-Browser: manually confirm Bearer token login succeeds and `/dashboard` renders without console errors.
+## Known gaps
 
-## Known gaps (track separately)
-
-- No CDN (Cloudflare deferred per B4)
-- No cache invalidation step
-- No release tagging (could add once deploy settles)
-- Locale switcher UI deferred (host-based locale works today)
+- No CDN (in-cluster nginx; add Cloudflare in front later if
+  latency global matters)
+- Locale switcher UI deferred (host-based default sufficient)
+- Hash chain UI (FE-P3) and history endpoints (FE-P2) pending


### PR DESCRIPTION
- Dockerfile multi-stage (node:20 build → nginx:1.27 runtime)
- nginx.conf with SPA fallback + security headers + gzip
- .dockerignore
- Workflow rewritten: build & push image to ghcr.io (push to main + workflow_dispatch)
- Runbook rewritten for k3s + cert-manager + ArgoCD
- Skeleton k8s manifests in docs/k8s/frontend/ for operator to copy into rbx-infra GitOps tree
- ADR-0028 registering pivot rationale

## Summary

- Briefly explain the problem and the proposed solution.

## Changes

- Key changes in this PR:
  - 

## Screenshots (optional)

## Tests

- How to verify:
  - [ ] `cd apps/backend/monolith && ./bin/dj test`
  - [ ] `cd apps/frontend && npm ci && npm test`
- Added/updated tests:
  - 

## Migrations

- [ ] No schema changes
- [ ] Includes schema migrations
- Notes:
  - 

## Backward Compatibility

- Does this PR introduce breaking changes? Explain mitigation/migration strategy.

## Security & Data

- Any secrets, credentials, or PII involved? If so, describe handling.
- External calls guarded by flags? (e.g., `TRADING_ENABLED=False` in dev)

## Checklist

- [ ] Scope is focused and documented
- [ ] Code follows project conventions (see `docs/DEVELOPER.md`)
- [ ] Migrations created (if needed) and rationale explained
- [ ] Tests added/updated and passing locally
- [ ] Docs updated (README/DEVELOPER/MIGRATION_GUIDE as applicable)
