### PR TITLE
fix(daemon): derive capital from engine/DB, not request payload

### DIFF
--- a/v3/robson-domain/src/value_objects.rs
+++ b/v3/robson-domain/src/value_objects.rs
@@ -337,12 +337,6 @@ impl RiskConfig {
     }
 }
 
-impl Default for RiskConfig {
-    fn default() -> Self {
-        Self { capital: Decimal::from(10000) }
-    }
-}
-
 impl fmt::Display for RiskConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -663,14 +657,14 @@ mod tests {
 
     #[test]
     fn test_risk_config_leverage() {
-        let config = RiskConfig::default();
+        let config = RiskConfig::new(dec!(10000)).unwrap();
         assert_eq!(config.leverage(), 10);
         assert_eq!(RiskConfig::LEVERAGE, 10);
     }
 
     #[test]
-    fn test_risk_config_default() {
-        let config = RiskConfig::default();
+    fn test_risk_config_capital() {
+        let config = RiskConfig::new(dec!(10000)).unwrap();
         assert_eq!(config.capital(), dec!(10000));
         assert_eq!(config.risk_per_trade_pct(), dec!(1));
     }

--- a/v3/robson-store/src/memory.rs
+++ b/v3/robson-store/src/memory.rs
@@ -477,6 +477,15 @@ impl PositionRepository for MemoryStore {
             .cloned()
             .collect())
     }
+
+    async fn find_all_closed(&self) -> Result<Vec<Position>, StoreError> {
+        let positions = self.positions.read().unwrap();
+        Ok(positions
+            .values()
+            .filter(|p| matches!(p.state, robson_domain::PositionState::Closed { .. }))
+            .cloned()
+            .collect())
+    }
 }
 
 // =============================================================================

--- a/v3/robson-store/src/repository.rs
+++ b/v3/robson-store/src/repository.rs
@@ -81,6 +81,12 @@ pub trait PositionRepository: Send + Sync {
         year: i32,
         month: u32,
     ) -> Result<Vec<Position>, StoreError>;
+
+    /// Find all closed positions (all-time).
+    ///
+    /// Returns every position in `Closed` state, regardless of when it closed.
+    /// Used to compute cumulative realized PnL for equity calculation.
+    async fn find_all_closed(&self) -> Result<Vec<Position>, StoreError>;
 }
 
 /// Repository for Order entities

--- a/v3/robsond/src/api.rs
+++ b/v3/robsond/src/api.rs
@@ -130,7 +130,6 @@ pub struct PendingApprovalSummary {
 pub struct ArmRequest {
     pub symbol: String,
     pub side: String,
-    pub capital: Decimal,
     #[serde(default = "default_account_id")]
     pub account_id: Uuid,
 }
@@ -636,12 +635,40 @@ where
         },
     };
 
-    // Create risk config (v3 policy: risk is fixed at 1%, not from request)
-    let risk_config = RiskConfig::new(req.capital).map_err(|e| {
+    // Capital base for position sizing.
+    //
+    // Source: `monthly_state` table, populated by `MonthBoundaryReset` event.
+    // Falls back to engine startup value when DB is unavailable.
+    //
+    // Policy (ADR-0024 §6, v3-risk-engine-spec §Month Boundary Rule):
+    //   capital_base = current_equity − latent_risk_carried
+    //
+    // The capital base is pessimistic: it assumes every inherited open position
+    // will hit its current stop. Inherited risk is absorbed into the base
+    // rather than carried as debt against the new month's budget. If a carried
+    // position's trailing stop advances (winning trade), the freed risk
+    // increments the capital base of the following month — never the current
+    // one. This guarantees every month starts with 4 available slots.
+    //
+    // The caller never supplies capital. Position sizing is derived:
+    //   position_size = (capital_base × 1%) / technical_stop_distance
+    let capital = {
+        let manager = state.position_manager.read().await;
+        manager.load_capital_base_for_month(chrono::Utc::now()).await
+    };
+    let capital = capital.map_err(|e| {
         (
-            StatusCode::BAD_REQUEST,
+            StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
-                error: format!("Invalid risk config: {}", e),
+                error: format!("Failed to load capital base: {}", e),
+            }),
+        )
+    })?;
+    let risk_config = RiskConfig::new(capital).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("Capital base invalid: {}", e),
             }),
         )
     })?;

--- a/v3/robsond/src/config.rs
+++ b/v3/robsond/src/config.rs
@@ -75,6 +75,15 @@ pub struct ProjectionConfig {
 /// See `RiskConfig::RISK_PER_TRADE_PCT` in robson-domain.
 #[derive(Debug, Clone)]
 pub struct EngineConfig {
+    /// Operator's declared starting capital in quote currency (e.g., USDT).
+    ///
+    /// Source: `ROBSON_CAPITAL_BASE` env var. Required for the first month of
+    /// operation. After the first `MonthBoundaryReset`, the persisted
+    /// `monthly_state.capital_base` takes precedence (see ADR-0024 §6).
+    ///
+    /// This value is the initial equity the operator brings to the account.
+    /// Position sizing is derived: `position_size = (capital_base × 1%) / stop_distance`.
+    pub capital_base: Decimal,
     /// Minimum tech stop distance (0.001 = 0.1%)
     pub min_tech_stop_percent: Decimal,
     /// Maximum tech stop distance (0.10 = 10%)
@@ -209,6 +218,7 @@ impl Config {
                 api_token: None,
             },
             engine: EngineConfig {
+                capital_base: Decimal::from(10000),
                 min_tech_stop_percent: Decimal::new(1, 3),  // 0.1%
                 max_tech_stop_percent: Decimal::new(10, 2), // 10%
             },
@@ -276,7 +286,19 @@ impl Config {
             Decimal::new(10, 2), // 10%
         )?;
 
+        let capital_base = Self::load_decimal_env(
+            "ROBSON_CAPITAL_BASE",
+            Decimal::new(10, 3), // 0.01 — deliberately tiny default to force operator configuration
+        )?;
+
+        if capital_base <= Decimal::ZERO {
+            return Err(DaemonError::Config(
+                "ROBSON_CAPITAL_BASE must be positive".to_string(),
+            ));
+        }
+
         Ok(EngineConfig {
+            capital_base,
             min_tech_stop_percent: min_tech_stop,
             max_tech_stop_percent: max_tech_stop,
         })
@@ -463,6 +485,7 @@ impl Default for Config {
                 api_token: None,
             },
             engine: EngineConfig {
+                capital_base: Decimal::from(10000),
                 min_tech_stop_percent: Decimal::new(1, 3),  // 0.1%
                 max_tech_stop_percent: Decimal::new(10, 2), // 10%
             },

--- a/v3/robsond/src/config.rs
+++ b/v3/robsond/src/config.rs
@@ -219,7 +219,7 @@ impl Config {
             },
             engine: EngineConfig {
                 capital_base: Decimal::from(10000),
-                min_tech_stop_percent: Decimal::new(1, 3),  // 0.1%
+                min_tech_stop_percent: Decimal::new(1, 3), // 0.1%
                 max_tech_stop_percent: Decimal::new(10, 2), // 10%
             },
             tech_stop: TechStopConfigEnv {
@@ -292,9 +292,7 @@ impl Config {
         )?;
 
         if capital_base <= Decimal::ZERO {
-            return Err(DaemonError::Config(
-                "ROBSON_CAPITAL_BASE must be positive".to_string(),
-            ));
+            return Err(DaemonError::Config("ROBSON_CAPITAL_BASE must be positive".to_string()));
         }
 
         Ok(EngineConfig {
@@ -486,7 +484,7 @@ impl Default for Config {
             },
             engine: EngineConfig {
                 capital_base: Decimal::from(10000),
-                min_tech_stop_percent: Decimal::new(1, 3),  // 0.1%
+                min_tech_stop_percent: Decimal::new(1, 3), // 0.1%
                 max_tech_stop_percent: Decimal::new(10, 2), // 10%
             },
             tech_stop: TechStopConfigEnv {

--- a/v3/robsond/src/config.rs
+++ b/v3/robsond/src/config.rs
@@ -82,7 +82,8 @@ pub struct EngineConfig {
     /// `monthly_state.capital_base` takes precedence (see ADR-0024 §6).
     ///
     /// This value is the initial equity the operator brings to the account.
-    /// Position sizing is derived: `position_size = (capital_base × 1%) / stop_distance`.
+    /// Position sizing is derived:
+    /// `position_size = (capital_base × 1%) / stop_distance`.
     pub capital_base: Decimal,
     /// Minimum tech stop distance (0.001 = 0.1%)
     pub min_tech_stop_percent: Decimal,

--- a/v3/robsond/src/config.rs
+++ b/v3/robsond/src/config.rs
@@ -288,7 +288,7 @@ impl Config {
 
         let capital_base = Self::load_decimal_env(
             "ROBSON_CAPITAL_BASE",
-            Decimal::new(10, 3), // 0.01 — deliberately tiny default to force operator configuration
+            Decimal::new(10, 3), // 0.01; operator must configure
         )?;
 
         if capital_base <= Decimal::ZERO {

--- a/v3/robsond/src/daemon.rs
+++ b/v3/robsond/src/daemon.rs
@@ -144,6 +144,10 @@ impl<S: Store + 'static> PositionRepository for StorePositionRepositoryAdapter<S
     ) -> Result<Vec<Position>, StoreError> {
         self.store.positions().find_closed_in_month(year, month).await
     }
+
+    async fn find_all_closed(&self) -> Result<Vec<Position>, StoreError> {
+        self.store.positions().find_all_closed().await
+    }
 }
 
 impl Daemon<StubExchange, MemoryStore> {
@@ -157,7 +161,7 @@ impl Daemon<StubExchange, MemoryStore> {
         let executor = Arc::new(Executor::new(Arc::clone(&exchange), journal, store.clone()));
         let event_bus = Arc::new(EventBus::new(1000));
         let query_recorder = default_query_recorder();
-        let risk_config = RiskConfig::new(dec!(10000)).unwrap();
+        let risk_config = RiskConfig::new(config.engine.capital_base).unwrap();
         let engine = Engine::new(risk_config);
         let trading_policy = TradingPolicy::default();
 
@@ -209,7 +213,7 @@ impl Daemon<StubExchange, MemoryStore> {
             } else {
                 default_query_recorder()
             };
-        let risk_config = RiskConfig::new(dec!(10000)).unwrap();
+        let risk_config = RiskConfig::new(config.engine.capital_base).unwrap();
         let engine = Engine::new(risk_config);
         let trading_policy = TradingPolicy::default();
 
@@ -252,7 +256,7 @@ impl Daemon<BinanceExchangeAdapter, MemoryStore> {
         let executor = Arc::new(Executor::new(Arc::clone(&exchange), journal, store.clone()));
         let event_bus = Arc::new(EventBus::new(1000));
         let query_recorder = default_query_recorder();
-        let risk_config = RiskConfig::new(dec!(10000)).unwrap();
+        let risk_config = RiskConfig::new(config.engine.capital_base).unwrap();
         let engine = Engine::new(risk_config);
         let trading_policy = TradingPolicy::default();
 
@@ -311,7 +315,7 @@ impl Daemon<BinanceExchangeAdapter, MemoryStore> {
             } else {
                 default_query_recorder()
             };
-        let risk_config = RiskConfig::new(dec!(10000)).unwrap();
+        let risk_config = RiskConfig::new(config.engine.capital_base).unwrap();
         let engine = Engine::new(risk_config);
         let trading_policy = TradingPolicy::default();
 
@@ -606,9 +610,16 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
 
         let open_positions = self.store.positions().find_risk_open().await?;
         let carried_risk = Self::calculate_carried_risk(&open_positions);
+
+        // current_equity per ADR-0024 §6:
+        //   current_equity = initial_capital + all_time_realized_pnl + unrealized_pnl
+        //
+        // The capital_base is pessimistic: it subtracts carried_risk (worst case
+        // loss from inherited positions) from current_equity. This guarantees
+        // every month starts with 4 available slots.
         let current_equity = {
             let manager = self.position_manager.read().await;
-            manager.configured_capital()
+            manager.compute_current_equity().await?
         };
         let capital_base = (current_equity - carried_risk).max(rust_decimal::Decimal::ZERO);
 

--- a/v3/robsond/src/position_manager.rs
+++ b/v3/robsond/src/position_manager.rs
@@ -886,8 +886,12 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
 
         {
             let mut pending_approvals = self.pending_approvals.write().await;
-            pending_approvals
-                .insert(query_id, PendingApprovalRecord { query, position, proposed, governed });
+            pending_approvals.insert(query_id, PendingApprovalRecord {
+                query,
+                position,
+                proposed,
+                governed,
+            });
         }
 
         let pending_approvals = self.pending_approvals.read().await;
@@ -3716,13 +3720,10 @@ mod tests {
         // newly armed one.
         let updated = manager.get_position(position.id).await.unwrap().unwrap();
         assert!(
-            matches!(
-                updated.state,
-                PositionState::Closed {
-                    exit_reason: robson_domain::ExitReason::DisarmedByUser,
-                    ..
-                }
-            ),
+            matches!(updated.state, PositionState::Closed {
+                exit_reason: robson_domain::ExitReason::DisarmedByUser,
+                ..
+            }),
             "Expected Closed after MonthlyHalt (Entering positions exhausted slots), got {:?}",
             updated.state
         );

--- a/v3/robsond/src/position_manager.rs
+++ b/v3/robsond/src/position_manager.rs
@@ -886,12 +886,8 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
 
         {
             let mut pending_approvals = self.pending_approvals.write().await;
-            pending_approvals.insert(query_id, PendingApprovalRecord {
-                query,
-                position,
-                proposed,
-                governed,
-            });
+            pending_approvals
+                .insert(query_id, PendingApprovalRecord { query, position, proposed, governed });
         }
 
         let pending_approvals = self.pending_approvals.read().await;
@@ -3720,10 +3716,13 @@ mod tests {
         // newly armed one.
         let updated = manager.get_position(position.id).await.unwrap().unwrap();
         assert!(
-            matches!(updated.state, PositionState::Closed {
-                exit_reason: robson_domain::ExitReason::DisarmedByUser,
-                ..
-            }),
+            matches!(
+                updated.state,
+                PositionState::Closed {
+                    exit_reason: robson_domain::ExitReason::DisarmedByUser,
+                    ..
+                }
+            ),
             "Expected Closed after MonthlyHalt (Entering positions exhausted slots), got {:?}",
             updated.state
         );

--- a/v3/robsond/src/position_manager.rs
+++ b/v3/robsond/src/position_manager.rs
@@ -115,6 +115,38 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
         self.engine.lock().unwrap().risk_config().capital()
     }
 
+    /// Compute current equity per ADR-0024 §6:
+    ///
+    /// ```text
+    /// current_equity = initial_capital + all_time_realized_pnl + unrealized_pnl
+    /// ```
+    ///
+    /// Where:
+    /// - `initial_capital`: operator's declared starting capital from config
+    /// - `all_time_realized_pnl`: Σ(realized_pnl − fees_paid) for every closed
+    ///   position since the system started
+    /// - `unrealized_pnl`: mark-to-market PnL of Active positions
+    pub(crate) async fn compute_current_equity(&self) -> DaemonResult<Decimal> {
+        let initial_capital = self.configured_capital();
+
+        // All-time realized PnL (net of fees)
+        let all_closed = self.store.positions().find_all_closed().await?;
+        let all_time_realized: Decimal =
+            all_closed.iter().map(|p| p.realized_pnl - p.fees_paid).sum();
+
+        // Unrealized PnL of open Active positions
+        let active = self.store.positions().find_risk_open().await?;
+        let unrealized: Decimal = active
+            .iter()
+            .filter_map(|p| match &p.state {
+                PositionState::Active { .. } => Some(p.calculate_pnl()),
+                _ => None,
+            })
+            .sum();
+
+        Ok(initial_capital + all_time_realized + unrealized)
+    }
+
     #[cfg(feature = "postgres")]
     fn event_stream_key(event: &Event) -> String {
         match event {
@@ -126,7 +158,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
     }
 
     #[cfg(feature = "postgres")]
-    async fn load_capital_base_for_month(
+    pub(crate) async fn load_capital_base_for_month(
         &self,
         now: chrono::DateTime<chrono::Utc>,
     ) -> DaemonResult<Decimal> {
@@ -147,7 +179,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
     }
 
     #[cfg(not(feature = "postgres"))]
-    async fn load_capital_base_for_month(
+    pub(crate) async fn load_capital_base_for_month(
         &self,
         _now: chrono::DateTime<chrono::Utc>,
     ) -> DaemonResult<Decimal> {

--- a/v3/robsond/tests/api_contract.rs
+++ b/v3/robsond/tests/api_contract.rs
@@ -21,6 +21,8 @@ use std::net::SocketAddr;
 
 use reqwest::Client;
 use robsond::{api, Config, Daemon};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
@@ -32,7 +34,14 @@ use uuid::Uuid;
 ///
 /// The server binds to port 0 (OS-assigned) so tests never conflict.
 async fn start_test_server() -> (String, SocketAddr) {
-    let config = Config::test();
+    start_test_server_with_capital(dec!(10000)).await
+}
+
+/// Spin up a stub daemon with a specific capital_base for tests that need
+/// small position sizing (e.g., exchange minimum quantity rejection).
+async fn start_test_server_with_capital(capital_base: Decimal) -> (String, SocketAddr) {
+    let mut config = Config::test();
+    config.engine.capital_base = capital_base;
     let daemon = Daemon::new_stub(config);
     let addr = daemon.start_api_server(None).await.expect("failed to start test server");
     let base_url = format!("http://{}", addr);
@@ -350,10 +359,10 @@ async fn test_arm_invalid_symbol_returns_400() {
 async fn test_arm_missing_required_field_returns_422() {
     let (base, _) = start_test_server().await;
 
-    // Missing capital
+    // Missing symbol (required field)
     let resp = client()
         .post(format!("{}/positions", base))
-        .json(&json!({ "symbol": "BTCUSDT", "side": "LONG" }))
+        .json(&json!({ "side": "LONG" }))
         .send()
         .await
         .unwrap();
@@ -391,8 +400,8 @@ async fn test_signal_on_armed_position_is_accepted() {
 
 #[tokio::test]
 async fn test_signal_rejects_quantity_below_exchange_minimum() {
-    let (base, _) = start_test_server().await;
-    let arm = arm_btcusdt_with_capital(&base, "100").await;
+    let (base, _) = start_test_server_with_capital(dec!(100)).await;
+    let arm = arm_btcusdt(&base).await;
 
     let resp = client()
         .post(format!("{}/positions/{}/signal", base, arm.position_id))


### PR DESCRIPTION
## Summary

- Remove `capital` from `ArmRequest` — the frontend sends `{symbol, side}` and capital is derived from the system
- Capital base comes from `monthly_state` DB table (populated by `MonthBoundaryReset`), falls back to `ROBSON_CAPITAL_BASE` env var
- Remove `RiskConfig::default()` (10 000 USDT placeholder with no policy basis)
- Fix `handle_month_boundary()` to compute `current_equity = initial_capital + all_time_realized_pnl + unrealized_pnl` per ADR-0024 §6

## Test plan

- [x] `cargo test --all` — 435 passed, 0 failed
- [x] `api_contract` tests updated for new contract (no `capital` in request)
- [x] `start_test_server_with_capital()` helper for tests needing small capital
- [ ] Manual: `curl -X POST /positions -d '{"symbol":"ADAUSDT","side":"Long"}'` → 201
- [ ] Deploy with `ROBSON_CAPITAL_BASE` env var set

🤖 Generated with [Claude Code](https://claude.com/claude-code)