### PR TITLE
fix(frontend): remove $isLoading guard — render content immediately

### DIFF
--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -2,7 +2,6 @@
   import '$design/tokens.css';
   import { initAuth } from '$stores/auth';
   import '$lib/i18n';
-  import { isLoading } from 'svelte-i18n';
   import { browser } from '$app/environment';
 
   import type { Snippet } from 'svelte';
@@ -11,11 +10,9 @@
   if (browser) initAuth();
 </script>
 
-{#if !$isLoading}
 <main class="rbx-root">
   {@render children()}
 </main>
-{/if}
 
 <style>
   :global(html, body) {


### PR DESCRIPTION
## Summary

The layout gates all rendering on `svelte-i18n`'s `$isLoading` store.
Even with static locale imports and `{ default }` wrapping, the store
apparently never resolves to `false` in the browser.

This PR removes the guard entirely. Locale data is statically inlined
at build time — there's no async loading to wait for. If i18n keys
aren't available yet, the fallback is to show raw keys (acceptable)
rather than a blank page (unacceptable).

## Test plan

- [ ] CI build succeeds
- [ ] https://robson.rbx.ia.br/ shows login form
- [ ] https://robson.rbxsystems.ch/ shows login form (en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)