### PR TITLE
feat(frontend): Entry button + ArmModal + pending approvals

### DIFF
--- a/apps/frontend/src/lib/api/robson.ts
+++ b/apps/frontend/src/lib/api/robson.ts
@@ -244,8 +244,11 @@ export const robsonApi = {
 
   getPosition: async (id: string) => normalizePosition(await apiFetch<Position>(`/positions/${id}`)),
 
-  armPosition: (body: { symbol: string; side: string }) =>
+  armPosition: (body: { symbol: string; side: string; capital: number }) =>
     apiFetch<Position>('/positions', { method: 'POST', body: JSON.stringify(body) }),
+
+  injectSignal: (id: string, body: { entry_price: number; stop_loss: number }) =>
+    apiFetch<void>(`/positions/${id}/signal`, { method: 'POST', body: JSON.stringify(body) }),
 
   closePosition: (id: string) =>
     apiFetch<void>(`/positions/${id}`, { method: 'DELETE' }),

--- a/apps/frontend/src/lib/design/components/ArmModal.svelte
+++ b/apps/frontend/src/lib/design/components/ArmModal.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+  import { robsonApi } from '$api/robson';
+
+  let { onclose }: { onclose: () => void } = $props();
+
+  let symbol = $state('BTCUSDT');
+  let side = $state<'Long' | 'Short'>('Long');
+  let capital = $state<number | ''>('');
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+
+  function enforceUppercase(e: Event) {
+    const input = e.target as HTMLInputElement;
+    symbol = input.value.toUpperCase();
+  }
+
+  function toggleSide() {
+    side = side === 'Long' ? 'Short' : 'Long';
+  }
+
+  async function submit() {
+    error = null;
+    const capitalNum = Number(capital);
+    if (!symbol.trim()) { error = 'SYMBOL REQUIRED'; return; }
+    if (!capitalNum || capitalNum < 100) { error = 'MINIMUM CAPITAL IS 100 USDT'; return; }
+
+    submitting = true;
+    try {
+      await robsonApi.armPosition({ symbol: symbol.trim(), side, capital: capitalNum });
+      onclose();
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'ARM FAILED';
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<svelte:window onkeydown={(e) => { if (e.key === 'Escape') onclose(); }} />
+
+<div class="overlay" role="dialog" aria-modal="true">
+  <div class="modal">
+    <div class="modal-header">
+      <span class="eyebrow">ARM POSITION</span>
+      <button class="btn-close" onclick={onclose} aria-label="Close">ESC</button>
+    </div>
+
+    <div class="fields">
+      <label class="field">
+        <span class="label">SYMBOL</span>
+        <input
+          type="text"
+          class="input"
+          bind:value={symbol}
+          oninput={enforceUppercase}
+          placeholder="BTCUSDT"
+        />
+      </label>
+
+      <div class="field">
+        <span class="label">SIDE</span>
+        <div class="toggle">
+          <button
+            class="toggle-btn"
+            class:active={side === 'Long'}
+            onclick={() => (side = 'Long')}
+          >LONG</button>
+          <button
+            class="toggle-btn"
+            class:active={side === 'Short'}
+            onclick={() => (side = 'Short')}
+          >SHORT</button>
+        </div>
+      </div>
+
+      <label class="field">
+        <span class="label">CAPITAL (USDT)</span>
+        <input
+          type="number"
+          class="input"
+          bind:value={capital}
+          min="100"
+          step="1"
+          placeholder="100"
+        />
+      </label>
+    </div>
+
+    {#if error}
+      <p class="err-text">{error}</p>
+    {/if}
+
+    <button class="btn-submit" onclick={submit} disabled={submitting}>
+      {submitting ? 'ARMING...' : 'ARM'}
+    </button>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: grid;
+    place-items: center;
+    z-index: 100;
+  }
+  .modal {
+    background: var(--bg-0);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--s-6);
+    min-width: 340px;
+    max-width: 420px;
+    box-shadow: var(--shadow-overlay);
+  }
+  .modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--s-5);
+  }
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--track-label);
+    color: var(--fg-2);
+    font-weight: 500;
+  }
+  .btn-close {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--track-label);
+    color: var(--fg-3);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+  }
+  .btn-close:hover {
+    color: var(--fg-1);
+  }
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s-4);
+    margin-bottom: var(--s-4);
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s-1);
+  }
+  .label {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--track-label);
+    color: var(--fg-2);
+    font-weight: 500;
+  }
+  .input {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    letter-spacing: var(--track-wide);
+    color: var(--fg-0);
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--s-2) var(--s-3);
+    outline: none;
+    text-transform: uppercase;
+  }
+  .input:focus {
+    border-color: var(--border-accent);
+  }
+  .input::placeholder {
+    color: var(--fg-3);
+  }
+  .toggle {
+    display: flex;
+    gap: var(--s-1);
+  }
+  .toggle-btn {
+    flex: 1;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    text-transform: uppercase;
+    letter-spacing: var(--track-label);
+    color: var(--fg-2);
+    background: var(--bg-1);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--s-2) var(--s-3);
+    cursor: pointer;
+    transition: color var(--dur) var(--ease), border-color var(--dur) var(--ease), background var(--dur) var(--ease);
+  }
+  .toggle-btn:hover {
+    border-color: var(--border-strong);
+  }
+  .toggle-btn.active {
+    color: var(--cyan-brand);
+    border-color: var(--cyan-dim);
+    background: var(--cyan-subtle);
+  }
+  .err-text {
+    color: var(--err);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--track-wide);
+    margin-bottom: var(--s-3);
+  }
+  .btn-submit {
+    width: 100%;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    text-transform: uppercase;
+    letter-spacing: var(--track-label);
+    color: var(--cyan-brand);
+    background: transparent;
+    border: 1px solid var(--cyan-dim);
+    border-radius: var(--radius-sm);
+    padding: var(--s-2) var(--s-4);
+    cursor: pointer;
+    transition: background var(--dur) var(--ease);
+  }
+  .btn-submit:hover:not(:disabled) {
+    background: var(--cyan-subtle);
+  }
+  .btn-submit:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/apps/frontend/src/routes/(authed)/dashboard/+page.svelte
+++ b/apps/frontend/src/routes/(authed)/dashboard/+page.svelte
@@ -5,7 +5,8 @@
   import Row from '$design/components/Row.svelte';
   import Grid from '$design/components/Grid.svelte';
   import TickRuler from '$design/components/TickRuler.svelte';
-  import { robsonApi, connectEventStream, type Position, type SseEvent } from '$api/robson';
+  import ArmModal from '$design/components/ArmModal.svelte';
+  import { robsonApi, connectEventStream, type Position, type SseEvent, type PendingApproval } from '$api/robson';
   import { activePositions } from '$stores/operations';
   import { haltStatus } from '$stores/slots';
   import { recentEvents, pushEvent } from '$stores/events';
@@ -26,6 +27,10 @@
   let connected = $state(false);
   let closeSse: (() => void) | null = null;
   let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let showArmModal = $state(false);
+  let pendingApprovals = $state<PendingApproval[]>([]);
+  let approvalTick = $state(Date.now());
+  let approvalTickTimer: ReturnType<typeof setInterval> | null = null;
 
   let positions = $derived($activePositions);
   let slots = $derived(deriveSlots(positions));
@@ -35,6 +40,15 @@
   let activeOps = $derived(positions.filter((p) => isPositionActive(p.state)));
   let todayEvents = $derived($recentEvents.filter((e) => isTodayUtc(e.occurred_at)));
   let haltState = $derived($haltStatus?.state ?? 'active');
+
+  function countdownRemaining(expiresAt: string): string {
+    const ms = new Date(expiresAt).getTime() - approvalTick;
+    if (ms <= 0) return 'expired';
+    const totalSec = Math.floor(ms / 1000);
+    const m = Math.floor(totalSec / 60);
+    const s = totalSec % 60;
+    return `${m}m ${s}s`;
+  }
 
   function pnlFor(p: Position): number | null {
     if (typeof p.state === 'object' && 'Closed' in p.state) {
@@ -58,6 +72,7 @@
       ]);
       activePositions.set(status.positions);
       haltStatus.set(halt);
+      pendingApprovals = status.pending_approvals;
       connected = true;
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to connect to Robson backend';
@@ -100,6 +115,7 @@
           ]);
           activePositions.set(status.positions);
           haltStatus.set(halt);
+          pendingApprovals = status.pending_approvals;
           connected = true;
           error = null;
         } catch {
@@ -127,12 +143,23 @@
       void load();
       startSse();
       startPolling();
+      approvalTickTimer = setInterval(() => { approvalTick = Date.now(); }, 1000);
     });
     return () => {
       stopSse();
       stopPolling();
+      if (approvalTickTimer) { clearInterval(approvalTickTimer); approvalTickTimer = null; }
     };
   });
+
+  async function approve(queryId: string) {
+    try {
+      await robsonApi.approveQuery(queryId);
+      void load();
+    } catch {
+      // error handled by next poll refresh
+    }
+  }
 </script>
 
 <svelte:head>
@@ -146,16 +173,23 @@
         <img src="/brand/rbx-mark.svg" alt="RBX" width="32" height="32" />
         <img src="/brand/wordmark-robson.svg" alt="RBX Robson" height="22" />
       </Row>
-      <div class="status-strip">
-        {#if error}
-          <span class="dot err"></span> {$_('dashboard.offline')} · {error}
-        {:else if !connected}
-          <span class="dot warn"></span> {$_('dashboard.connecting')}
+      <Row gap={4} align="center">
+        <div class="status-strip">
+          {#if error}
+            <span class="dot err"></span> {$_('dashboard.offline')} · {error}
+          {:else if !connected}
+            <span class="dot warn"></span> {$_('dashboard.connecting')}
+          {:else}
+            <span class="dot live"></span>
+            {haltStateLabel(haltState)} · SLOT {occupied}/{displayedSlots}
+          {/if}
+        </div>
+        {#if haltState === 'monthly_halt'}
+          <button class="btn-entry" disabled>HALT</button>
         {:else}
-          <span class="dot live"></span>
-          {haltStateLabel(haltState)} · SLOT {occupied}/{displayedSlots}
+          <button class="btn-entry" onclick={() => (showArmModal = true)}>ENTRY</button>
         {/if}
-      </div>
+      </Row>
     </Row>
   </header>
 
@@ -185,6 +219,26 @@
         <div class="eyebrow dim">{$_('dashboard.occupied', { values: { count: occupied } })} · {$_('dashboard.freeCount', { values: { count: free } })}</div>
       </Stack>
     </section>
+
+    {#if pendingApprovals.length > 0}
+      <section>
+        <Stack gap={4}>
+          <div class="eyebrow">PENDING APPROVALS · {pendingApprovals.length}</div>
+          {#each pendingApprovals as approval (approval.query_id)}
+            <Card>
+              <Row justify="between" align="center">
+                <Stack gap={1}>
+                  <span class="mono">{approval.position_id ? approval.position_id.slice(0, 8) : '--------'}</span>
+                  <span class="meta">{approval.reason}</span>
+                  <span class="meta dim">expires in {countdownRemaining(approval.expires_at)}</span>
+                </Stack>
+                <button class="btn-approve" onclick={() => approve(approval.query_id)}>APPROVE</button>
+              </Row>
+            </Card>
+          {/each}
+        </Stack>
+      </section>
+    {/if}
 
     <section>
       <Stack gap={4}>
@@ -242,6 +296,10 @@
         </Card>
       </Stack>
     </section>
+  {/if}
+
+  {#if showArmModal}
+    <ArmModal onclose={() => { showArmModal = false; void load(); }} />
   {/if}
 </div>
 
@@ -390,5 +448,47 @@
   }
   .btn-retry:hover {
     background: var(--cyan-subtle);
+  }
+  .btn-entry {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--track-label);
+    color: var(--cyan-brand);
+    background: transparent;
+    border: 1px solid var(--cyan-dim);
+    border-radius: var(--radius-sm);
+    padding: var(--s-1) var(--s-3);
+    cursor: pointer;
+    transition: background var(--dur) var(--ease);
+  }
+  .btn-entry:hover:not(:disabled) {
+    background: var(--cyan-subtle);
+  }
+  .btn-entry:disabled {
+    color: var(--err);
+    border-color: var(--err);
+    cursor: not-allowed;
+    opacity: 0.8;
+  }
+  .btn-approve {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--track-label);
+    color: var(--cyan-brand);
+    background: transparent;
+    border: 1px solid var(--cyan-dim);
+    border-radius: var(--radius-sm);
+    padding: var(--s-1) var(--s-3);
+    cursor: pointer;
+    transition: background var(--dur) var(--ease);
+    white-space: nowrap;
+  }
+  .btn-approve:hover {
+    background: var(--cyan-subtle);
+  }
+  .meta.dim {
+    color: var(--fg-3);
   }
 </style>


### PR DESCRIPTION
## Summary
- Fix `armPosition` to include `capital: number` in the API call; add `injectSignal` method for manual signal injection
- New `ArmModal.svelte` component — symbol (uppercase-enforced), LONG/SHORT toggle, capital input (min 100 USDT), inline error, spinner
- Dashboard: ENTRY button in header (HALT when monthly_halt), PENDING APPROVALS section with live countdown + APPROVE action

## Test plan
- [ ] Verify `bun run check` passes (0 errors)
- [ ] Click ENTRY button → modal opens, submits `POST /positions` with `{ symbol, side, capital }`
- [ ] ENTRY shows HALT (disabled) when halt state is `monthly_halt`
- [ ] Pending approvals appear when `GET /status` returns non-empty `pending_approvals[]`
- [ ] Countdown ticks every second; APPROVE calls `POST /queries/:id/approve` and refreshes
- [ ] Existing dashboard sections (slots, operations, events) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)