### PR TITLE
fix(daemon,frontend): enrich operation page + entry confirmation toast

### DIFF
--- a/apps/frontend/src/lib/api/robson.ts
+++ b/apps/frontend/src/lib/api/robson.ts
@@ -28,8 +28,8 @@ export type Position = {
   exit_order_id: string | null;
   insurance_stop_id: string | null;
   binance_position_id: string | null;
-  created_at: string;
-  updated_at: string;
+  created_at: string | null;
+  updated_at: string | null;
   closed_at: string | null;
 };
 
@@ -169,8 +169,8 @@ function normalizePosition(raw: unknown): Position {
     exit_order_id: p.exit_order_id == null ? null : String(p.exit_order_id),
     insurance_stop_id: p.insurance_stop_id == null ? null : String(p.insurance_stop_id),
     binance_position_id: p.binance_position_id == null ? null : String(p.binance_position_id),
-    created_at: String(p.created_at ?? ''),
-    updated_at: String(p.updated_at ?? ''),
+    created_at: p.created_at == null ? null : String(p.created_at),
+    updated_at: p.updated_at == null ? null : String(p.updated_at),
     closed_at: p.closed_at == null ? null : String(p.closed_at)
   };
 }

--- a/apps/frontend/src/lib/design/components/ArmModal.svelte
+++ b/apps/frontend/src/lib/design/components/ArmModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { robsonApi } from '$api/robson';
 
-  let { onclose }: { onclose: () => void } = $props();
+  let { onclose, onresult }: { onclose: () => void; onresult?: (r: { position_id: string; symbol: string; side: string }) => void } = $props();
 
   let symbol = $state('BTCUSDT');
   let side = $state<'Long' | 'Short'>('Long');
@@ -19,8 +19,9 @@
 
     submitting = true;
     try {
-      await robsonApi.armPosition({ symbol: symbol.trim(), side });
+      const result = await robsonApi.armPosition({ symbol: symbol.trim(), side });
       onclose();
+      if (onresult) onresult({ position_id: result.position_id, symbol: result.symbol, side: result.side });
     } catch (e) {
       error = e instanceof Error ? e.message : 'ARM FAILED';
     } finally {

--- a/apps/frontend/src/lib/design/components/ArmModal.svelte
+++ b/apps/frontend/src/lib/design/components/ArmModal.svelte
@@ -21,7 +21,7 @@
     try {
       const result = await robsonApi.armPosition({ symbol: symbol.trim(), side });
       onclose();
-      if (onresult) onresult({ position_id: result.position_id, symbol: result.symbol, side: result.side });
+      if (onresult) onresult({ position_id: result.id, symbol: result.symbol, side: result.side });
     } catch (e) {
       error = e instanceof Error ? e.message : 'ARM FAILED';
     } finally {

--- a/apps/frontend/src/lib/i18n/en.json
+++ b/apps/frontend/src/lib/i18n/en.json
@@ -55,6 +55,7 @@
     "eventStreamLabel": "EVENT STREAM",
     "sessionOnly": "Events from this session only. Full history in FE-P2.",
     "noEvents": "No events received yet for this position.",
+    "armedDescription": "awaiting entry signal · SMA crossover",
     "loading": "LOADING...",
     "loadError": "LOAD ERROR",
     "retry": "Retry"

--- a/apps/frontend/src/lib/i18n/pt-BR.json
+++ b/apps/frontend/src/lib/i18n/pt-BR.json
@@ -55,6 +55,7 @@
     "eventStreamLabel": "FLUXO DE EVENTOS",
     "sessionOnly": "Apenas eventos desta sessão. Histórico completo em FE-P2.",
     "noEvents": "Nenhum evento recebido ainda para esta posição.",
+    "armedDescription": "aguardando sinal de entrada · crossover SMA",
     "loading": "CARREGANDO...",
     "loadError": "ERRO DE CARREGAMENTO",
     "retry": "Tentar novamente"

--- a/apps/frontend/src/lib/presentation/labels.ts
+++ b/apps/frontend/src/lib/presentation/labels.ts
@@ -22,7 +22,8 @@ export function positionSummaryLines(p: Position): string[] {
 
   if (typeof state === 'string') {
     if (state === 'Armed') {
-      lines.push(label('ARMED', 'awaiting entry signal'));
+      lines.push(label('ARMED', 'awaiting entry signal · SMA crossover'));
+      lines.push(label('LEVERAGE', '10x (fixed)'));
     } else if (state === 'Active') {
       const details = [];
       if (p.entry_price != null) details.push(`entry ${fmtNum(p.entry_price)}`);
@@ -60,8 +61,8 @@ export function positionSummaryLines(p: Position): string[] {
 
 export function positionMetaLine(p: Position): string {
   const state = positionStateLabel(p.state);
-  const created = formatDateUtc(p.created_at);
-  const parts = [`State ${state}`, `Created ${created}`];
+  const parts = [`State ${state}`];
+  if (p.created_at) parts.push(`Created ${formatDateUtc(p.created_at)}`);
   if (p.closed_at) parts.push(`Closed ${formatDateUtc(p.closed_at)}`);
   return parts.join(' · ');
 }
@@ -112,7 +113,9 @@ function fmtPnl(n: number): string {
 }
 
 function formatDateUtc(iso: string): string {
+  if (!iso) return '--';
   const d = new Date(iso);
+  if (isNaN(d.getTime())) return '--';
   return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} UTC`;
 }
 

--- a/apps/frontend/src/lib/stores/toast.ts
+++ b/apps/frontend/src/lib/stores/toast.ts
@@ -1,0 +1,19 @@
+import { writable } from 'svelte/store';
+
+export type Toast = {
+  id: number;
+  message: string;
+  kind: 'ok' | 'err';
+};
+
+let counter = 0;
+
+export const toasts = writable<Toast[]>([]);
+
+export function showToast(message: string, kind: Toast['kind'] = 'ok') {
+  const id = ++counter;
+  toasts.update((prev) => [...prev, { id, message, kind }]);
+  setTimeout(() => {
+    toasts.update((prev) => prev.filter((t) => t.id !== id));
+  }, 4000);
+}

--- a/apps/frontend/src/routes/(authed)/dashboard/+page.svelte
+++ b/apps/frontend/src/routes/(authed)/dashboard/+page.svelte
@@ -10,6 +10,7 @@
   import { activePositions } from '$stores/operations';
   import { haltStatus } from '$stores/slots';
   import { recentEvents, pushEvent } from '$stores/events';
+  import { toasts, showToast } from '$stores/toast';
   import { deriveSlots, INITIAL_MONTHLY_SLOT_BUDGET } from '$lib/config/slots';
   import { formatTimeUtc, isTodayUtc } from '$lib/utils/time';
   import {
@@ -299,7 +300,17 @@
   {/if}
 
   {#if showArmModal}
-    <ArmModal onclose={() => { showArmModal = false; void load(); }} />
+    <ArmModal onclose={() => { showArmModal = false; void load(); }} onresult={(r) => { showToast(`${r.symbol} ${r.side} armed — detector active`, 'ok'); }} />
+  {/if}
+
+  {#if $toasts.length > 0}
+    <div class="toast-container">
+      {#each $toasts as t (t.id)}
+        <div class="toast" class:ok={t.kind === 'ok'} class:err-toast={t.kind === 'err'}>
+          {t.message}
+        </div>
+      {/each}
+    </div>
   {/if}
 </div>
 
@@ -490,5 +501,36 @@
   }
   .meta.dim {
     color: var(--fg-3);
+  }
+  .toast-container {
+    position: fixed;
+    bottom: var(--s-6);
+    right: var(--s-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--s-2);
+    z-index: 200;
+  }
+  .toast {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    letter-spacing: var(--track-wide);
+    padding: var(--s-3) var(--s-5);
+    border-radius: var(--radius-sm);
+    animation: toast-in var(--dur) var(--ease);
+  }
+  .toast.ok {
+    color: var(--ok);
+    border: 1px solid var(--ok);
+    background: rgba(127, 183, 126, 0.08);
+  }
+  .toast.err-toast {
+    color: var(--err);
+    border: 1px solid var(--err);
+    background: rgba(197, 106, 106, 0.08);
+  }
+  @keyframes toast-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
   }
 </style>

--- a/apps/frontend/tests/unit/labels.test.ts
+++ b/apps/frontend/tests/unit/labels.test.ts
@@ -48,9 +48,10 @@ function makeEvent(payload: Record<string, unknown>): SseEvent {
 describe('positionSummaryLines', () => {
   it('Armed state', () => {
     const lines = positionSummaryLines(basePosition({ state: 'Armed' }));
-    expect(lines).toHaveLength(1);
+    expect(lines).toHaveLength(2);
     expect(lines[0]).toContain('ARMED');
     expect(lines[0]).toContain('awaiting entry signal');
+    expect(lines[1]).toContain('LEVERAGE');
   });
 
   it('Active state with trailing stop', () => {

--- a/v3/robsond/src/api.rs
+++ b/v3/robsond/src/api.rs
@@ -105,6 +105,9 @@ pub struct PositionSummary {
     pub symbol: String,
     pub side: String,
     pub state: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quantity: Option<Decimal>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entry_price: Option<Decimal>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -979,6 +982,12 @@ fn position_to_summary(position: &Position) -> PositionSummary {
         symbol: position.symbol.as_pair(),
         side: format!("{:?}", position.side),
         state: state_str,
+        created_at: position.created_at,
+        quantity: if position.quantity.as_decimal() > Decimal::ZERO {
+            Some(position.quantity.as_decimal())
+        } else {
+            None
+        },
         entry_price,
         trailing_stop,
         pnl,


### PR DESCRIPTION
## Summary
- Backend `PositionSummary` now includes `created_at` and `quantity` fields
- Frontend fixes NaN-NaN-NaN in operation page date display
- Armed summary shows "awaiting entry signal · SMA crossover" with leverage info
- New toast notification system: arm success shows confirmation toast on dashboard

## Changes

### Backend
- `PositionSummary`: added `created_at` (DateTime) and `quantity` (Option<Decimal>) fields

### Frontend
- `formatDateUtc()`: guard against empty/invalid ISO strings (returns `--`)
- `positionSummaryLines()`: enriched Armed state with signal type and leverage
- `positionMetaLine()`: handles nullable `created_at` gracefully
- `normalizePosition()`: `created_at`/`updated_at` now nullable
- New `toast.ts` store: minimal auto-expiry toast system
- `ArmModal`: emits `onresult` callback with position details on success
- Dashboard: renders toast notifications on arm success

## Test Plan
- [x] `cargo test --all` — 436 pass
- [x] `bun run build` — FE compiles
- [x] nightly rustfmt clean
- [ ] Deploy and verify operation page shows date correctly
- [ ] Deploy and verify toast appears after arming position

🤖 Generated with [Claude Code](https://claude.com/claude-code)