### PR TITLE
fix(frontend): render real status payload and slot policy

### DIFF
--- a/apps/frontend/src/lib/api/robson.ts
+++ b/apps/frontend/src/lib/api/robson.ts
@@ -12,16 +12,18 @@ const API_BASE: string = env.PUBLIC_ROBSON_API_BASE ?? '';
 
 export type Position = {
   id: string;
-  account_id: string;
+  account_id: string | null;
   symbol: string;
-  side: 'Long' | 'Short';
+  side: 'Long' | 'Short' | string;
   state: PositionState;
   entry_price: number | null;
   entry_filled_at: string | null;
   tech_stop_distance: number | null;
-  quantity: number;
-  realized_pnl: number;
-  fees_paid: number;
+  quantity: number | null;
+  realized_pnl: number | null;
+  pnl?: number | null;
+  fees_paid: number | null;
+  trailing_stop?: number | null;
   entry_order_id: string | null;
   exit_order_id: string | null;
   insurance_stop_id: string | null;
@@ -33,6 +35,11 @@ export type Position = {
 
 export type PositionState =
   | 'Armed'
+  | 'Entering'
+  | 'Active'
+  | 'Exiting'
+  | 'Closed'
+  | 'Error'
   | { Entering: { entry_order_id: string; expected_entry: number; signal_id: string } }
   | {
       Active: {
@@ -136,6 +143,47 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function normalizePosition(raw: unknown): Position {
+  const p = raw as Record<string, unknown>;
+  return {
+    id: String(p.id ?? ''),
+    account_id: p.account_id == null ? null : String(p.account_id),
+    symbol: String(p.symbol ?? ''),
+    side: String(p.side ?? ''),
+    state: (p.state ?? 'Error') as PositionState,
+    entry_price: toNumber(p.entry_price),
+    entry_filled_at: p.entry_filled_at == null ? null : String(p.entry_filled_at),
+    tech_stop_distance: toNumber(p.tech_stop_distance),
+    quantity: toNumber(p.quantity),
+    realized_pnl: toNumber(p.realized_pnl),
+    pnl: toNumber(p.pnl),
+    fees_paid: toNumber(p.fees_paid),
+    trailing_stop: toNumber(p.trailing_stop),
+    entry_order_id: p.entry_order_id == null ? null : String(p.entry_order_id),
+    exit_order_id: p.exit_order_id == null ? null : String(p.exit_order_id),
+    insurance_stop_id: p.insurance_stop_id == null ? null : String(p.insurance_stop_id),
+    binance_position_id: p.binance_position_id == null ? null : String(p.binance_position_id),
+    created_at: String(p.created_at ?? ''),
+    updated_at: String(p.updated_at ?? ''),
+    closed_at: p.closed_at == null ? null : String(p.closed_at)
+  };
+}
+
+function normalizeStatus(raw: StatusResponse): StatusResponse {
+  return {
+    ...raw,
+    active_positions: Number(raw.active_positions ?? 0),
+    positions: Array.isArray(raw.positions) ? raw.positions.map(normalizePosition) : [],
+    pending_approvals: Array.isArray(raw.pending_approvals) ? raw.pending_approvals : []
+  };
+}
+
 export class ApiError extends Error {
   constructor(
     public readonly path: string,
@@ -192,9 +240,9 @@ function createEventSource(url: string): EventSourceLike {
 export const robsonApi = {
   health: () => apiFetch<{ status: string }>('/health'),
 
-  getStatus: () => apiFetch<StatusResponse>('/status'),
+  getStatus: async () => normalizeStatus(await apiFetch<StatusResponse>('/status')),
 
-  getPosition: (id: string) => apiFetch<Position>(`/positions/${id}`),
+  getPosition: async (id: string) => normalizePosition(await apiFetch<Position>(`/positions/${id}`)),
 
   armPosition: (body: { symbol: string; side: string }) =>
     apiFetch<Position>('/positions', { method: 'POST', body: JSON.stringify(body) }),

--- a/apps/frontend/src/lib/config/slots.ts
+++ b/apps/frontend/src/lib/config/slots.ts
@@ -1,7 +1,7 @@
 import type { PositionState } from '$api/robson';
 import { isPositionActive } from '$lib/presentation/labels';
 
-export const SLOT_COUNT = 6;
+export const INITIAL_MONTHLY_SLOT_BUDGET = 4;
 
 export type SlotCell = {
   index: number;
@@ -12,8 +12,10 @@ export type SlotCell = {
 
 export function deriveSlots(positions: { id: string; state: PositionState }[]): SlotCell[] {
   const active = positions.filter((p) => isPositionActive(p.state));
+  const count = Math.max(INITIAL_MONTHLY_SLOT_BUDGET, active.length);
   const cells: SlotCell[] = [];
-  for (let i = 0; i < SLOT_COUNT; i++) {
+  
+  for (let i = 0; i < count; i++) {
     const pos = active[i];
     cells.push({
       index: i,

--- a/apps/frontend/src/lib/presentation/labels.ts
+++ b/apps/frontend/src/lib/presentation/labels.ts
@@ -23,31 +23,35 @@ export function positionSummaryLines(p: Position): string[] {
   if (typeof state === 'string') {
     if (state === 'Armed') {
       lines.push(label('ARMED', 'awaiting entry signal'));
+    } else if (state === 'Active') {
+      const details = [];
+      if (p.entry_price != null) details.push(`entry ${fmtNum(p.entry_price)}`);
+      if (p.trailing_stop != null) details.push(`stop ${fmtNum(p.trailing_stop)}`);
+      lines.push(label('ACTIVE', details.join(' · ') || 'position open'));
     }
-    return lines;
-  }
+  } else {
+    const key = Object.keys(state)[0];
+    const val = (state as Record<string, Record<string, unknown>>)[key];
 
-  const key = Object.keys(state)[0];
-  const val = (state as Record<string, Record<string, unknown>>)[key];
-
-  if (key === 'Entering' && val) {
-    lines.push(label('ENTERING', `expected entry ${fmtNum(val.expected_entry as number)}`));
-  } else if (key === 'Active' && val) {
-    lines.push(label('ACTIVE', `price ${fmtNum(val.current_price as number)} · stop ${fmtNum(val.trailing_stop as number)}`));
-    if (val.favorable_extreme) lines.push(label('EXTREME', fmtNum(val.favorable_extreme as number)));
-  } else if (key === 'Exiting' && val) {
-    lines.push(label('EXITING', `${val.exit_reason}`));
-  } else if (key === 'Closed' && val) {
-    lines.push(label('CLOSED', `exit ${fmtNum(val.exit_price as number)} · reason ${val.exit_reason}`));
-    lines.push(label('PnL', `${fmtPnl(val.realized_pnl as number)}%`));
-  } else if (key === 'Error' && val) {
-    lines.push(label('ERROR', `${val.error}`));
+    if (key === 'Entering' && val) {
+      lines.push(label('ENTERING', `expected entry ${fmtNum(val.expected_entry as number)}`));
+    } else if (key === 'Active' && val) {
+      lines.push(label('ACTIVE', `price ${fmtNum(val.current_price as number)} · stop ${fmtNum(val.trailing_stop as number)}`));
+      if (val.favorable_extreme) lines.push(label('EXTREME', fmtNum(val.favorable_extreme as number)));
+    } else if (key === 'Exiting' && val) {
+      lines.push(label('EXITING', `${val.exit_reason}`));
+    } else if (key === 'Closed' && val) {
+      lines.push(label('CLOSED', `exit ${fmtNum(val.exit_price as number)} · reason ${val.exit_reason}`));
+      lines.push(label('PnL', `${fmtPnl(val.realized_pnl as number)}%`));
+    } else if (key === 'Error' && val) {
+      lines.push(label('ERROR', `${val.error}`));
+    }
   }
 
   if (p.entry_price != null) {
     lines.push(label('ENTRY', fmtNum(p.entry_price)));
   }
-  if (p.quantity > 0) {
+  if (p.quantity != null && p.quantity > 0) {
     lines.push(label('SIZE', String(p.quantity)));
   }
 
@@ -90,7 +94,7 @@ export function eventTypeLabel(event: SseEvent): string {
 }
 
 export function isPositionActive(state: PositionState): boolean {
-  if (state === 'Armed') return true;
+  if (state === 'Armed' || state === 'Entering' || state === 'Active') return true;
   if (typeof state === 'object') {
     const key = Object.keys(state)[0];
     return key === 'Entering' || key === 'Active';

--- a/apps/frontend/src/routes/(authed)/dashboard/+page.svelte
+++ b/apps/frontend/src/routes/(authed)/dashboard/+page.svelte
@@ -9,7 +9,7 @@
   import { activePositions } from '$stores/operations';
   import { haltStatus } from '$stores/slots';
   import { recentEvents, pushEvent } from '$stores/events';
-  import { deriveSlots, SLOT_COUNT } from '$lib/config/slots';
+  import { deriveSlots, INITIAL_MONTHLY_SLOT_BUDGET } from '$lib/config/slots';
   import { formatTimeUtc, isTodayUtc } from '$lib/utils/time';
   import {
     positionLabel,
@@ -30,7 +30,8 @@
   let positions = $derived($activePositions);
   let slots = $derived(deriveSlots(positions));
   let occupied = $derived(slots.filter((s) => s.occupied).length);
-  let free = $derived(SLOT_COUNT - occupied);
+  let displayedSlots = $derived(slots.length);
+  let free = $derived(Math.max(0, INITIAL_MONTHLY_SLOT_BUDGET - occupied));
   let activeOps = $derived(positions.filter((p) => isPositionActive(p.state)));
   let todayEvents = $derived($recentEvents.filter((e) => isTodayUtc(e.occurred_at)));
   let haltState = $derived($haltStatus?.state ?? 'active');
@@ -39,7 +40,7 @@
     if (typeof p.state === 'object' && 'Closed' in p.state) {
       return Number(p.state.Closed.realized_pnl);
     }
-    return p.realized_pnl != null ? Number(p.realized_pnl) : null;
+    return p.pnl ?? p.realized_pnl ?? null;
   }
 
   function monthLabel(): string {
@@ -152,7 +153,7 @@
           <span class="dot warn"></span> {$_('dashboard.connecting')}
         {:else}
           <span class="dot live"></span>
-          {haltStateLabel(haltState)} · SLOT {occupied}/{SLOT_COUNT}
+          {haltStateLabel(haltState)} · SLOT {occupied}/{displayedSlots}
         {/if}
       </div>
     </Row>
@@ -295,7 +296,7 @@
   }
   .slots-grid {
     display: grid;
-    grid-template-columns: repeat(6, 64px);
+    grid-template-columns: repeat(4, 64px);
     gap: var(--s-2);
   }
   .slot {

--- a/apps/frontend/src/routes/(authed)/kill-switch/+page.svelte
+++ b/apps/frontend/src/routes/(authed)/kill-switch/+page.svelte
@@ -6,6 +6,7 @@
   import { haltStatus } from '$stores/slots';
   import { _ } from 'svelte-i18n';
   import { positionLabel, positionStateLabel } from '$lib/presentation/labels';
+  import { INITIAL_MONTHLY_SLOT_BUDGET } from '$lib/config/slots';
 
   type PageState = 'loading' | 'active' | 'halted' | 'error';
 
@@ -112,7 +113,7 @@
           <div class="eyebrow">{$_('killSwitch.currentState')}</div>
           <div class="state-line">
             <span class="dot live"></span>
-            ACTIVE · {$_('killSwitch.slotLabel')} {activeCount}/6 · {activeCount} {activeCount === 1 ? ($_('killSwitch.openPositions_one') ?? 'OPEN POSITION') : ($_('killSwitch.openPositions_other') ?? 'OPEN POSITIONS')}
+            ACTIVE · {$_('killSwitch.slotLabel')} {activeCount}/{Math.max(INITIAL_MONTHLY_SLOT_BUDGET, activeCount)} · {activeCount} {activeCount === 1 ? ($_('killSwitch.openPositions_one') ?? 'OPEN POSITION') : ($_('killSwitch.openPositions_other') ?? 'OPEN POSITIONS')}
           </div>
         </div>
 

--- a/apps/frontend/tests/e2e/dashboard.spec.ts
+++ b/apps/frontend/tests/e2e/dashboard.spec.ts
@@ -13,7 +13,7 @@ const STATUS_OK = {
 };
 
 test.describe('Dashboard', () => {
-  test('data state: 6 slots, 2 occupied, correct status strip', async ({ page }) => {
+  test('data state: 4 slots, 2 occupied, correct status strip', async ({ page }) => {
     await installMockEventSource(page);
     await page.route('**/status', (route) =>
       route.fulfill({
@@ -33,9 +33,9 @@ test.describe('Dashboard', () => {
     await authAndGoto(page, '/dashboard');
 
     await expect(page.locator('.dashboard')).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('.slot')).toHaveCount(6);
+    await expect(page.locator('.slot')).toHaveCount(4);
     await expect(page.locator('.slot.occupied')).toHaveCount(2);
-    await expect(page.locator('.status-strip')).toContainText('SLOT 2/6');
+    await expect(page.locator('.status-strip')).toContainText('SLOT 2/4');
     await expect(page.locator('.op-card-link')).toHaveCount(2);
     await expect(page.locator('.eyebrow', { hasText: "TODAY'S EVENTS" })).toBeVisible();
     await expect(page.locator('.tick-ruler')).toBeVisible();

--- a/apps/frontend/tests/e2e/kill-switch.spec.ts
+++ b/apps/frontend/tests/e2e/kill-switch.spec.ts
@@ -202,7 +202,7 @@ test.describe('Kill Switch', () => {
     await authAndGoto(page, '/kill-switch');
 
     await expect(page.locator('.state-line')).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('.state-line')).toContainText('SLOT 2/6');
+    await expect(page.locator('.state-line')).toContainText('SLOT 2/4');
   });
 
   test('pt-BR locale uses DESLIGAR keyword', async ({ page }) => {

--- a/apps/frontend/tests/unit/dashboard-logic.test.ts
+++ b/apps/frontend/tests/unit/dashboard-logic.test.ts
@@ -7,7 +7,7 @@ import {
   eventSummaryText,
   eventTypeLabel
 } from '$lib/presentation/labels';
-import { deriveSlots, occupiedCount, SLOT_COUNT } from '$lib/config/slots';
+import { deriveSlots, occupiedCount, INITIAL_MONTHLY_SLOT_BUDGET } from '$lib/config/slots';
 import { formatTimeUtc, isTodayUtc } from '$lib/utils/time';
 import type { Position, PositionState, SseEvent, StatusResponse, MonthlyHaltStatus } from '$api/robson';
 
@@ -46,10 +46,10 @@ function makeSseEvent(payload: Record<string, unknown>): SseEvent {
 // --- Dashboard data flow tests ---
 
 describe('dashboard slot derivation from status response', () => {
-  it('empty status yields 6 free slots', () => {
+  it('empty status yields 4 free slots', () => {
     const positions: Position[] = [];
     const slots = deriveSlots(positions);
-    expect(slots).toHaveLength(6);
+    expect(slots).toHaveLength(INITIAL_MONTHLY_SLOT_BUDGET);
     expect(slots.filter(s => s.occupied).length).toBe(0);
     slots.forEach(s => expect(s.occupied).toBe(false));
   });
@@ -61,6 +61,21 @@ describe('dashboard slot derivation from status response', () => {
     const slots = deriveSlots(positions);
     expect(slots.filter(s => s.occupied).length).toBe(1);
     expect(slots.filter(s => s.occupied && s.positionId === 'p1')).toHaveLength(1);
+  });
+
+  it('production Active string position occupies one slot', () => {
+    const positions = [
+      makePosition({
+        id: '019db3dc-c107-7872-bdcb-c3e6602ebbe0',
+        state: 'Active',
+        entry_price: 77932.4,
+        trailing_stop: 76158.25,
+        pnl: 0
+      })
+    ];
+    const slots = deriveSlots(positions);
+    expect(slots).toHaveLength(INITIAL_MONTHLY_SLOT_BUDGET);
+    expect(slots.filter(s => s.occupied)).toHaveLength(1);
   });
 
   it('Armed position counts as occupied', () => {
@@ -115,13 +130,12 @@ describe('dashboard slot derivation from status response', () => {
     expect(deriveSlots(positions).filter(s => s.occupied).length).toBe(3); // Armed + Active + Entering
   });
 
-  it('caps at SLOT_COUNT even with 8+ active positions', () => {
+  it('does not cap displayed active positions at the initial monthly budget', () => {
     const positions = Array.from({ length: 8 }, (_, i) =>
       makePosition({ id: `p${i}`, state: 'Armed' })
     );
     const slots = deriveSlots(positions);
-    expect(slots).toHaveLength(SLOT_COUNT);
-    // All 6 slots occupied
+    expect(slots).toHaveLength(8);
     expect(slots.every(s => s.occupied)).toBe(true);
   });
 });
@@ -230,6 +244,7 @@ describe('event stream rendering logic', () => {
 describe('isPositionActive for dashboard operations panel', () => {
   it('only Armed, Entering, Active are active', () => {
     expect(isPositionActive('Armed')).toBe(true);
+    expect(isPositionActive('Active')).toBe(true);
     expect(isPositionActive({ Entering: { entry_order_id: 'x', expected_entry: 1, signal_id: 'x' } })).toBe(true);
     expect(isPositionActive({ Active: { current_price: 1, trailing_stop: 1, favorable_extreme: 1, extreme_at: '', insurance_stop_id: null, last_emitted_stop: null } })).toBe(true);
     expect(isPositionActive({ Exiting: { exit_order_id: 'x', exit_reason: 'x' } })).toBe(false);

--- a/apps/frontend/tests/unit/labels.test.ts
+++ b/apps/frontend/tests/unit/labels.test.ts
@@ -175,6 +175,7 @@ describe('eventTypeLabel', () => {
 
 describe('isPositionActive', () => {
   it('Armed is active', () => expect(isPositionActive('Armed')).toBe(true));
+  it('Active string state is active', () => expect(isPositionActive('Active')).toBe(true));
   it('Entering is active', () =>
     expect(
       isPositionActive({

--- a/apps/frontend/tests/unit/slots.test.ts
+++ b/apps/frontend/tests/unit/slots.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveSlots, occupiedCount, SLOT_COUNT } from '$lib/config/slots';
+import { deriveSlots, occupiedCount, INITIAL_MONTHLY_SLOT_BUDGET } from '$lib/config/slots';
 import type { PositionState } from '$api/robson';
 
 const activeState: PositionState = {
@@ -14,9 +14,9 @@ const activeState: PositionState = {
 };
 
 describe('deriveSlots', () => {
-  it('returns 6 empty slots when no positions', () => {
+  it('returns 4 empty slots when no positions', () => {
     const result = deriveSlots([]);
-    expect(result).toHaveLength(SLOT_COUNT);
+    expect(result).toHaveLength(INITIAL_MONTHLY_SLOT_BUDGET);
     expect(result.every((s) => !s.occupied)).toBe(true);
   });
 
@@ -41,13 +41,13 @@ describe('deriveSlots', () => {
     expect(result.every((s) => !s.occupied)).toBe(true);
   });
 
-  it('caps at SLOT_COUNT even with more than 6 active positions', () => {
+  it('expands beyond the initial monthly budget when more positions are active', () => {
     const positions = Array.from({ length: 8 }, (_, i) => ({
       id: `p-${i}`,
       state: activeState
     }));
     const result = deriveSlots(positions);
-    expect(result).toHaveLength(SLOT_COUNT);
+    expect(result).toHaveLength(8);
     expect(result.every((s) => s.occupied)).toBe(true);
   });
 });
@@ -64,7 +64,7 @@ describe('occupiedCount', () => {
     expect(occupiedCount(positions)).toBe(3);
   });
 
-  it('returns count > SLOT_COUNT when more than 6 active', () => {
+  it('returns count > initial monthly budget when more than 4 active', () => {
     const positions = Array.from({ length: 8 }, () => ({ state: activeState }));
     expect(occupiedCount(positions)).toBe(8);
   });


### PR DESCRIPTION
## Summary

Fixes dashboard rendering against the current production `/status` shape.

The frontend was still typed around an older rich `PositionState` object contract. Production can return compact positions such as `state: "Active"`, decimal strings for prices, and `pnl`, so the dashboard filtered the active position out and showed no operation.

This PR:

- normalizes status/position payloads in the frontend API client
- treats string states like `Active` and `Entering` as active where appropriate
- uses `pnl` when present, falling back to `realized_pnl`
- removes the stale 6-slot assumption
- represents ADR-0024 policy as an initial monthly slot budget of 4 while allowing the displayed slot grid to expand when more active positions exist, avoiding a false hard cap
- updates dashboard, kill-switch, unit, and e2e tests

## Policy note

Per ADR-0024, 4 is not a maximum open-position count. It is the initial monthly budget implied by 4% monthly drawdown / 1% risk per trade. Dynamic availability depends on realized loss and latent risk. Because `/status` does not expose `remaining_budget`, `risk_per_trade_amount`, `latent_risk`, or `slots_available`, the frontend cannot compute exact dynamic availability yet; it only renders active positions truthfully and avoids the legacy hard-coded 6.

## Validation

- `pnpm check` (0 errors, existing Svelte warnings in design components)
- `pnpm test` (74 tests passed)
- `PUBLIC_ROBSON_API_BASE=https://api.robson.rbx.ia.br pnpm build`
- `pnpm exec playwright test tests/e2e/dashboard.spec.ts tests/e2e/kill-switch.spec.ts --reporter=line` (13 passed)
- Headless local preview with production-like `/status` payload: 4 displayed baseline slots, 1 occupied, 1 active operation, `BTCUSDT`, `Active`, `0.00%` rendered