### PR TITLE
docs: v3 canonical onboarding + ADRs + FE-P1 closeout

### DIFF
--- a/docs/AUTH_FLOW.md
+++ b/docs/AUTH_FLOW.md
@@ -1,4 +1,14 @@
-# JWT Authentication Flow – Detailed Guide
+> **DEPRECATED — historical reference only.**
+>
+> This document describes the v1 Django JWT auth flow, removed
+> from active code in 2026-04. Robson v3 uses a Bearer token
+> issued by `robsond` and entered manually by the operator at
+> `/login`; see
+> [`docs/adr/ADR-0025-frontend-auth-bearer-token.md`](adr/ADR-0025-frontend-auth-bearer-token.md).
+
+---
+
+# JWT Authentication Flow – Detailed Guide (v1, archived)
 
 ## 1) Login (Obtain Tokens)
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,4 +1,18 @@
-Robson Bot – Developer Guide
+> **DEPRECATED — historical reference only.**
+>
+> This document describes the v1 Django monolith, removed from
+> active code in 2026-04. Robson v3 is the canonical version: a
+> Rust runtime (`v3/robsond/`) plus a SvelteKit static frontend
+> (`apps/frontend/`). The Django code path is gone from the
+> working tree; this file is preserved for historical product
+> archaeology only.
+>
+> For current developer onboarding, read
+> [`docs/onboarding/DEVELOPER-QUICKSTART.md`](onboarding/DEVELOPER-QUICKSTART.md).
+
+---
+
+Robson Bot – Developer Guide (v1, archived)
 
 Overview
 - Robson is open source. This guide standardizes local development, migrations/tests, and contribution practices, keeping production isolated (GitOps/CI/CD).

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -6,11 +6,16 @@
 
 ## 🚀 Quick Start
 
-**New to Robson Bot?** Start here:
+**New to Robson v3?** Start here:
 
 1. **[README.md](../README.md)** - Project overview and installation
-2. **[ARCHITECTURE.md](ARCHITECTURE.md)** - System architecture and design principles
-3. **[DEVELOPER.md](DEVELOPER.md)** - Development workflow and practices
+2. **[onboarding/DEVELOPER-QUICKSTART.md](onboarding/DEVELOPER-QUICKSTART.md)** - Clone → first PR (current)
+3. **[architecture/v3-runtime-spec.md](architecture/v3-runtime-spec.md)** - Robsond runtime architecture
+4. **[../AGENTS.md](../AGENTS.md)** - Repository-wide rules (canonical)
+
+> **Note:** `DEVELOPER.md` and `AUTH_FLOW.md` describe the v1 Django
+> stack and are kept only for historical reference. Robson v3 is the
+> canonical version (Rust runtime + SvelteKit frontend).
 
 **For AI Agents?** Start here:
 

--- a/docs/adr/ADR-0025-frontend-auth-bearer-token.md
+++ b/docs/adr/ADR-0025-frontend-auth-bearer-token.md
@@ -1,0 +1,98 @@
+# ADR-0025: Frontend Auth — Bearer Token via Robsond
+
+**Date:** 2026-04-23 (original decision); 2026-04-25 (formalized as ADR)
+**Status:** Accepted
+
+## Context
+
+The v3 frontend (SvelteKit + `adapter-static`) is hosted as a static
+single-page application. The original FE-P1 plan called for GitHub
+OAuth backed by Auth.js (`hooks.server.ts` + `SvelteKitAuth`).
+
+`adapter-static` produces a fully static bundle: no Node runtime, no
+edge function, no server-side hooks. Auth.js requires a server
+runtime to handle the OAuth callback URL and session cookies. The two
+choices are mutually exclusive.
+
+Three paths existed:
+
+1. Switch to `adapter-node` and run a Node process behind a reverse
+   proxy. Adds a stateful surface to operate, undermining the
+   serve-it-from-anywhere goal.
+2. Add an edge function (Cloudflare Workers, Vercel) just for the
+   OAuth callback. Adds a third deployment target and a vendor
+   dependency.
+3. Drop OAuth and authenticate the operator directly against the
+   robsond API with a Bearer token.
+
+The primary user is a single operator. The system is governed and
+audited end-to-end by robsond regardless of who triggers an action;
+identity at the frontend exists only to gate access to the surface.
+
+## Decision
+
+The frontend authenticates with a Bearer token issued by robsond.
+
+- Token entered manually by the operator on `/login`.
+- Persisted in `sessionStorage` under key `robson_api_token`.
+- Sent on every REST call as `Authorization: Bearer <token>`.
+- Sent on the SSE stream as `?token=<token>` query parameter, since
+  the browser `EventSource` API does not allow custom headers.
+- Validated on `/login` by issuing `GET /health` and only navigating
+  to `/dashboard` if the request succeeds.
+- Cleared by `clearAuth()` (called on explicit logout).
+
+## Consequences
+
+**Positive**
+
+- Frontend stays a pure static bundle — works on any object-storage
+  or container nginx host without runtime constraints.
+- One fewer system to operate (no Auth.js, no OAuth app, no callback
+  routing).
+- Token can be rotated by reissuing on the robsond side without any
+  frontend redeploy.
+- Backend gates everything anyway, so trust boundary is unchanged.
+
+**Negative / trade-offs**
+
+- No SSO; operators paste a token manually.
+- `sessionStorage` is per-tab and lost on close; this is acceptable
+  for a single-operator console but does not scale to multi-user.
+- SSE token in query string can leak to access logs. Robsond logs
+  must filter the `token` parameter before persisting access logs
+  (see implementation note below).
+
+## Alternatives
+
+- **Auth.js + adapter-node** — rejected because it adds a stateful
+  Node service and a domain-locked callback that conflicts with
+  dual-domain hosting (rbx.ia.br + rbxsystems.ch).
+- **Auth.js + edge function** — rejected because it pulls in a
+  vendor (Cloudflare Workers / Vercel) for a single endpoint, and
+  requires synchronizing an OAuth app with two callback URLs.
+- **Custom session cookies set by robsond** — rejected because
+  cross-origin cookies require backend-controlled `Set-Cookie` plus
+  `SameSite=None; Secure` plumbing on every response, and the
+  operator-paste-token flow is simpler.
+
+## Implementation Notes
+
+- Auth store: `apps/frontend/src/lib/stores/auth.ts`
+  (`authToken`, `setToken`, `clearAuth`, `initAuth`).
+- API client: `apps/frontend/src/lib/api/robson.ts`
+  attaches `Authorization` header from `authToken`.
+- Login flow: `apps/frontend/src/routes/login/+page.svelte`
+  validates the token via `robsonApi.health()`.
+- Auth guard: `apps/frontend/src/routes/(authed)/+layout.svelte`
+  redirects to `/login` when no token is present.
+- Root redirect: `apps/frontend/src/routes/+page.svelte` sends `/`
+  to `/dashboard` if a token exists, otherwise to `/login`.
+
+**Backend log-hygiene requirement.** Robsond access logs MUST strip
+the `token` query parameter before persisting. The token is in the
+URL only because `EventSource` cannot send headers; logging it
+defeats the security boundary.
+
+**Related**: ADR-0027 (CORS layer for production origins).
+**Supersedes**: prior FE-P1 plan to use Auth.js + GitHub OAuth.

--- a/docs/adr/ADR-0026-nginx-non-root-k8s.md
+++ b/docs/adr/ADR-0026-nginx-non-root-k8s.md
@@ -1,0 +1,112 @@
+# ADR-0026: Nginx Non-Root Container in k3s
+
+**Date:** 2026-04-25
+**Status:** Accepted
+
+## Context
+
+The v3 frontend is served by an `nginx:1.27-alpine` container in
+the rbx-infra k3s cluster (see ADR-0028 for the hosting pivot).
+
+The cluster baseline applies a security context that requires
+`runAsNonRoot: true`. The default nginx alpine image starts as
+root, then drops to the `nginx` user (UID 101) for worker
+processes. With `runAsNonRoot` enforced at the pod level, the
+container cannot start at all — kubelet refuses to schedule it.
+
+Additionally, even when the container is forced to run as `nginx`
+from PID 1, several nginx defaults still attempt to write to
+locations owned by root:
+
+- `/var/cache/nginx/*` (proxy/fastcgi caches)
+- `/run/nginx.pid` (master pidfile)
+- `/var/log/nginx/*.log` (access/error logs)
+
+A naive `runAsUser: 101` causes `CrashLoopBackOff` with errors
+like `mkdir() ".../proxy_temp" failed (13: Permission denied)`
+or `open() "/run/nginx.pid" failed (13: Permission denied)`.
+
+## Decision
+
+Run nginx as UID 101 explicitly, with writable `emptyDir` volumes
+mounted over the cache and runtime directories, and direct logs to
+stdout/stderr so the cluster log pipeline owns log rotation.
+
+The Deployment spec for `robson-frontend-v2` sets:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  fsGroup: 101
+containers:
+  - name: nginx
+    image: ghcr.io/ldamasio/robson-frontend-v2:latest
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: false
+      capabilities:
+        drop: ["ALL"]
+    volumeMounts:
+      - name: cache
+        mountPath: /var/cache/nginx
+      - name: run
+        mountPath: /run
+volumes:
+  - name: cache
+    emptyDir: {}
+  - name: run
+    emptyDir: {}
+```
+
+The `nginx.conf` shipped in the image:
+
+- Listens on port 8080 (port 80 requires `CAP_NET_BIND_SERVICE`,
+  which is dropped).
+- Sends access and error logs to stdout/stderr.
+- Sets `pid /run/nginx.pid;` so the writable `emptyDir` covers it.
+
+## Consequences
+
+**Positive**
+
+- Container starts cleanly under cluster `runAsNonRoot` baseline.
+- No persistent filesystem state — pod restarts get a clean cache.
+- Capability set is empty; nginx cannot bind privileged ports or
+  acquire any other Linux capabilities.
+- Logs flow to the standard k8s log pipeline (Promtail/Loki) with
+  no extra agent.
+
+**Negative / trade-offs**
+
+- `emptyDir` is per-pod. There is no shared cache across replicas;
+  each pod warms its own. Acceptable for a static asset server.
+- `readOnlyRootFilesystem: false` is set because nginx writes
+  small temp files in `/var/lib/nginx/` during reload. Tightening
+  to read-only-root would require additional mounts and is
+  deferred to a follow-up.
+
+## Alternatives
+
+- **Run as root** — rejected; violates cluster baseline and
+  exposes container breakout risk.
+- **Custom nginx-unprivileged image** (e.g., `nginxinc/nginx-unprivileged`)
+  — viable; not adopted because vanilla `nginx:alpine` plus the
+  volume strategy keeps the image sourcing standard and avoids a
+  second supply chain.
+- **OpenResty / Caddy** — overkill for a static SPA; introduces a
+  new operational surface.
+
+## Implementation Notes
+
+- Manifest: `rbx-infra/apps/prod/robson/robson-frontend-v2-deploy.yml`.
+- nginx config (in the image): `apps/frontend/nginx.conf`.
+- The same pattern applies to any future static-asset container in
+  the cluster.
+
+**Failure mode to remember.** If a future engineer copies this
+deployment and forgets the `emptyDir` mounts, the symptom is
+`CrashLoopBackOff` with `nginx: [emerg] mkdir() ".../proxy_temp"
+failed (13: Permission denied)`. Diagnose with `kubectl logs
+<pod> --previous`.

--- a/docs/adr/ADR-0027-cors-layer-robsond.md
+++ b/docs/adr/ADR-0027-cors-layer-robsond.md
@@ -1,0 +1,123 @@
+# ADR-0027: Robsond CORS Layer Driven by Env Var
+
+**Date:** 2026-04-25
+**Status:** Accepted
+
+## Context
+
+Production exposes the frontend at two origins:
+
+- `https://robson.rbx.ia.br` (pt-BR default)
+- `https://robson.rbxsystems.ch` (en default)
+
+Both origins call the robsond API at
+`https://api.robson.rbx.ia.br`. Every cross-origin request must
+pass a CORS preflight (`OPTIONS`) that the backend acknowledges
+with `Access-Control-Allow-Origin`. Without that header the
+browser refuses to send the actual request and the operator sees
+silent failures (login appears to hang, dashboard shows
+"connection error").
+
+Robsond historically had no CORS handling because v2 ran behind
+the same origin as the legacy React frontend (`app.robson.rbx.ia.br`).
+The v3 cutover splits frontend and backend onto different
+subdomains, making CORS mandatory.
+
+The allow-list must be configurable per environment:
+
+- Production: only the two real frontend origins.
+- Testnet: same hosts under a different scheme or a `testnet-*`
+  prefix.
+- Development: typically `http://localhost:5173` for `pnpm dev`.
+
+Hardcoding the list in code would force a rebuild for any origin
+change.
+
+## Decision
+
+Add a `tower_http::cors::CorsLayer` to the merged Axum router in
+`v3/robsond/src/api.rs`. The allow-list is read from the
+`ROBSON_CORS_ALLOWED_ORIGINS` environment variable as a
+comma-separated list.
+
+```rust
+fn build_cors_layer() -> CorsLayer {
+    let raw = std::env::var("ROBSON_CORS_ALLOWED_ORIGINS")
+        .unwrap_or_default();
+    let origins: Vec<HeaderValue> = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| HeaderValue::from_str(s).ok())
+        .collect();
+    if origins.is_empty() {
+        return CorsLayer::new();
+    }
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::list(origins))
+        .allow_methods([Method::GET, Method::POST,
+                        Method::DELETE, Method::OPTIONS])
+        .allow_headers([header::AUTHORIZATION,
+                        header::CONTENT_TYPE])
+}
+```
+
+When `ROBSON_CORS_ALLOWED_ORIGINS` is unset or empty, the layer
+adds no CORS headers. This preserves the pre-existing behavior
+that test harnesses (which call the API from the same origin)
+relied on, and avoids leaking origins when the variable is not
+intentionally configured.
+
+In production the variable is set in
+`rbx-infra/apps/prod/robson/robsond-config.yml`:
+
+```yaml
+ROBSON_CORS_ALLOWED_ORIGINS: "https://robson.rbx.ia.br,https://robson.rbxsystems.ch"
+```
+
+## Consequences
+
+**Positive**
+
+- Browser preflight succeeds; frontend works against the prod
+  backend without further changes.
+- Allow-list is operator-managed via ConfigMap, no rebuild needed
+  to add/remove origins (e.g., adding a staging frontend).
+- Default empty behavior preserves test compatibility.
+- Pattern matches the existing env-direct reads in robsond
+  (`ROBSON_API_HOST`, `ROBSON_API_PORT`, `ROBSON_API_TOKEN`) — no
+  new architectural concept introduced.
+
+**Negative / trade-offs**
+
+- Wildcard origins (`*`) are not supported by intent; the parser
+  treats `*` as a literal value that fails `HeaderValue::from_str`
+  for `AllowOrigin::list`. If a future use case requires wildcard
+  + credentials, the function will need an explicit branch.
+- Misconfiguration (typo in env var) silently disables CORS for
+  that origin. The recommended check is `curl -I -X OPTIONS -H
+  "Origin: https://..." https://api.robson.rbx.ia.br/health` — see
+  the runbook in `rbx-infra/docs/runbooks/`.
+
+## Alternatives
+
+- **Hardcoded allow-list in source** — rejected; requires rebuild
+  for every origin change and conflates code with environment.
+- **`tower_http::cors::CorsLayer::permissive()`** — rejected;
+  exposes the API to any origin, including hostile ones, defeating
+  the trust boundary even though Bearer auth still gates mutation.
+- **CORS via Traefik middleware** — viable but splits the policy
+  between code and ingress config. Keeping the allow-list with the
+  service makes it visible to anyone reading the daemon source.
+
+## Implementation Notes
+
+- Code: `v3/robsond/src/api.rs` (`build_cors_layer`, applied via
+  `.layer()` on the merged router).
+- Doc reference in `v3/robsond/src/config.rs` (`ApiConfig`
+  comment) so readers find the env var without grepping.
+- Unit test: `build_cors_layer_parses_origins_from_env` in the
+  `tests` module of `api.rs`.
+- ConfigMap: `rbx-infra/apps/prod/robson/robsond-config.yml`.
+
+**Related:** ADR-0025 (Bearer token auth), ADR-0028 (k3s hosting).

--- a/docs/implementation/FE-P1-FRONTEND-MVP.md
+++ b/docs/implementation/FE-P1-FRONTEND-MVP.md
@@ -871,3 +871,44 @@ apps/frontend/
 | — | EP-006 kill-switch | — | TODO |
 | 2026-04-24 | EP-007 i18n — login/dashboard/operation detail extended to svelte-i18n; en.json + pt-BR.json key parity test added; labels.ts kept English (technical state identifiers); root layout guards render behind $isLoading to avoid init race. Commit e8fb9d50 on branch fe-p1/ep-007-i18n. | GLM-5.1 | DONE |
 | 2026-04-24 | EP-008 deploy skeleton — workflow_dispatch-only GitHub Actions workflow targeting Contabo S3 bucket robson-app; runbook docs/runbooks/frontend-deploy.md with prerequisites B1–B5. Workflow does not run until operator provisions bucket, secrets, DNS, TLS decision, backend CORS/public reachability. Commit 15f86514 on branch fe-p1/ep-008-deploy. | GLM-5.1 | DONE (skeleton; execution blocked on B1–B5) |
+| 2026-04-25 | Hosting pivot Contabo S3 → k3s in-cluster (ADR-0028). Frontend becomes containerized nginx; ArgoCD GitOps; cert-manager + Let's Encrypt. | Opus 4.7 + GLM-5.1 | DONE |
+| 2026-04-25 | v3 canonical layout: Django and legacy React deleted; `v2/` → `v3/`; `apps/frontend-v2/` → `apps/frontend/`; obsolete CI workflows removed. | GLM-5.1 | DONE |
+| 2026-04-25 | Production launch — three endpoints HTTPS 200: robson.rbx.ia.br, robson.rbxsystems.ch, api.robson.rbx.ia.br. CORS layer (ADR-0027), nginx non-root config (ADR-0026), Bearer-token auth (ADR-0025) all live. | Opus 4.7 + GLM-5.1 | **FE-P1 LIVE** |
+
+---
+
+## Closing notes (2026-04-25)
+
+**FE-P1 is complete and live.** The frontend serves the operator
+console at two domains with host-based locale; robsond exposes a
+public backend at `api.robson.rbx.ia.br`; the operator authenticates
+with a Bearer token issued by robsond.
+
+**What shipped vs the original plan.** The original FE-P1 plan
+proposed GitHub OAuth and Contabo S3 hosting. Both were replaced:
+
+- **Auth:** Bearer token (ADR-0025) instead of OAuth. `adapter-static`
+  has no server runtime, so an OAuth callback could not be handled
+  without an edge function or `adapter-node`. The single-operator
+  console does not justify the extra surface.
+- **Hosting:** k3s in-cluster nginx (ADR-0028) instead of Contabo S3.
+  Contabo Object Storage lacks native website hosting, per-bucket
+  IAM, and ACL UI. The cluster already had Traefik + cert-manager,
+  so reusing that path eliminated four blockers in one move.
+- **CORS:** env-driven allow-list (ADR-0027). Net-new since the
+  legacy React frontend shared origin with the Django backend.
+- **nginx security context:** non-root + `emptyDir` caches
+  (ADR-0026). Net-new for the cluster baseline.
+
+**Deferred to follow-up slices** (intentionally, not blockers):
+
+- Image rename phase 2: drop the `-v2` suffix from
+  `ghcr.io/ldamasio/robson-frontend-v2` and
+  `ghcr.io/rbxrobotica/robson-v2`. Coordinated PR pair across
+  robson + rbx-infra.
+- Locale switcher UI in the header. Host-based default suffices.
+- Playwright e2e in `frontend-tests.yml` CI. Currently `pnpm test`
+  unit only is the gate.
+- Hash chain UI (FE-P3).
+- History endpoints + monthly views (FE-P2).
+- Cleanup of legacy `fe-p1/*` branches superseded by `main`.

--- a/docs/onboarding/DEVELOPER-QUICKSTART.md
+++ b/docs/onboarding/DEVELOPER-QUICKSTART.md
@@ -1,0 +1,208 @@
+# Developer Quickstart — Robson v3
+
+**Audience:** engineers contributing to the Robson v3 codebase
+(Rust runtime + SvelteKit frontend).
+**Goal:** clone, build, and submit a first PR within an hour.
+
+For infrastructure access (cluster, DNS, secrets) see
+`rbx-infra/docs/onboarding/ENGINEER-DAY-ONE.md`.
+
+---
+
+## What Robson is
+
+Robson v3 is the canonical version. Earlier iterations (v1 Django,
+v2 hybrid) live only in git history.
+
+- **Runtime:** `robsond`, a Rust daemon that executes governed
+  trading actions on Binance Futures. Production live with real
+  capital.
+- **Frontend:** static SvelteKit single-page app served from k3s
+  in-cluster behind Traefik.
+- **Hosting:** rbx-infra k3s cluster, ArgoCD GitOps,
+  cert-manager + Let's Encrypt TLS.
+- **Operator UI:** `robson.rbx.ia.br` (pt-BR) and
+  `robson.rbxsystems.ch` (en).
+
+Read `AGENTS.md` and `v3/CLAUDE.md` for the full project rules
+before writing code.
+
+---
+
+## Prerequisites
+
+Software:
+
+- Rust stable toolchain (`rustup default stable`)
+- Node.js 20.x and pnpm 9
+- Docker (only if you build container images locally)
+- `gh` CLI authenticated to your GitHub user
+
+Optional but recommended:
+
+- `kubectl` and `kustomize` (for inspecting cluster state)
+- `just` (workspace task runner; see `v3/justfile` if present)
+
+You do **not** need cluster access to contribute code. Reviewers
+and CI handle deployments.
+
+---
+
+## Clone and build
+
+```bash
+git clone git@github.com:ldamasio/robson.git
+cd robson
+```
+
+### Backend (Rust)
+
+```bash
+cd v3
+cargo build
+cargo test --all                  # unit + in-memory tests
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+The workspace has 11 crates. Pure-domain logic lives in
+`robson-domain`; business logic in `robson-engine`; daemon entry
+in `robsond`. See `v3/CLAUDE.md` for crate dependency rules.
+
+Postgres-backed integration tests are gated behind
+`#[ignore = "requires DATABASE_URL"]`. Skip them locally; CI runs
+them with a provisioned database.
+
+### Frontend (SvelteKit)
+
+```bash
+cd apps/frontend
+pnpm install
+cp .env.example .env.local
+# .env.local: PUBLIC_ROBSON_API_BASE=http://localhost:8080
+pnpm run dev                      # opens http://localhost:5173
+```
+
+Verification scripts:
+
+```bash
+pnpm run check                    # svelte-check, 0 errors expected
+pnpm run test                     # vitest unit
+pnpm run test:e2e                 # playwright (mocked API)
+pnpm run build                    # static output in build/
+```
+
+---
+
+## Running the stack locally
+
+**Frontend only (no backend):** the login form calls
+`GET /health` against `PUBLIC_ROBSON_API_BASE`. With no backend
+running, login will fail. UI rendering, i18n, and most components
+work without a backend.
+
+**Backend only:**
+
+```bash
+cd v3
+ROBSON_ENV=development \
+ROBSON_API_HOST=127.0.0.1 \
+ROBSON_API_PORT=8080 \
+cargo run -p robsond
+```
+
+The daemon refuses to start in production mode without a real
+exchange configuration. Development mode runs against the
+in-memory store.
+
+**Frontend + backend together:**
+
+1. Run robsond as above.
+2. In another terminal, run `pnpm run dev` in `apps/frontend/`.
+3. Generate a dev token (any non-empty string when
+   `ROBSON_ENV=development` and `ROBSON_API_TOKEN` is unset; the
+   auth middleware is no-op when token is unset).
+4. Open `http://localhost:5173`, paste any non-empty string at
+   `/login`, and the dashboard loads.
+
+---
+
+## Project conventions
+
+- **English only** — code, comments, commits, docs (ADR-0006).
+- **Conventional Commits** — `<type>(<scope>): <subject>`. Scopes
+  follow the crate or area touched (`domain`, `engine`, `frontend`,
+  `infra`, etc.).
+- **One PR per logical slice.** Avoid bundling unrelated changes.
+- **Hexagonal architecture** in Rust — domain has zero external
+  deps, ports in `robson-exec`, adapters in `robson-connectors` and
+  `robson-store` (ADR-0002).
+- **No `unwrap()`/`expect()` in production code.** Use `?` and
+  proper error types. Tests may unwrap.
+- **`rust_decimal::Decimal` for all financial amounts.** Never
+  `f64`.
+- **Robson-authored position invariant** — every open exchange
+  position must trace to a `robsond` `GovernedAction`. See
+  ADR-0022 and `docs/policies/UNTRACKED-POSITION-RECONCILIATION.md`.
+- **Symbol-agnostic policies** — never hardcode a symbol in policy
+  text. See ADR-0023 and
+  `docs/policies/SYMBOL-AGNOSTIC-POLICIES.md`.
+- **Technical Stop from chart analysis only.** `entry × (1 − pct)`
+  is forbidden. See ADR-0021.
+
+---
+
+## Submitting your first PR
+
+```bash
+git checkout -b feat/<scope>/<short-description>
+# ...edit, build, test...
+git commit -m "feat(<scope>): <subject>"
+git push -u origin feat/<scope>/<short-description>
+gh pr create --base main
+```
+
+CI runs:
+
+- `Robsond CI/CD` — when `v3/**` changes (`cargo fmt`, `cargo
+  clippy`, `cargo test`, build + push image to GHCR if mergeing
+  to main).
+- `Frontend Tests` — when `apps/frontend/**` changes (`pnpm
+  check`, `pnpm test`, `pnpm build`).
+- `Frontend Build & Publish` — when frontend changes are merged
+  to main; builds and pushes the image.
+
+All three must pass before merge.
+
+After merge, ArgoCD picks up new image SHAs from `rbx-infra`
+deployment manifests (auto-bumped via separate GitHub Actions on
+the rbx-infra side). Cluster sync typically completes within
+2–3 minutes.
+
+---
+
+## Where to look when something breaks
+
+| Symptom | First place to check |
+|---------|---------------------|
+| `cargo clippy` warning that wasn't there yesterday | `v2/clippy.toml` (workspace-level allowlist) |
+| `pnpm run check` errors after a merge | run `pnpm install --frozen-lockfile` to sync deps |
+| Frontend dev server can't reach backend | `PUBLIC_ROBSON_API_BASE` in `.env.local` |
+| Tests pass locally, fail in CI | check `cargo test --features postgres` and the database test tier |
+| Production dashboard shows "connection error" | likely CORS — see ADR-0027 and `rbx-infra/docs/runbooks/CERT-MANAGER-DEBUG.md` for related diagnostics |
+
+---
+
+## Further reading
+
+- `AGENTS.md` — repository-wide rules
+- `v3/CLAUDE.md` — Rust workspace details
+- `docs/architecture/v3-runtime-spec.md` — runtime architecture
+- `docs/architecture/v3-control-loop.md` — execution stages
+- `docs/adr/` — accepted architectural decisions
+- `docs/runbooks/frontend-deploy.md` — deploy procedure
+- `rbx-infra/docs/onboarding/ENGINEER-DAY-ONE.md` — infra access
+- `rbx-infra/docs/infra/ARCHITECTURE.md` — cluster topology
+
+When in doubt, read the ADRs. They explain why the codebase looks
+the way it does.


### PR DESCRIPTION
- new ADRs:
  - ADR-0025 frontend Bearer-token auth (formalizes the decision referenced across FE-P1 docs but never written as a file)
  - ADR-0026 nginx non-root in k3s (UID 101 + emptyDir mounts; captures the CrashLoopBackOff fix from the prod launch)
  - ADR-0027 robsond CORS env-driven allow-list (ROBSON_CORS_ALLOWED_ORIGINS)
- new onboarding doc:
  - docs/onboarding/DEVELOPER-QUICKSTART.md replaces stale DEVELOPER.md as the entry point for new contributors
- mark v1 Django docs as deprecated:
  - docs/DEVELOPER.md (banner pointing to QUICKSTART)
  - docs/AUTH_FLOW.md (banner pointing to ADR-0025)
- INDEX.md: quick-start path repointed to v3 onboarding
- FE-P1-FRONTEND-MVP.md: closing notes documenting ship vs plan, deferrals, and FE-P1 LIVE status

v3 is now the canonical layout. v1 (Django) and v2 (hybrid) live only in git history.

## Summary

- Briefly explain the problem and the proposed solution.

## Changes

- Key changes in this PR:
  - 

## Screenshots (optional)

## Tests

- How to verify:
  - [ ] `cd apps/backend/monolith && ./bin/dj test`
  - [ ] `cd apps/frontend && npm ci && npm test`
- Added/updated tests:
  - 

## Migrations

- [ ] No schema changes
- [ ] Includes schema migrations
- Notes:
  - 

## Backward Compatibility

- Does this PR introduce breaking changes? Explain mitigation/migration strategy.

## Security & Data

- Any secrets, credentials, or PII involved? If so, describe handling.
- External calls guarded by flags? (e.g., `TRADING_ENABLED=False` in dev)

## Checklist

- [ ] Scope is focused and documented
- [ ] Code follows project conventions (see `docs/DEVELOPER.md`)
- [ ] Migrations created (if needed) and rationale explained
- [ ] Tests added/updated and passing locally
- [ ] Docs updated (README/DEVELOPER/MIGRATION_GUIDE as applicable)
