### PR TITLE
fix(frontend): restore root redirect rendering

### DIFF
--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { authToken } from '$stores/auth';
   import { get } from 'svelte/store';
 
-  onMount(() => {
-    const token = get(authToken);
-    void goto(token ? '/dashboard' : '/login', { replaceState: true });
-  });
+  if (browser) {
+    queueMicrotask(() => {
+      const token = get(authToken);
+      void goto(token ? '/dashboard' : '/login', { replaceState: true });
+    });
+  }
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary

Fixes the remaining blank frontend root page after the i18n guard changes.

The root route was relying on `onMount()` to redirect `/` to `/login` or `/dashboard`, but the production Svelte 5 bundle generated for `+page.svelte` did not include the redirect callback. The page mounted only an empty `<noscript>` node, leaving the viewport blank.

This change moves the redirect into explicit client-side execution guarded by `browser`, scheduled with `queueMicrotask()`, so the static fallback still boots and `/` reliably redirects after hydration.

## Validation

- `PUBLIC_ROBSON_API_BASE=https://api.robson.rbx.ia.br pnpm build`
- `pnpm check` (0 errors, existing Svelte warnings in design components)
- Headless Playwright against local preview: `/` redirects to `/login` and renders the login form text.