### PR TITLE
fix(frontend): blank page — static i18n imports + { default } wrapper

### DIFF
--- a/apps/frontend/src/lib/i18n/index.ts
+++ b/apps/frontend/src/lib/i18n/index.ts
@@ -3,8 +3,8 @@ import { init, register, getLocaleFromNavigator, locale } from 'svelte-i18n';
 import ptBR from './pt-BR.json';
 import en from './en.json';
 
-register('pt-BR', () => Promise.resolve(ptBR));
-register('en', () => Promise.resolve(en));
+register('pt-BR', () => Promise.resolve({ default: ptBR }));
+register('en', () => Promise.resolve({ default: en }));
 
 export function detectLocale(): string {
   if (!browser) return 'pt-BR';


### PR DESCRIPTION
## Summary

Two-part fix for blank frontend page:

1. **Static imports** — Vite 6 strips exports from dynamic `import('./pt-BR.json')`. Changed to static imports inlined at build time.
2. **`{ default }` wrapper** — svelte-i18n `register()` expects module shape `{ default: dict }`, not raw dict. Without this, `$isLoading` never resolves.

## Test plan

- [x] Local build succeeds
- [ ] CI build + deploy
- [ ] https://robson.rbx.ia.br/ shows login page
- [ ] https://robson.rbxsystems.ch/ shows login page (en locale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)