### PR TITLE
feat(frontend): Entry button + ArmModal + pending approvals

### DIFF
--- a/apps/frontend/src/lib/api/robson.ts
+++ b/apps/frontend/src/lib/api/robson.ts
@@ -244,7 +244,7 @@ export const robsonApi = {
 
   getPosition: async (id: string) => normalizePosition(await apiFetch<Position>(`/positions/${id}`)),
 
-  armPosition: (body: { symbol: string; side: string; capital: number }) =>
+  armPosition: (body: { symbol: string; side: string }) =>
     apiFetch<Position>('/positions', { method: 'POST', body: JSON.stringify(body) }),
 
   injectSignal: (id: string, body: { entry_price: number; stop_loss: number }) =>

--- a/apps/frontend/src/lib/design/components/ArmModal.svelte
+++ b/apps/frontend/src/lib/design/components/ArmModal.svelte
@@ -5,7 +5,6 @@
 
   let symbol = $state('BTCUSDT');
   let side = $state<'Long' | 'Short'>('Long');
-  let capital = $state<number | ''>('');
   let submitting = $state(false);
   let error = $state<string | null>(null);
 
@@ -14,19 +13,13 @@
     symbol = input.value.toUpperCase();
   }
 
-  function toggleSide() {
-    side = side === 'Long' ? 'Short' : 'Long';
-  }
-
   async function submit() {
     error = null;
-    const capitalNum = Number(capital);
     if (!symbol.trim()) { error = 'SYMBOL REQUIRED'; return; }
-    if (!capitalNum || capitalNum < 100) { error = 'MINIMUM CAPITAL IS 100 USDT'; return; }
 
     submitting = true;
     try {
-      await robsonApi.armPosition({ symbol: symbol.trim(), side, capital: capitalNum });
+      await robsonApi.armPosition({ symbol: symbol.trim(), side });
       onclose();
     } catch (e) {
       error = e instanceof Error ? e.message : 'ARM FAILED';
@@ -72,18 +65,6 @@
           >SHORT</button>
         </div>
       </div>
-
-      <label class="field">
-        <span class="label">CAPITAL (USDT)</span>
-        <input
-          type="number"
-          class="input"
-          bind:value={capital}
-          min="100"
-          step="1"
-          placeholder="100"
-        />
-      </label>
     </div>
 
     {#if error}


### PR DESCRIPTION
## Summary
- Add `injectSignal` API method for manual signal injection (`POST /positions/:id/signal`)
- New `ArmModal.svelte` — symbol (uppercase-enforced) + LONG/SHORT toggle; position sizing left to backend policy
- Dashboard: ENTRY button in header (HALT when `monthly_halt`), PENDING APPROVALS section with live countdown + APPROVE action

## Test plan
- [ ] Verify `bun run check` passes (0 errors)
- [ ] Click ENTRY → modal opens, submits `POST /positions` with `{ symbol, side }` only (no capital)
- [ ] ENTRY shows HALT (disabled) when halt state is `monthly_halt`
- [ ] Pending approvals render when `GET /status` returns non-empty `pending_approvals[]`
- [ ] Countdown ticks every second; APPROVE calls `POST /queries/:id/approve` and refreshes
- [ ] Existing dashboard sections (slots, operations, events) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)