### PR TITLE
fix(frontend): blank page — static i18n imports for Vite 6

### DIFF
--- a/apps/frontend/src/lib/i18n/index.ts
+++ b/apps/frontend/src/lib/i18n/index.ts
@@ -1,8 +1,10 @@
 import { browser } from '$app/environment';
 import { init, register, getLocaleFromNavigator, locale } from 'svelte-i18n';
+import ptBR from './pt-BR.json';
+import en from './en.json';
 
-register('pt-BR', () => import('./pt-BR.json'));
-register('en', () => import('./en.json'));
+register('pt-BR', () => Promise.resolve(ptBR));
+register('en', () => Promise.resolve(en));
 
 export function detectLocale(): string {
   if (!browser) return 'pt-BR';


### PR DESCRIPTION
## Summary

Frontend shows dark background with no content. Root cause: Vite 6
compiles `import('./pt-BR.json')` (dynamic) to a chunk with **no
export**, so svelte-i18n receives an empty module, `$isLoading` never
resolves, and the layout never renders children.

Fix: replace dynamic JSON imports with static imports wrapped in
`Promise.resolve()` for `register()`.

## Root cause analysis

```
Vite 6 build:
  register('pt-BR', () => import('./pt-BR.json'))
                                    ↓
  CB80bSQl.js: const e={dashboard:"Painel",...}  ← NO EXPORT
                                    ↓
  svelte-i18n: loader resolves to {} (empty module)
                                    ↓
  $isLoading stays true → {#if !$isLoading} never renders
                                    ↓
  Blank dark page
```

## Test plan

- [x] Local build succeeds with static imports
- [x] Locale data inlined in node 0 chunk with `Promise.resolve`
- [ ] CI build succeeds
- [ ] Deploy to prod, verify https://robson.rbx.ia.br/ shows login page
- [ ] Verify https://robson.rbxsystems.ch/ also renders (en locale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)