### PR TITLE
docs: P2 completion + legacy banners + CHANGELOG fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI uses nightly rustfmt**: Added `rustup toolchain install nightly --component rustfmt`
   step; formatting check now runs `cargo +nightly fmt --all --check` instead of stable.
 - **GitOps paths corrected**: `Build & Push Image` job was targeting non-existent paths
-  `apps/prod/robson-v2/robsond-deployment.yml` in rbx-infra. Fixed to correct paths:
+  `apps/prod/robson/robsond-deploy.yml` in rbx-infra. Fixed to correct paths:
   `apps/prod/robson/robsond-deploy.yml` and `apps/prod/robson/robsond-db-migrate-job.yml`.
 - Codebase reformatted with nightly rustfmt (62 files, net −534 lines).
 

--- a/docs/adr/ADR-0015-rust-stop-engine-rabbitmq.md
+++ b/docs/adr/ADR-0015-rust-stop-engine-rabbitmq.md
@@ -1,5 +1,9 @@
 # ADR-0015: Rust Stop Engine with RabbitMQ for Critical Stop-Loss Execution
 
+> **STATUS: SUPERSEDED** — RabbitMQ is not used in Robson v3. The stop-loss
+> engine runs in-process within robsond. This ADR is retained for historical
+> reference only.
+
 **Status**: APPROVED
 **Date**: 2024-12-26
 **Deciders**: Product Owner, System Architect

--- a/docs/architecture/STATIC-FILES-ARCHITECTURE.md
+++ b/docs/architecture/STATIC-FILES-ARCHITECTURE.md
@@ -1,5 +1,10 @@
 # Static Files Architecture
 
+> **DEPRECATED** — This document describes the legacy Django + Gunicorn
+> static file architecture. The frontend now serves via nginx in k3s
+> (SvelteKit + adapter-static). See ADR-0028 (hosting pivot to k3s) and
+> `docs/runbooks/frontend-deploy.md` for the current architecture.
+
 ## Overview
 
 Robson uses a layered architecture for serving web traffic, combining

--- a/docs/runbooks/FRONTEND-NGINX-TROUBLESHOOTING.md
+++ b/docs/runbooks/FRONTEND-NGINX-TROUBLESHOOTING.md
@@ -1,0 +1,140 @@
+# Frontend nginx Troubleshooting (k3s)
+
+**Audience:** engineers debugging `robson-frontend-v2` pod failures.
+
+The SvelteKit frontend runs as static files served by nginx inside a
+container. The pod is configured to run as non-root (UID 101), which
+introduces specific failure modes.
+
+---
+
+## Common failures
+
+### CrashLoopBackOff: mkdir /var/cache/nginx permission denied
+
+**Symptom:** pod crashes immediately, logs show:
+
+```
+mkdir(): "/var/cache/nginx/client_temp" failed (13: Permission denied)
+```
+
+**Cause:** nginx tries to create cache directories under
+`/var/cache/nginx`, but the filesystem is owned by root and the
+container runs as UID 101.
+
+**Fix:** Add an emptyDir volume at `/var/cache/nginx`:
+
+```yaml
+spec:
+  containers:
+  - name: nginx
+    volumeMounts:
+    - name: nginx-cache
+      mountPath: /var/cache/nginx
+  volumes:
+  - name: nginx-cache
+    emptyDir: {}
+```
+
+### CrashLoopBackOff: /run/nginx.pid permission denied
+
+**Symptom:** pod crashes, logs show:
+
+```
+open() "/run/nginx.pid" failed (13: Permission denied)
+```
+
+**Cause:** nginx writes its PID file to `/run`, which is owned by
+root.
+
+**Fix:** Add an emptyDir volume at `/run`:
+
+```yaml
+spec:
+  containers:
+  - name: nginx
+    volumeMounts:
+    - name: nginx-run
+      mountPath: /run
+  volumes:
+  - name: nginx-run
+      emptyDir: {}
+```
+
+### CreateContainerConfigError: runAsNonRoot with non-numeric user
+
+**Symptom:** pod never starts, event shows:
+
+```
+Error: container has runAsNonRoot and image will run as uid 0
+```
+
+or:
+
+```
+Error: compute effective security context: non-numeric user (nginx)
+```
+
+**Cause:** `securityContext.runAsNonRoot: true` is set but no
+explicit `runAsUser` is specified. The kubelet cannot verify the
+container will run as non-root when the image uses a named user
+(like `nginx`) rather than a numeric UID.
+
+**Fix:** Add `runAsUser: 101` to the securityContext:
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 101
+  capabilities:
+    drop:
+      - ALL
+```
+
+### ImagePullBackOff
+
+**Symptom:** pod shows `ImagePullBackOff` or `ErrImagePull`.
+
+**Cause:** The image tag doesn't exist in GHCR, or the tag format
+is wrong.
+
+**Fix:** Verify the image exists:
+
+```bash
+gh api /users/ldamasio/packages/container/robson-frontend-v2/versions \
+  --jq '.[].metadata.container.tags'
+```
+
+Ensure the deployment uses a valid SHA tag
+(`ghcr.io/ldamasio/robson-frontend-v2:sha-XXXXXXXX`).
+
+---
+
+## Diagnostic commands
+
+```bash
+# Check pod status
+kubectl get pods -n robson -l app.kubernetes.io/name=robson-frontend-v2
+
+# View crash logs (previous container)
+kubectl logs -n robson -l app.kubernetes.io/name=robson-frontend-v2 --previous
+
+# View events
+kubectl get events -n robson --sort-by='.lastTimestamp'
+
+# Describe the pod for detailed error
+kubectl describe pod -n robson -l app.kubernetes.io/name=robson-frontend-v2
+
+# Check deployment config
+kubectl get deploy robson-frontend-v2 -n robson -o yaml
+```
+
+---
+
+## Reference
+
+- ADR-0028: hosting pivot from Contabo S3 to k3s
+- `docs/runbooks/frontend-deploy.md`: deployment procedure
+- `rbx-infra/apps/prod/robson/robson-frontend-v2-deploy.yml`: current
+  deployment manifest with both emptyDir volumes applied

--- a/docs/runbooks/rabbitmq-operations.md
+++ b/docs/runbooks/rabbitmq-operations.md
@@ -1,5 +1,8 @@
 # RabbitMQ Operations Runbook
 
+> **STATUS: DEPRECATED** — RabbitMQ is not used in Robson v3. This runbook
+> should be archived to `docs/history/`. Retained pending archive.
+
 **Service**: RabbitMQ Admin Plane
 **Owner**: Platform Team
 **Related ADRs**: [ADR-0015](../adr/ADR-0015-rust-stop-engine-rabbitmq.md), [ADR-0016](../adr/ADR-0016-networking-and-observability-architecture.md)


### PR DESCRIPTION
## Summary
- `docs/runbooks/FRONTEND-NGINX-TROUBLESHOOTING.md` — common CrashLoopBackOff scenarios with nginx non-root (UID 101, emptyDir volumes)
- `CHANGELOG.md` — fix stale path `apps/prod/robson-v2/robsond-deployment.yml` → `apps/prod/robson/robsond-deploy.yml`
- `docs/adr/ADR-0015-rust-stop-engine-rabbitmq.md` — superseded banner (RabbitMQ confirmed not in use)
- `docs/runbooks/rabbitmq-operations.md` — deprecation banner
- `docs/architecture/STATIC-FILES-ARCHITECTURE.md` — DEPRECATED (Django + Gunicorn era, superseded by ADR-0028)

## Operator decisions needed
- RabbitMQ: confirmed NOT in use → banners can be upgraded to Superseded/Archived after merge
- STATIC-FILES-ARCHITECTURE.md: confirmed deprecated → can be moved to docs/history/ after merge

## Test plan
- [ ] Verify FRONTEND-NGINX-TROUBLESHOOTING.md renders correctly
- [ ] Confirm CHANGELOG path fix is accurate
- [ ] Review deprecation banners for appropriate wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)