### PR TITLE
docs(analysis): record stop-aware post-merge testnet validation

### DIFF
--- a/docs/analysis/2026-05-04-stop-aware-post-merge-testnet-validation.md
+++ b/docs/analysis/2026-05-04-stop-aware-post-merge-testnet-validation.md
@@ -1,0 +1,167 @@
+# Stop-Aware Post-Merge Testnet Validation
+
+**Date:** 2026-05-04
+**Result:** PASS
+**Scope:** Post-merge testnet validation for Robson Stop-Aware shadow telemetry and runtime health
+
+## Context
+
+PR #57 was squash-merged into Robson `main` and validated locally and in CI before
+testnet rollout. The follow-up GitOps change in `rbx-infra` updated the Robson
+testnet Deployment image to the Robson main commit produced by PR #57.
+
+This report records the post-merge testnet validation evidence. It is doc-only and
+does not authorize production exposure, query approval, order execution, or any
+StopQuality boost application.
+
+## Commits And Images
+
+| Item | Value |
+|------|-------|
+| Robson main commit | `83130b2bf40874115ea82359313f7d0fad6fb075` |
+| Robson CI image | `ghcr.io/rbxrobotica/robson-v2:sha-83130b2b` |
+| `rbx-infra` GitOps merge | PR #6, squash-merged to `main` |
+| `rbx-infra` main SHA after merge | `d39fafce1820118b70fc8167baf8e4dad73f6a49` |
+| GitOps path | `apps/testnet/robson/robsond-deploy.yml` |
+| Testnet Deployment image | `ghcr.io/rbxrobotica/robson-v2:sha-83130b2b` |
+
+## Validation Scope
+
+Validated:
+
+- ArgoCD Application state for `robson-testnet`.
+- Kubernetes Deployment image for `robsond` in namespace `robson-testnet`.
+- ReplicaSet and Pod health for the new image.
+- Recent `robsond` startup logs.
+- Read-only `/health` and `/status` API responses through a temporary local
+  port-forward.
+
+Not validated in this run:
+
+- End-to-end order lifecycle.
+- Query approval flow.
+- Real order execution.
+- Stop-triggered exit.
+- Production deployment.
+- StopQuality boost behavior.
+
+## ArgoCD State
+
+| Resource | State |
+|----------|-------|
+| Application | `robson-testnet` |
+| Sync status | `Synced` |
+| Health status | `Healthy` |
+
+## Deployment, ReplicaSet, And Pod
+
+| Item | Value |
+|------|-------|
+| Namespace | `robson-testnet` |
+| Deployment | `robsond` |
+| Deployment image | `ghcr.io/rbxrobotica/robson-v2:sha-83130b2b` |
+| Active ReplicaSet | `robsond-5ddd4cb88b` |
+| ReplicaSet desired/current/ready | `1/1/1` |
+| Active Pod | `robsond-5ddd4cb88b-mhnls` |
+| Pod status | `Running` |
+| Pod readiness | `1/1` |
+| Pod restarts | `0` |
+
+Historical ReplicaSets remained scaled to zero, including earlier images
+`sha-447aba4b`, `sha-c547fb33`, `sha-7c3af2b9`, and others. The only ready
+ReplicaSet observed during validation was the new `sha-83130b2b` ReplicaSet.
+
+## Health And Status
+
+Read-only API checks were performed through a temporary local port-forward and the
+port-forward was then closed.
+
+`/health`:
+
+```json
+{"status":"healthy","version":"2.0.0-alpha"}
+```
+
+`/status`:
+
+```json
+{"active_positions":0,"positions":[],"pending_approvals":[],"slots_available":4}
+```
+
+## Relevant Logs
+
+Recent startup logs showed:
+
+- Robson daemon started with version `2.0.0-alpha`.
+- PostgreSQL connection pool initialized.
+- Exchange configured as Binance testnet.
+- Engine capital initialized from exchange balance.
+- Store recovery found no active positions.
+- Startup reconciliation completed cleanly with `0 UNTRACKED`.
+- Position monitor loaded `0` persisted positions.
+- Position monitor initialized for `BTCUSDT` and `ETHUSDT`.
+- API server started on `0.0.0.0:8080`.
+- WebSocket clients spawned for `BTCUSDT` and `ETHUSDT`.
+- Projection worker started for stream key `robson:testnet`.
+- WebSocket connected for both `BTCUSDT` and `ETHUSDT`.
+- First tick received for both `BTCUSDT` and `ETHUSDT`.
+
+No evidence was observed in the recent logs for:
+
+- Panic.
+- Migration failure.
+- Binance `-2015` authentication failure.
+- Reconciliation error.
+- UNTRACKED exchange position.
+
+## Safety Invariants
+
+The validation preserved the following invariants:
+
+- Testnet remained isolated in namespace `robson-testnet`.
+- The deployed image was pinned by immutable SHA tag, not `latest`.
+- `active_positions` remained `0`.
+- `pending_approvals` remained `[]`.
+- Startup reconciliation reported `0 UNTRACKED`.
+- No query was approved.
+- No order was executed.
+- No StopQuality boost was applied.
+- No production resource was inspected or changed as part of the validation.
+
+## Explicitly Not Executed
+
+The validation did not execute:
+
+- `kubectl apply`.
+- `kubectl patch`.
+- `kubectl rollout restart`.
+- Pod deletion.
+- Manifest edits.
+- ConfigMap edits.
+- Secret edits.
+- Manual deploy.
+- Production access or production changes.
+- Query approval.
+- Order execution.
+- Real boost application.
+
+## Result
+
+PASS.
+
+The Robson testnet environment successfully rolled forward to
+`ghcr.io/rbxrobotica/robson-v2:sha-83130b2b`, became `Synced` and `Healthy` in
+ArgoCD, ran one ready pod with zero restarts, returned healthy API responses, and
+started cleanly with Binance testnet connectivity for both configured symbols.
+
+## Recommended Next Step
+
+Continue with observational Stop-Aware shadow validation only:
+
+- Keep testnet scoped to read-only observation unless a separate operator runbook
+  authorizes a bounded stimulus.
+- Capture `stop-aware entry shadow telemetry` across BTCUSDT and ETHUSDT.
+- Confirm `active_positions=0`, `pending_approvals=[]`, and `0 UNTRACKED` before
+  any future observation window.
+- Do not apply boost, approve queries, execute orders, or promote to production
+  without a separate explicit authorization and validation plan.


### PR DESCRIPTION
## Summary

Adds a doc-only analysis report for the Robson Stop-Aware post-merge testnet validation performed after PR #57 and the rbx-infra GitOps rollout.

The report records:

- Robson commit `83130b2bf40874115ea82359313f7d0fad6fb075`.
- Testnet image `ghcr.io/rbxrobotica/robson-v2:sha-83130b2b`.
- ArgoCD `robson-testnet` state: `Synced / Healthy`.
- Deployment, ReplicaSet, Pod, health, status, and startup log evidence.
- Safety invariants and explicitly non-executed actions.
- Final result: `PASS`.

## Scope

In scope:

- One markdown report under `docs/analysis`.

Out of scope:

- Code changes.
- Runtime changes.
- Infra changes.
- Secrets or ConfigMap changes.
- Production changes.
- kubectl/deploy/rollout actions.
- Query approval, order execution, or StopQuality boost application.

## Validation

- Confirmed staged and committed diff contains only `docs/analysis/2026-05-04-stop-aware-post-merge-testnet-validation.md`.
- No code, runtime, manifest, or infra files were changed.
