### PR TITLE
ci(frontend): automate GitOps image tag updates

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -58,3 +58,58 @@ jobs:
 
       - name: Image digest
         run: echo "Image digest ${{ steps.meta.outputs.digest }}"
+
+      - name: Compute SHA tag
+        id: tag
+        run: echo "sha_tag=sha-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
+      - name: Update frontend image tag in rbx-infra
+        env:
+          GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+          SHA_TAG: ${{ steps.tag.outputs.sha_tag }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          git clone https://x-access-token:${GITOPS_TOKEN}@github.com/rbxrobotica/rbx-infra.git /tmp/rbx-infra
+          cd /tmp/rbx-infra
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          sed -i "s|image: ghcr.io/ldamasio/robson-frontend-v2:sha-[a-f0-9]*|image: ghcr.io/ldamasio/robson-frontend-v2:${SHA_TAG}|g" \
+            apps/prod/robson/robson-frontend-v2-deploy.yml
+
+          git add apps/prod/robson/robson-frontend-v2-deploy.yml
+
+          if git diff --staged --quiet; then
+            echo "No manifest changes needed (already at ${SHA_TAG})"
+            exit 0
+          fi
+
+          git commit -m "chore(robson-frontend-v2): update image tag to ${SHA_TAG}" \
+            -m "Automated update by Robson frontend CI/CD pipeline." \
+            -m "Triggered by: ${REPO}@${SHA}" \
+            -m "[skip ci]"
+
+          for i in 1 2 3; do
+            if git push origin main; then
+              echo "Manifests pushed - ArgoCD will auto-sync"
+              exit 0
+            fi
+            echo "Push attempt $i failed, rebasing..."
+            git pull --rebase origin main
+          done
+
+          echo "::error::Failed to push to rbx-infra after 3 attempts"
+          exit 1
+
+      - name: Summary
+        run: |
+          echo "## Robson frontend published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| | |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Image | \`ghcr.io/${{ github.repository_owner }}/robson-frontend-v2:${{ steps.tag.outputs.sha_tag }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Commit | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "ArgoCD will auto-sync when rbx-infra manifest is updated." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Makes the frontend deploy workflow update `rbx-infra` automatically after publishing `ghcr.io/ldamasio/robson-frontend-v2`.

The workflow now mirrors the existing robsond CI/CD behavior:

- compute `sha-<7>` from the merge commit
- clone `rbxrobotica/rbx-infra` using `secrets.GITOPS_TOKEN`
- update `apps/prod/robson/robson-frontend-v2-deploy.yml`
- commit with `[skip ci]`
- retry push with rebase up to 3 times
- leave ArgoCD to auto-sync the updated manifest

## Validation

- Existing production gap was fixed manually first: `rbx-infra` now points frontend to `sha-a8b5f39`
- ArgoCD `robson-prod` is `Synced Healthy`
- Production authenticated dashboard validates as 4 displayed baseline slots, 1 occupied, 1 active operation

## Note

This PR only automates future frontend image tag bumps. It does not change frontend runtime code beyond PR #49.