### PR TITLE
Slice 5B1 Manual Recovery

### DIFF
--- a/docs/runbooks/td-2026-05-05-001-stale-active-recovery.md
+++ b/docs/runbooks/td-2026-05-05-001-stale-active-recovery.md
@@ -2,8 +2,8 @@
 
 **Severity**: Critical
 **Time to Execute**: 10–30 min per affected position (steady state); up to 60 min on first incident
-**Required Access**: `kubectl` for `robson` and `robson-testnet` namespaces, Binance Futures account access (web UI or `binance-cli`), `robsond` API token, `robson-cli` binary at the version that ships Slice 5
-**Status**: PARTIAL (Slice 5A of TD-2026-05-05-001) — abort path (exit code 78) is live. The `robson-cli reconcile-close` command lands in Slice 5B. Until 5B ships, recovery requires engineering involvement after following §Evidence Collection Order and §Manual Verification Checklist.
+**Required Access**: `kubectl` for `robson` and `robson-testnet` namespaces, Binance Futures account access (web UI or `binance-cli`), `robsond` API token, `robson-cli` binary at the version that ships Slice 5B1
+**Status**: Slice 5B1 LIVE — operator-driven manual recovery available via `robson-cli reconcile-close`. Startup `auto_reconcile` is Slice 5B2 (future).
 
 ---
 
@@ -185,44 +185,90 @@ Before issuing the close, every operator MUST tick all of:
 
 ---
 
-## Recovery Command (Slice 5B — not yet available)
+## Recovery Command (Slice 5B1 — operator-driven manual path)
 
-> The `robson-cli reconcile-close` command is **not yet implemented**; it lands
-> in Slice 5B of TD-2026-05-05-001. Until 5B ships, recovery requires
-> engineering involvement: collect evidence per §Evidence Collection Order,
-> validate per §Manual Verification Checklist, then coordinate with engineering
-> to emit the `PositionClosed` event manually via the internal API.
+> **Only `order_fill_record` and `user_trade_record` evidence are accepted.**
+> `account_snapshot` and `estimated` are not supported in Slice 5B1. They will
+> land in a future slice.
 
-**General shape (target — to be confirmed in Slice 5)**:
+### Command
 
 ```bash
 robson-cli reconcile-close \
   --position-id <UUID> \
-  --evidence <order_fill_record|user_trade_record|account_snapshot|estimated> \
-  --evidence-payload @evidence.json
+  --evidence-file evidence.json \
+  --robsond-url http://localhost:8080 \
+  --token "$ROBSON_API_TOKEN"
 ```
 
-Where `evidence.json` mirrors the `ReconciliationEvidence::*` payload from
-the domain types in `v3/robson-domain/src/entities.rs` (Slice 1).
+Flags:
 
-The command:
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--position-id` | Yes | — | UUID of the position to close |
+| `--evidence-file` | Yes | — | Path to JSON file with evidence |
+| `--robsond-url` | No | `http://localhost:8080` | Base URL of robsond API |
+| `--token` | No | `$ROBSON_API_TOKEN` env | Bearer token for auth |
 
-1. Validates the evidence shape locally.
-2. Calls `robsond` HTTP API at `/reconcile-close` (TBD — Slice 5).
-3. The API path goes through the same `execute_and_persist` pipeline used
-   by normal exits, emitting `Event::PositionClosed { exit_reason:
-   ReconciledMissingOnExchange, closure_evidence:
-   Reconciled(<your evidence>), ... }`.
-4. Eventlog → projector → `positions_current.state = 'closed'` → `/status`
-   reflects the close on next read.
+### Exit Codes
 
-**TODO (Slice 5)**:
+| Code | Meaning |
+|------|---------|
+| 0 | Success, position closed |
+| 1 | Generic error (network, parse) |
+| 2 | Usage error or evidence locally rejected |
+| 3 | Position not found (404) |
+| 4 | Position not Active (409) |
+| 5 | Evidence inconsistent (400) |
+| 6 | Unauthorized (401) |
 
-- [ ] Final command name and flag set.
-- [ ] Authentication / token requirements.
-- [ ] Exit codes for each rejection class (invalid evidence, position not Active, position not found, api unreachable).
-- [ ] Sample `evidence.json` files for each of the four sources.
-- [ ] Failure-mode runbook (CLI returns 4xx vs 5xx; eventlog write fails; projector lag).
+### Sample evidence.json — OrderFillRecord
+
+```json
+{
+  "source": "order_fill_record",
+  "data": {
+    "exchange_order_id": "12345678",
+    "fill_price": "95000.50",
+    "filled_quantity": "0.010",
+    "fee": "0.95",
+    "fee_asset": "USDT",
+    "filled_at": "2026-05-09T14:30:00Z"
+  }
+}
+```
+
+### Sample evidence.json — UserTradeRecord
+
+```json
+{
+  "source": "user_trade_record",
+  "data": {
+    "exchange_order_id": "12345678",
+    "exchange_trade_id": "87654321",
+    "fill_price": "95000.50",
+    "filled_quantity": "0.010",
+    "fee": "0.95",
+    "fee_asset": "USDT",
+    "filled_at": "2026-05-09T14:30:00Z"
+  }
+}
+```
+
+### What happens
+
+1. CLI validates evidence shape locally (rejects `account_snapshot` and `estimated`).
+2. CLI sends `POST /reconcile-close` to `robsond` with the evidence.
+3. API validates Bearer token, deserializes evidence, calls `PositionManager::reconcile_close()`.
+4. `reconcile_close()` checks position is `Active`, validates evidence consistency, emits `PositionClosed { exit_reason: ReconciledMissingOnExchange }`.
+5. Eventlog → projector → position becomes `Closed`.
+6. CLI prints `realized_pnl` and `exit_price`.
+
+### Not yet supported
+
+- `account_snapshot` evidence — rejected at CLI and API level.
+- `estimated` evidence — rejected at CLI and API level.
+- Startup `auto_reconcile` — Slice 5B2, future work.
 
 ---
 
@@ -276,3 +322,4 @@ There is **no rollback** for a reconciled close. Once `Event::PositionClosed` is
 |---|---|---|
 | 2026-05-08 | Initial skeleton (Slice 2 of TD-2026-05-05-001). Operational structure, evidence ordering, decision flow. CLI command deferred to Slice 5B. | Claude Opus 4.7 |
 | 2026-05-09 | Slice 5A: startup abort is live (exit 78). Added §Startup Abort section, updated status and recovery command note. | Claude Sonnet 4.6 |
+| 2026-05-09 | Slice 5B1: operator-driven manual recovery via `robson-cli reconcile-close` + `POST /reconcile-close`. OrderFillRecord and UserTradeRecord evidence accepted. AccountSnapshot/Estimated rejected. Exit codes 0-6 documented. | Claude Opus 4.7 |

--- a/v3/Cargo.lock
+++ b/v3/Cargo.lock
@@ -73,6 +73,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +405,52 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -1199,6 +1295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1510,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -1896,6 +2004,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "robson-cli"
+version = "2.0.0-alpha"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "reqwest 0.12.28",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -2670,6 +2795,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,6 +3356,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/v3/Cargo.toml
+++ b/v3/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "robson-db",
     "robson-testkit",
     "robsond",
+    "robson-cli",
     "robson-sim",
 ]
 resolver = "2"

--- a/v3/robson-cli/Cargo.toml
+++ b/v3/robson-cli/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "robson-cli"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "robson-cli"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive", "env"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { version = "0.12", features = ["json"] }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+rust_decimal = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/v3/robson-cli/src/api_client.rs
+++ b/v3/robson-cli/src/api_client.rs
@@ -1,0 +1,120 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::commands::reconcile_close::EvidenceJson;
+
+#[derive(Debug, Serialize)]
+pub struct ReconcileCloseRequest {
+    pub position_id: Uuid,
+    pub evidence: EvidenceJson,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct SuccessResponse {
+    pub status: String,
+    pub position_id: Uuid,
+    pub realized_pnl: String,
+    pub exit_price: String,
+    pub closure_evidence: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct NotFoundResponse {
+    pub error: String,
+    pub position_id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct NotActiveResponse {
+    pub error: String,
+    pub details: String,
+    pub current_state: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ErrorResponse {
+    pub error: String,
+    #[allow(dead_code)]
+    pub details: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UnauthorizedResponse {
+    pub error: String,
+}
+
+#[derive(Debug)]
+pub enum ReconcileCloseResponse {
+    Success(SuccessResponse),
+    NotFound(NotFoundResponse),
+    NotActive(NotActiveResponse),
+    Inconsistent(ErrorResponse),
+    Unsupported(ErrorResponse),
+    Unauthorized(UnauthorizedResponse),
+}
+
+pub struct ApiClient {
+    base_url: String,
+    token: Option<String>,
+    client: reqwest::Client,
+}
+
+impl ApiClient {
+    pub fn new(base_url: &str, token: Option<&str>) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            token: token.map(|t| t.to_string()),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub async fn reconcile_close(&self, body: ReconcileCloseRequest) -> Result<ReconcileCloseResponse> {
+        let url = format!("{}/reconcile-close", self.base_url);
+        let mut req = self.client.post(&url);
+        if let Some(token) = &self.token {
+            req = req.bearer_auth(token);
+        }
+        let resp = req
+            .json(&body)
+            .send()
+            .await
+            .context("failed to connect to robsond")?;
+
+        match resp.status().as_u16() {
+            200 => {
+                let success: SuccessResponse =
+                    resp.json().await.context("failed to parse success response")?;
+                Ok(ReconcileCloseResponse::Success(success))
+            },
+            400 => {
+                let err: ErrorResponse = resp.json().await.context("failed to parse 400 response")?;
+                if err.error == "unsupported_evidence" {
+                    Ok(ReconcileCloseResponse::Unsupported(err))
+                } else {
+                    Ok(ReconcileCloseResponse::Inconsistent(err))
+                }
+            },
+            401 => {
+                let err: UnauthorizedResponse =
+                    resp.json().await.context("failed to parse 401 response")?;
+                Ok(ReconcileCloseResponse::Unauthorized(err))
+            },
+            404 => {
+                let err: NotFoundResponse = resp.json().await.context("failed to parse 404 response")?;
+                Ok(ReconcileCloseResponse::NotFound(err))
+            },
+            409 => {
+                let err: NotActiveResponse = resp.json().await.context("failed to parse 409 response")?;
+                Ok(ReconcileCloseResponse::NotActive(err))
+            },
+            other => {
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("unexpected HTTP {} from robsond: {}", other, text)
+            },
+        }
+    }
+}

--- a/v3/robson-cli/src/api_client.rs
+++ b/v3/robson-cli/src/api_client.rs
@@ -72,17 +72,16 @@ impl ApiClient {
         }
     }
 
-    pub async fn reconcile_close(&self, body: ReconcileCloseRequest) -> Result<ReconcileCloseResponse> {
+    pub async fn reconcile_close(
+        &self,
+        body: ReconcileCloseRequest,
+    ) -> Result<ReconcileCloseResponse> {
         let url = format!("{}/reconcile-close", self.base_url);
         let mut req = self.client.post(&url);
         if let Some(token) = &self.token {
             req = req.bearer_auth(token);
         }
-        let resp = req
-            .json(&body)
-            .send()
-            .await
-            .context("failed to connect to robsond")?;
+        let resp = req.json(&body).send().await.context("failed to connect to robsond")?;
 
         match resp.status().as_u16() {
             200 => {
@@ -91,7 +90,8 @@ impl ApiClient {
                 Ok(ReconcileCloseResponse::Success(success))
             },
             400 => {
-                let err: ErrorResponse = resp.json().await.context("failed to parse 400 response")?;
+                let err: ErrorResponse =
+                    resp.json().await.context("failed to parse 400 response")?;
                 if err.error == "unsupported_evidence" {
                     Ok(ReconcileCloseResponse::Unsupported(err))
                 } else {
@@ -104,11 +104,13 @@ impl ApiClient {
                 Ok(ReconcileCloseResponse::Unauthorized(err))
             },
             404 => {
-                let err: NotFoundResponse = resp.json().await.context("failed to parse 404 response")?;
+                let err: NotFoundResponse =
+                    resp.json().await.context("failed to parse 404 response")?;
                 Ok(ReconcileCloseResponse::NotFound(err))
             },
             409 => {
-                let err: NotActiveResponse = resp.json().await.context("failed to parse 409 response")?;
+                let err: NotActiveResponse =
+                    resp.json().await.context("failed to parse 409 response")?;
                 Ok(ReconcileCloseResponse::NotActive(err))
             },
             other => {

--- a/v3/robson-cli/src/commands/mod.rs
+++ b/v3/robson-cli/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod reconcile_close;

--- a/v3/robson-cli/src/commands/reconcile_close.rs
+++ b/v3/robson-cli/src/commands/reconcile_close.rs
@@ -1,0 +1,334 @@
+use std::path::PathBuf;
+
+use anyhow::{bail, Context, Result};
+use chrono::{DateTime, Utc};
+use clap::Args;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::api_client;
+
+pub const EXIT_SUCCESS: i32 = 0;
+pub const EXIT_GENERIC_ERROR: i32 = 1;
+pub const EXIT_USAGE_ERROR: i32 = 2;
+pub const EXIT_NOT_FOUND: i32 = 3;
+pub const EXIT_NOT_ACTIVE: i32 = 4;
+pub const EXIT_INCONSISTENT: i32 = 5;
+pub const EXIT_UNAUTHORIZED: i32 = 6;
+
+#[derive(Args)]
+pub struct ReconcileCloseArgs {
+    /// UUID of the position to reconcile-close.
+    #[arg(long)]
+    pub position_id: Uuid,
+
+    /// Path to a JSON file containing the reconciliation evidence.
+    #[arg(long)]
+    pub evidence_file: PathBuf,
+
+    /// Base URL of the robsond API.
+    #[arg(long, default_value = "http://localhost:8080")]
+    pub robsond_url: String,
+
+    /// Bearer token for authentication. Falls back to ROBSON_API_TOKEN env var.
+    #[arg(long, value_name = "TOKEN", env = "ROBSON_API_TOKEN")]
+    pub token: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "source", content = "data", rename_all = "snake_case")]
+pub enum EvidenceJson {
+    OrderFillRecord(OrderFillData),
+    UserTradeRecord(UserTradeData),
+    AccountSnapshot(serde_json::Value),
+    Estimated(serde_json::Value),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrderFillData {
+    pub exchange_order_id: String,
+    pub fill_price: String,
+    pub filled_quantity: String,
+    pub fee: String,
+    pub fee_asset: String,
+    pub filled_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UserTradeData {
+    pub exchange_order_id: String,
+    pub exchange_trade_id: String,
+    pub fill_price: String,
+    pub filled_quantity: String,
+    pub fee: String,
+    pub fee_asset: String,
+    pub filled_at: String,
+}
+
+pub fn validate_order_fill(data: &OrderFillData) -> Result<()> {
+    let price: Decimal = data
+        .fill_price
+        .parse()
+        .ok()
+        .context("fill_price is not a valid decimal")?;
+    if price <= Decimal::ZERO {
+        bail!("fill_price must be > 0");
+    }
+
+    let qty: Decimal = data
+        .filled_quantity
+        .parse()
+        .ok()
+        .context("filled_quantity is not a valid decimal")?;
+    if qty <= Decimal::ZERO {
+        bail!("filled_quantity must be > 0");
+    }
+
+    let fee: Decimal = data
+        .fee
+        .parse()
+        .ok()
+        .context("fee is not a valid decimal")?;
+    if fee < Decimal::ZERO {
+        bail!("fee must be >= 0");
+    }
+
+    if data.fee_asset.is_empty() {
+        bail!("fee_asset must not be empty");
+    }
+    if data.exchange_order_id.is_empty() {
+        bail!("exchange_order_id must not be empty");
+    }
+
+    let _: DateTime<Utc> = DateTime::parse_from_rfc3339(&data.filled_at)
+        .map(|dt| dt.to_utc())
+        .context("filled_at is not a valid ISO-8601 timestamp")?;
+
+    Ok(())
+}
+
+pub fn validate_user_trade(data: &UserTradeData) -> Result<()> {
+    if data.exchange_trade_id.is_empty() {
+        bail!("exchange_trade_id must not be empty");
+    }
+
+    validate_order_fill(&OrderFillData {
+        exchange_order_id: data.exchange_order_id.clone(),
+        fill_price: data.fill_price.clone(),
+        filled_quantity: data.filled_quantity.clone(),
+        fee: data.fee.clone(),
+        fee_asset: data.fee_asset.clone(),
+        filled_at: data.filled_at.clone(),
+    })
+}
+
+pub async fn run(args: ReconcileCloseArgs) -> i32 {
+    match run_inner(args).await {
+        Ok(code) => code,
+        Err(code) => code,
+    }
+}
+
+async fn run_inner(args: ReconcileCloseArgs) -> Result<i32, i32> {
+    let raw = std::fs::read_to_string(&args.evidence_file).map_err(|e| {
+        eprintln!("error: failed to read {}: {e}", args.evidence_file.display());
+        EXIT_GENERIC_ERROR
+    })?;
+    let evidence: EvidenceJson =
+        serde_json::from_str(&raw).map_err(|_| {
+            eprintln!("error: invalid evidence JSON");
+            EXIT_USAGE_ERROR
+        })?;
+
+    match &evidence {
+        EvidenceJson::AccountSnapshot(_) => {
+            eprintln!(
+                "account_snapshot evidence is not supported in Slice 5B1. \
+                 Only order_fill_record and user_trade_record are accepted."
+            );
+            return Err(EXIT_USAGE_ERROR);
+        },
+        EvidenceJson::Estimated(_) => {
+            eprintln!(
+                "estimated evidence is not supported in Slice 5B1. \
+                 Only order_fill_record and user_trade_record are accepted."
+            );
+            return Err(EXIT_USAGE_ERROR);
+        },
+        EvidenceJson::OrderFillRecord(data) => {
+            if let Err(e) = validate_order_fill(data) {
+                eprintln!("error: {e:#}");
+                return Err(EXIT_USAGE_ERROR);
+            }
+        },
+        EvidenceJson::UserTradeRecord(data) => {
+            if let Err(e) = validate_user_trade(data) {
+                eprintln!("error: {e:#}");
+                return Err(EXIT_USAGE_ERROR);
+            }
+        },
+    }
+
+    let request_body = api_client::ReconcileCloseRequest {
+        position_id: args.position_id,
+        evidence,
+    };
+
+    let client = api_client::ApiClient::new(&args.robsond_url, args.token.as_deref());
+    let response = client.reconcile_close(request_body).await.map_err(|e| {
+        eprintln!("error: {e:#}");
+        EXIT_GENERIC_ERROR
+    })?;
+
+    match response {
+        api_client::ReconcileCloseResponse::Success(resp) => {
+            println!(
+                "position {} closed: realized_pnl={}, exit_price={}",
+                resp.position_id, resp.realized_pnl, resp.exit_price
+            );
+            Ok(EXIT_SUCCESS)
+        },
+        api_client::ReconcileCloseResponse::NotFound(resp) => {
+            eprintln!("position not found: {}", resp.position_id);
+            Err(EXIT_NOT_FOUND)
+        },
+        api_client::ReconcileCloseResponse::NotActive(resp) => {
+            eprintln!(
+                "position not active: {} (current_state={})",
+                resp.error, resp.current_state
+            );
+            Err(EXIT_NOT_ACTIVE)
+        },
+        api_client::ReconcileCloseResponse::Inconsistent(resp) => {
+            eprintln!(
+                "inconsistent evidence: {}{}",
+                resp.error,
+                resp.details
+                    .as_ref()
+                    .map(|d| format!(" — {d}"))
+                    .unwrap_or_default()
+            );
+            Err(EXIT_INCONSISTENT)
+        },
+        api_client::ReconcileCloseResponse::Unsupported(resp) => {
+            eprintln!(
+                "unsupported evidence: {}{}",
+                resp.error,
+                resp.details
+                    .as_ref()
+                    .map(|d| format!(" — {d}"))
+                    .unwrap_or_default()
+            );
+            Err(EXIT_USAGE_ERROR)
+        },
+        api_client::ReconcileCloseResponse::Unauthorized(resp) => {
+            eprintln!("unauthorized: {}", resp.error);
+            Err(EXIT_UNAUTHORIZED)
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as IoWrite;
+    use tempfile::NamedTempFile;
+
+    fn write_evidence_file(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        write!(f, "{content}").unwrap();
+        f
+    }
+
+    #[test]
+    fn test_cli_rejects_estimated_evidence() {
+        let f = write_evidence_file(
+            r#"{"source":"estimated","data":{"estimation_basis":"trailing_stop_at_detection","exit_price":"95000.00","evaluator":"op:ldamasio","detected_at":"2026-05-09T14:30:00Z"}}"#,
+        );
+        let raw = std::fs::read_to_string(f.path()).unwrap();
+        let evidence: EvidenceJson = serde_json::from_str(&raw).unwrap();
+        assert!(matches!(evidence, EvidenceJson::Estimated(_)));
+    }
+
+    #[test]
+    fn test_cli_rejects_account_snapshot_evidence() {
+        let f = write_evidence_file(
+            r#"{"source":"account_snapshot","data":{"first_observed_missing_at":"2026-05-09T14:00:00Z","confirmed_missing_at":"2026-05-09T14:01:00Z"}}"#,
+        );
+        let raw = std::fs::read_to_string(f.path()).unwrap();
+        let evidence: EvidenceJson = serde_json::from_str(&raw).unwrap();
+        assert!(matches!(evidence, EvidenceJson::AccountSnapshot(_)));
+    }
+
+    #[test]
+    fn test_cli_serializes_order_fill_record() {
+        let data = OrderFillData {
+            exchange_order_id: "12345678".to_string(),
+            fill_price: "95000.50".to_string(),
+            filled_quantity: "0.010".to_string(),
+            fee: "0.95".to_string(),
+            fee_asset: "USDT".to_string(),
+            filled_at: "2026-05-09T14:30:00Z".to_string(),
+        };
+        let evidence = EvidenceJson::OrderFillRecord(data);
+        let json = serde_json::to_string(&evidence).unwrap();
+        assert!(json.contains("\"source\":\"order_fill_record\""));
+        assert!(json.contains("\"exchange_order_id\":\"12345678\""));
+        assert!(json.contains("\"fill_price\":\"95000.50\""));
+        assert!(json.contains("\"filled_quantity\":\"0.010\""));
+    }
+
+    #[test]
+    fn test_cli_serializes_user_trade_record() {
+        let data = UserTradeData {
+            exchange_order_id: "12345678".to_string(),
+            exchange_trade_id: "87654321".to_string(),
+            fill_price: "95000.50".to_string(),
+            filled_quantity: "0.010".to_string(),
+            fee: "0.95".to_string(),
+            fee_asset: "USDT".to_string(),
+            filled_at: "2026-05-09T14:30:00Z".to_string(),
+        };
+        let evidence = EvidenceJson::UserTradeRecord(data);
+        let json = serde_json::to_string(&evidence).unwrap();
+        assert!(json.contains("\"source\":\"user_trade_record\""));
+        assert!(json.contains("\"exchange_trade_id\":\"87654321\""));
+        assert!(json.contains("\"exchange_order_id\":\"12345678\""));
+    }
+
+    #[test]
+    fn test_cli_rejects_invalid_json() {
+        let result = serde_json::from_str::<EvidenceJson>("not json at all");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_validates_order_fill_fields() {
+        let valid = OrderFillData {
+            exchange_order_id: "123".to_string(),
+            fill_price: "95000.50".to_string(),
+            filled_quantity: "0.010".to_string(),
+            fee: "0.95".to_string(),
+            fee_asset: "USDT".to_string(),
+            filled_at: "2026-05-09T14:30:00Z".to_string(),
+        };
+        assert!(validate_order_fill(&valid).is_ok());
+
+        let mut bad = valid.clone();
+        bad.fill_price = "-1.0".to_string();
+        assert!(validate_order_fill(&bad).is_err());
+
+        let mut bad2 = valid.clone();
+        bad2.fee_asset = "".to_string();
+        assert!(validate_order_fill(&bad2).is_err());
+
+        let mut bad3 = valid.clone();
+        bad3.filled_at = "not-a-date".to_string();
+        assert!(validate_order_fill(&bad3).is_err());
+
+        let mut bad4 = valid.clone();
+        bad4.exchange_order_id = "".to_string();
+        assert!(validate_order_fill(&bad4).is_err());
+    }
+}

--- a/v3/robson-cli/src/commands/reconcile_close.rs
+++ b/v3/robson-cli/src/commands/reconcile_close.rs
@@ -67,11 +67,8 @@ pub struct UserTradeData {
 }
 
 pub fn validate_order_fill(data: &OrderFillData) -> Result<()> {
-    let price: Decimal = data
-        .fill_price
-        .parse()
-        .ok()
-        .context("fill_price is not a valid decimal")?;
+    let price: Decimal =
+        data.fill_price.parse().ok().context("fill_price is not a valid decimal")?;
     if price <= Decimal::ZERO {
         bail!("fill_price must be > 0");
     }
@@ -85,11 +82,7 @@ pub fn validate_order_fill(data: &OrderFillData) -> Result<()> {
         bail!("filled_quantity must be > 0");
     }
 
-    let fee: Decimal = data
-        .fee
-        .parse()
-        .ok()
-        .context("fee is not a valid decimal")?;
+    let fee: Decimal = data.fee.parse().ok().context("fee is not a valid decimal")?;
     if fee < Decimal::ZERO {
         bail!("fee must be >= 0");
     }
@@ -135,11 +128,10 @@ async fn run_inner(args: ReconcileCloseArgs) -> Result<i32, i32> {
         eprintln!("error: failed to read {}: {e}", args.evidence_file.display());
         EXIT_GENERIC_ERROR
     })?;
-    let evidence: EvidenceJson =
-        serde_json::from_str(&raw).map_err(|_| {
-            eprintln!("error: invalid evidence JSON");
-            EXIT_USAGE_ERROR
-        })?;
+    let evidence: EvidenceJson = serde_json::from_str(&raw).map_err(|_| {
+        eprintln!("error: invalid evidence JSON");
+        EXIT_USAGE_ERROR
+    })?;
 
     match &evidence {
         EvidenceJson::AccountSnapshot(_) => {
@@ -170,10 +162,8 @@ async fn run_inner(args: ReconcileCloseArgs) -> Result<i32, i32> {
         },
     }
 
-    let request_body = api_client::ReconcileCloseRequest {
-        position_id: args.position_id,
-        evidence,
-    };
+    let request_body =
+        api_client::ReconcileCloseRequest { position_id: args.position_id, evidence };
 
     let client = api_client::ApiClient::new(&args.robsond_url, args.token.as_deref());
     let response = client.reconcile_close(request_body).await.map_err(|e| {
@@ -194,20 +184,14 @@ async fn run_inner(args: ReconcileCloseArgs) -> Result<i32, i32> {
             Err(EXIT_NOT_FOUND)
         },
         api_client::ReconcileCloseResponse::NotActive(resp) => {
-            eprintln!(
-                "position not active: {} (current_state={})",
-                resp.error, resp.current_state
-            );
+            eprintln!("position not active: {} (current_state={})", resp.error, resp.current_state);
             Err(EXIT_NOT_ACTIVE)
         },
         api_client::ReconcileCloseResponse::Inconsistent(resp) => {
             eprintln!(
                 "inconsistent evidence: {}{}",
                 resp.error,
-                resp.details
-                    .as_ref()
-                    .map(|d| format!(" — {d}"))
-                    .unwrap_or_default()
+                resp.details.as_ref().map(|d| format!(" — {d}")).unwrap_or_default()
             );
             Err(EXIT_INCONSISTENT)
         },
@@ -215,10 +199,7 @@ async fn run_inner(args: ReconcileCloseArgs) -> Result<i32, i32> {
             eprintln!(
                 "unsupported evidence: {}{}",
                 resp.error,
-                resp.details
-                    .as_ref()
-                    .map(|d| format!(" — {d}"))
-                    .unwrap_or_default()
+                resp.details.as_ref().map(|d| format!(" — {d}")).unwrap_or_default()
             );
             Err(EXIT_USAGE_ERROR)
         },
@@ -231,9 +212,11 @@ async fn run_inner(args: ReconcileCloseArgs) -> Result<i32, i32> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::io::Write as IoWrite;
+
     use tempfile::NamedTempFile;
+
+    use super::*;
 
     fn write_evidence_file(content: &str) -> NamedTempFile {
         let mut f = NamedTempFile::new().unwrap();

--- a/v3/robson-cli/src/main.rs
+++ b/v3/robson-cli/src/main.rs
@@ -1,0 +1,19 @@
+mod api_client;
+mod commands;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "robson-cli", version, about = "Operational CLI for Robson daemon")]
+enum Cli {
+    ReconcileClose(commands::reconcile_close::ReconcileCloseArgs),
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    let code = match cli {
+        Cli::ReconcileClose(args) => commands::reconcile_close::run(args).await,
+    };
+    std::process::exit(code);
+}

--- a/v3/robson-cli/src/main.rs
+++ b/v3/robson-cli/src/main.rs
@@ -4,7 +4,11 @@ mod commands;
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(name = "robson-cli", version, about = "Operational CLI for Robson daemon")]
+#[command(
+    name = "robson-cli",
+    version,
+    about = "Operational CLI for Robson daemon"
+)]
 enum Cli {
     ReconcileClose(commands::reconcile_close::ReconcileCloseArgs),
 }

--- a/v3/robsond/src/api.rs
+++ b/v3/robsond/src/api.rs
@@ -285,6 +285,36 @@ pub struct ErrorResponse {
 }
 
 // =============================================================================
+// Reconcile Close Types (Slice 5B1)
+// =============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct ReconcileCloseRequest {
+    pub position_id: Uuid,
+    pub evidence: robson_domain::ReconciliationEvidence,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReconcileCloseSuccessResponse {
+    pub status: String,
+    pub position_id: Uuid,
+    pub realized_pnl: String,
+    pub exit_price: String,
+    pub closure_evidence: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReconcileCloseErrorResponse {
+    pub error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_state: Option<String>,
+}
+
+// =============================================================================
 // Safety Net Types
 // =============================================================================
 
@@ -433,6 +463,8 @@ where
         .route("/panic", post(panic_handler))
         // MonthlyHalt trigger (mutating)
         .route("/monthly-halt", post(monthly_halt_trigger_handler))
+        // Manual reconciliation close (Slice 5B1)
+        .route("/reconcile-close", post(reconcile_close_handler))
         .layer(auth_layer)
         .with_state(state);
 
@@ -921,6 +953,183 @@ where
         query_id: query.id,
         state: format!("{:?}", query.state),
     }))
+}
+
+/// `POST /reconcile-close` — operator-driven manual reconciliation close.
+///
+/// Accepts real evidence (`OrderFillRecord` or `UserTradeRecord`) and closes
+/// a stale-Active position. Rejects `AccountSnapshot` and `Estimated` in
+/// Slice 5B1.
+async fn reconcile_close_handler<E, S>(
+    State(state): State<Arc<ApiState<E, S>>>,
+    Json(req): Json<ReconcileCloseRequest>,
+) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<serde_json::Value>)>
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    use robson_domain::ReconciliationEvidence;
+
+    // Reject unsupported evidence types before touching position manager.
+    match &req.evidence {
+        ReconciliationEvidence::AccountSnapshot(_) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::to_value(ReconcileCloseErrorResponse {
+                    error: "unsupported_evidence".to_string(),
+                    details: Some(
+                        "account_snapshot evidence is not supported in Slice 5B1".to_string(),
+                    ),
+                    position_id: None,
+                    current_state: None,
+                })
+                .unwrap()),
+            ));
+        },
+        ReconciliationEvidence::Estimated(_) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::to_value(ReconcileCloseErrorResponse {
+                    error: "unsupported_evidence".to_string(),
+                    details: Some(
+                        "estimated evidence is not supported in Slice 5B1".to_string(),
+                    ),
+                    position_id: None,
+                    current_state: None,
+                })
+                .unwrap()),
+            ));
+        },
+        _ => {},
+    }
+
+    // Build ReconciledCloseInput from the request evidence.
+    let (exit_price, filled_quantity, fee, fee_asset, closed_at) = match &req.evidence {
+        ReconciliationEvidence::OrderFillRecord(e) => {
+            (e.fill_price, e.filled_quantity, e.fee, e.fee_asset.clone(), e.filled_at)
+        },
+        ReconciliationEvidence::UserTradeRecord(e) => {
+            (e.fill_price, e.filled_quantity, e.fee, e.fee_asset.clone(), e.filled_at)
+        },
+        _ => unreachable!("guarded above"),
+    };
+
+    let input = crate::position_manager::ReconciledCloseInput {
+        position_id: req.position_id,
+        exit_price,
+        filled_quantity,
+        fee,
+        fee_asset,
+        closed_at,
+        evidence: req.evidence,
+    };
+
+    let manager = state.position_manager.write().await;
+    let outcome = manager.reconcile_close(input).await.map_err(|e| match e {
+        DaemonError::PositionNotFound(id) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::to_value(ReconcileCloseErrorResponse {
+                error: "position_not_found".to_string(),
+                details: None,
+                position_id: Some(id),
+                current_state: None,
+            })
+            .unwrap()),
+        ),
+        other => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": other.to_string() })),
+        ),
+    })?;
+
+    match outcome {
+        crate::position_manager::ReconcileCloseOutcome::Closed => {
+            // Reload position to get the realized PnL from state.
+            let position = manager
+                .get_position(req.position_id)
+                .await
+                .ok()
+                .flatten();
+            let (realized_pnl, exit_price_val, closure_evidence) = match &position {
+                Some(p) => match &p.state {
+                    PositionState::Closed { realized_pnl, exit_price: ep, exit_reason, .. } => {
+                        let ce = serde_json::json!({
+                            "kind": "reconciled",
+                            "exit_reason": format!("{:?}", exit_reason),
+                        });
+                        (*realized_pnl, ep.as_decimal(), ce)
+                    },
+                    _ => (rust_decimal::Decimal::ZERO, rust_decimal::Decimal::ZERO, serde_json::json!({})),
+                },
+                None => (rust_decimal::Decimal::ZERO, rust_decimal::Decimal::ZERO, serde_json::json!({})),
+            };
+            let resp = ReconcileCloseSuccessResponse {
+                status: "closed".to_string(),
+                position_id: req.position_id,
+                realized_pnl: realized_pnl.to_string(),
+                exit_price: exit_price_val.to_string(),
+                closure_evidence,
+            };
+            Ok((StatusCode::OK, Json(serde_json::to_value(resp).unwrap())))
+        },
+        crate::position_manager::ReconcileCloseOutcome::AlreadyTerminal => {
+            // Reload to report current state.
+            let current_state = manager
+                .get_position(req.position_id)
+                .await
+                .ok()
+                .flatten()
+                .map(|p| p.state.name().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            Err((
+                StatusCode::CONFLICT,
+                Json(serde_json::to_value(ReconcileCloseErrorResponse {
+                    error: "position_not_active".to_string(),
+                    details: Some("Position is already terminal".to_string()),
+                    position_id: Some(req.position_id),
+                    current_state: Some(current_state),
+                })
+                .unwrap()),
+            ))
+        },
+        crate::position_manager::ReconcileCloseOutcome::SkippedNonActive { state } => Err((
+            StatusCode::CONFLICT,
+            Json(serde_json::to_value(ReconcileCloseErrorResponse {
+                error: "position_not_active".to_string(),
+                details: Some(format!("Position is in {} state, expected Active", state)),
+                position_id: Some(req.position_id),
+                current_state: Some(state),
+            })
+            .unwrap()),
+        )),
+        crate::position_manager::ReconcileCloseOutcome::RejectedUnsupportedEvidence { source } => {
+            Err((
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::to_value(ReconcileCloseErrorResponse {
+                    error: "unsupported_evidence".to_string(),
+                    details: Some(format!(
+                        "{} evidence is not supported in Slice 5B1",
+                        source
+                    )),
+                    position_id: None,
+                    current_state: None,
+                })
+                .unwrap()),
+            ))
+        },
+        crate::position_manager::ReconcileCloseOutcome::RejectedInconsistentEvidence { field } => {
+            Err((
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::to_value(ReconcileCloseErrorResponse {
+                    error: "inconsistent_evidence".to_string(),
+                    details: Some(format!("field={} mismatches evidence", field)),
+                    position_id: Some(req.position_id),
+                    current_state: None,
+                })
+                .unwrap()),
+            ))
+        },
+    }
 }
 
 // =============================================================================

--- a/v3/robsond/src/api.rs
+++ b/v3/robsond/src/api.rs
@@ -1007,6 +1007,21 @@ where
         _ => {},
     }
 
+    if let Err(details) = validate_reconcile_close_evidence(&req.evidence) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(
+                serde_json::to_value(ReconcileCloseErrorResponse {
+                    error: "invalid_evidence".to_string(),
+                    details: Some(details),
+                    position_id: Some(req.position_id),
+                    current_state: None,
+                })
+                .unwrap(),
+            ),
+        ));
+    }
+
     // Build ReconciledCloseInput from the request evidence.
     let (exit_price, filled_quantity, fee, fee_asset, closed_at) = match &req.evidence {
         ReconciliationEvidence::OrderFillRecord(e) => {
@@ -1017,6 +1032,9 @@ where
         },
         _ => unreachable!("guarded above"),
     };
+
+    let closure_evidence_for_response =
+        robson_domain::ClosureEvidence::Reconciled(req.evidence.clone());
 
     let input = crate::position_manager::ReconciledCloseInput {
         position_id: req.position_id,
@@ -1054,16 +1072,8 @@ where
             let position = manager.get_position(req.position_id).await.ok().flatten();
             let (realized_pnl, exit_price_val, closure_evidence) = match &position {
                 Some(p) => match &p.state {
-                    PositionState::Closed {
-                        realized_pnl,
-                        exit_price: ep,
-                        exit_reason,
-                        ..
-                    } => {
-                        let ce = serde_json::json!({
-                            "kind": "reconciled",
-                            "exit_reason": format!("{:?}", exit_reason),
-                        });
+                    PositionState::Closed { realized_pnl, exit_price: ep, .. } => {
+                        let ce = serde_json::to_value(&closure_evidence_for_response).unwrap();
                         (*realized_pnl, ep.as_decimal(), ce)
                     },
                     _ => (
@@ -1150,6 +1160,61 @@ where
             ))
         },
     }
+}
+
+fn validate_reconcile_close_evidence(
+    evidence: &robson_domain::ReconciliationEvidence,
+) -> Result<(), String> {
+    use robson_domain::ReconciliationEvidence;
+
+    match evidence {
+        ReconciliationEvidence::OrderFillRecord(e) => validate_reconcile_close_fields(
+            e.fill_price.as_decimal(),
+            e.filled_quantity.as_decimal(),
+            e.fee,
+            &e.fee_asset,
+            &e.exchange_order_id,
+            None,
+        ),
+        ReconciliationEvidence::UserTradeRecord(e) => validate_reconcile_close_fields(
+            e.fill_price.as_decimal(),
+            e.filled_quantity.as_decimal(),
+            e.fee,
+            &e.fee_asset,
+            &e.exchange_order_id,
+            Some(&e.exchange_trade_id),
+        ),
+        ReconciliationEvidence::AccountSnapshot(_) | ReconciliationEvidence::Estimated(_) => Ok(()),
+    }
+}
+
+fn validate_reconcile_close_fields(
+    fill_price: Decimal,
+    filled_quantity: Decimal,
+    fee: Decimal,
+    fee_asset: &str,
+    exchange_order_id: &str,
+    exchange_trade_id: Option<&str>,
+) -> Result<(), String> {
+    if fill_price <= Decimal::ZERO {
+        return Err("fill_price must be > 0".to_string());
+    }
+    if filled_quantity <= Decimal::ZERO {
+        return Err("filled_quantity must be > 0".to_string());
+    }
+    if fee < Decimal::ZERO {
+        return Err("fee must be >= 0".to_string());
+    }
+    if fee_asset.is_empty() {
+        return Err("fee_asset must not be empty".to_string());
+    }
+    if exchange_order_id.is_empty() {
+        return Err("exchange_order_id must not be empty".to_string());
+    }
+    if matches!(exchange_trade_id, Some("")) {
+        return Err("exchange_trade_id must not be empty".to_string());
+    }
+    Ok(())
 }
 
 // =============================================================================
@@ -2320,6 +2385,9 @@ mod tests {
         let resp: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
         assert_eq!(resp["status"], "closed");
         assert_eq!(resp["position_id"], pos.id.to_string());
+        assert_eq!(resp["closure_evidence"]["kind"], "reconciled");
+        assert_eq!(resp["closure_evidence"]["evidence"]["source"], "order_fill_record");
+        assert_eq!(resp["closure_evidence"]["evidence"]["data"]["exchange_order_id"], "ORD-1");
     }
 
     #[tokio::test]
@@ -2349,6 +2417,9 @@ mod tests {
         let resp_body = response.into_body().collect().await.unwrap().to_bytes();
         let resp: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
         assert_eq!(resp["status"], "closed");
+        assert_eq!(resp["closure_evidence"]["kind"], "reconciled");
+        assert_eq!(resp["closure_evidence"]["evidence"]["source"], "user_trade_record");
+        assert_eq!(resp["closure_evidence"]["evidence"]["data"]["exchange_trade_id"], "TRADE-1");
     }
 
     #[tokio::test]
@@ -2414,20 +2485,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reconcile_close_api_inconsistent_evidence() {
+    async fn test_reconcile_close_api_rejects_invalid_real_evidence_fields() {
         let (app, _event_bus, pm) = create_test_app_with_event_bus(100).await;
         let pos =
             save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
 
-        // Evidence says fill_price=90, but the serialized ReconciliationEvidence
-        // will have fill_price=90. The input to reconcile_close will use the
-        // evidence's fill_price as exit_price. But we're testing the API-level
-        // deserialization — the inconsistency test needs a mismatch between
-        // the request's implicit exit_price and the evidence.
-        // Since the API derives exit_price from the evidence, there's no way
-        // to create inconsistency at the API layer alone. Instead, we test
-        // that a valid close works and the idempotent 409 is returned.
-        // For actual inconsistent evidence, that's tested in position_manager tests.
+        let body = serde_json::json!({
+            "position_id": pos.id,
+            "evidence": make_order_fill_evidence_json("-1", "1")
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let resp_body = response.into_body().collect().await.unwrap().to_bytes();
+        let resp: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(resp["error"], "invalid_evidence");
+        assert_eq!(resp["details"], "fill_price must be > 0");
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_close_api_second_call_conflicts_after_close() {
+        let (app, _event_bus, pm) = create_test_app_with_event_bus(100).await;
+        let pos =
+            save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
 
         // First close succeeds
         let body = serde_json::json!({

--- a/v3/robsond/src/api.rs
+++ b/v3/robsond/src/api.rs
@@ -1537,7 +1537,7 @@ mod tests {
         http::{header::CONTENT_TYPE, Request},
     };
     use http_body_util::BodyExt;
-    use robson_domain::{RiskConfig, TechnicalStopDistance, TradingPolicy};
+    use robson_domain::{Quantity, RiskConfig, TechnicalStopDistance, TradingPolicy};
     use robson_engine::Engine;
     use robson_exec::{Executor, IntentJournal, StubExchange};
     use robson_store::MemoryStore;
@@ -2202,5 +2202,426 @@ mod tests {
         );
         let _ = build_cors_layer();
         std::env::remove_var("ROBSON_CORS_ALLOWED_ORIGINS");
+    }
+
+    // =========================================================================
+    // Reconcile Close API Tests (Slice 5B1)
+    // =========================================================================
+
+    async fn save_active_position_for_api(
+        position_manager: &Arc<RwLock<PositionManager<StubExchange, MemoryStore>>>,
+        symbol: &str,
+        side: Side,
+        entry_price: Decimal,
+        quantity: Decimal,
+    ) -> Position {
+        let account_id = Uuid::now_v7();
+        let symbol = Symbol::from_pair(symbol).unwrap();
+        let entry_price = Price::new(entry_price).unwrap();
+        let trailing_stop = match side {
+            Side::Long => Price::new(entry_price.as_decimal() - dec!(10)).unwrap(),
+            Side::Short => Price::new(entry_price.as_decimal() + dec!(10)).unwrap(),
+        };
+        let quantity = Quantity::new(quantity).unwrap();
+        let now = chrono::Utc::now();
+
+        let mut position = Position::new(account_id, symbol, side);
+        position.entry_price = Some(entry_price);
+        position.entry_filled_at = Some(now);
+        position.quantity = quantity;
+        position.state = PositionState::Active {
+            current_price: entry_price,
+            trailing_stop,
+            favorable_extreme: entry_price,
+            extreme_at: now,
+            insurance_stop_id: None,
+            last_emitted_stop: None,
+        };
+        position.updated_at = now;
+
+        position_manager
+            .read()
+            .await
+            .store()
+            .positions()
+            .save(&position)
+            .await
+            .unwrap();
+        position
+    }
+
+    fn make_order_fill_evidence_json(exit_price: &str, quantity: &str) -> serde_json::Value {
+        serde_json::json!({
+            "source": "order_fill_record",
+            "data": {
+                "exchange_order_id": "ORD-1",
+                "fill_price": exit_price,
+                "filled_quantity": quantity,
+                "fee": "0.01",
+                "fee_asset": "USDT",
+                "filled_at": "2026-05-09T14:30:00Z"
+            }
+        })
+    }
+
+    fn make_user_trade_evidence_json(exit_price: &str, quantity: &str) -> serde_json::Value {
+        serde_json::json!({
+            "source": "user_trade_record",
+            "data": {
+                "exchange_order_id": "ORD-2",
+                "exchange_trade_id": "TRADE-1",
+                "fill_price": exit_price,
+                "filled_quantity": quantity,
+                "fee": "0.01",
+                "fee_asset": "USDT",
+                "filled_at": "2026-05-09T14:30:00Z"
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_close_api_success_order_fill() {
+        let (app, _event_bus, pm) = create_test_app_with_event_bus(100).await;
+        let pos = save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
+
+        let body = serde_json::json!({
+            "position_id": pos.id,
+            "evidence": make_order_fill_evidence_json("90", "1")
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let resp_body = response.into_body().collect().await.unwrap().to_bytes();
+        let resp: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(resp["status"], "closed");
+        assert_eq!(resp["position_id"], pos.id.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_close_api_success_user_trade() {
+        let (app, _event_bus, pm) = create_test_app_with_event_bus(100).await;
+        let pos = save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
+
+        let body = serde_json::json!({
+            "position_id": pos.id,
+            "evidence": make_user_trade_evidence_json("90", "1")
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let resp_body = response.into_body().collect().await.unwrap().to_bytes();
+        let resp: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(resp["status"], "closed");
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_close_api_position_not_found() {
+        let (app, _event_bus, _pm) = create_test_app_with_event_bus(100).await;
+        let fake_id = Uuid::now_v7();
+
+        let body = serde_json::json!({
+            "position_id": fake_id,
+            "evidence": make_order_fill_evidence_json("90", "1")
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let resp_body = response.into_body().collect().await.unwrap().to_bytes();
+        let resp: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(resp["error"], "position_not_found");
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_close_api_position_not_active() {
+        let (app, _event_bus, pm) = create_test_app_with_event_bus(100).await;
+        // Save position in Armed state (not Active) — reconcile_close should
+        // reject it with SkippedNonActive.
+        let account_id = Uuid::now_v7();
+        let symbol = Symbol::from_pair("BTCUSDT").unwrap();
+        let mut pos = Position::new(account_id, symbol, Side::Long);
+        pos.updated_at = chrono::Utc::now();
+        pm.read()
+            .await
+            .store()
+            .positions()
+            .save(&pos)
+            .await
+            .unwrap();
+
+        let body = serde_json::json!({
+            "position_id": pos.id,
+            "evidence": make_order_fill_evidence_json("90", "1")
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let resp_body = response.into_body().collect().await.unwrap().to_bytes();
+        let resp: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(resp["error"], "position_not_active");
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_close_api_inconsistent_evidence() {
+        let (app, _event_bus, pm) = create_test_app_with_event_bus(100).await;
+        let pos = save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
+
+        // Evidence says fill_price=90, but the serialized ReconciliationEvidence
+        // will have fill_price=90. The input to reconcile_close will use the
+        // evidence's fill_price as exit_price. But we're testing the API-level
+        // deserialization — the inconsistency test needs a mismatch between
+        // the request's implicit exit_price and the evidence.
+        // Since the API derives exit_price from the evidence, there's no way
+        // to create inconsistency at the API layer alone. Instead, we test
+        // that a valid close works and the idempotent 409 is returned.
+        // For actual inconsistent evidence, that's tested in position_manager tests.
+
+        // First close succeeds
+        let body = serde_json::json!({
+            "position_id": pos.id,
+            "evidence": make_order_fill_evidence_json("90", "1")
+        });
+        let response = app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Second close returns 409 (idempotent — not active anymore)
+        let body2 = serde_json::json!({
+            "position_id": pos.id,
+            "evidence": make_order_fill_evidence_json("85", "1")
+        });
+        let response2 = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body2.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response2.status(), StatusCode::CONFLICT);
+        let resp_body = response2.into_body().collect().await.unwrap().to_bytes();
+        let resp: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(resp["error"], "position_not_active");
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_close_api_unauthorized() {
+        let (app_with_token, _event_bus, pm) = {
+            let exchange = Arc::new(StubExchange::new(dec!(95000)));
+            let journal = Arc::new(IntentJournal::new());
+            let store = Arc::new(MemoryStore::new());
+            let executor = Arc::new(Executor::new(exchange, journal, store.clone()));
+            let event_bus = Arc::new(crate::event_bus::EventBus::new(100));
+            let risk_config = RiskConfig::new(dec!(10000)).unwrap();
+            let engine = Engine::new(risk_config);
+            let manager = PositionManager::new(
+                engine,
+                executor,
+                store,
+                Arc::clone(&event_bus),
+                Arc::new(TracingQueryRecorder),
+                TradingPolicy::default(),
+            );
+            let position_manager = Arc::new(RwLock::new(manager));
+            let circuit_breaker = position_manager.read().await.circuit_breaker();
+
+            let state = Arc::new(ApiState {
+                position_manager: Arc::clone(&position_manager),
+                event_bus: Arc::clone(&event_bus),
+                circuit_breaker,
+                position_monitor: None,
+                #[cfg(feature = "postgres")]
+                pg_pool: None,
+                #[cfg(feature = "postgres")]
+                tenant_id: None,
+                api_token: Some("secret-token-123".to_string()),
+            });
+
+            (create_router(state), event_bus, position_manager)
+        };
+
+        let _pos = save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
+
+        let body = serde_json::json!({
+            "position_id": Uuid::now_v7(),
+            "evidence": make_order_fill_evidence_json("90", "1")
+        });
+
+        let response = app_with_token
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_close_api_idempotent() {
+        let (app, _event_bus, pm) = create_test_app_with_event_bus(100).await;
+        let pos = save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
+
+        let body = serde_json::json!({
+            "position_id": pos.id,
+            "evidence": make_order_fill_evidence_json("90", "1")
+        });
+
+        // First call closes
+        let r1 = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r1.status(), StatusCode::OK);
+
+        // Second call returns 409
+        let r2 = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r2.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_close_api_rejects_account_snapshot() {
+        let (app, _event_bus, _pm) = create_test_app_with_event_bus(100).await;
+
+        let body = serde_json::json!({
+            "position_id": Uuid::now_v7(),
+            "evidence": {
+                "source": "account_snapshot",
+                "data": {
+                    "first_observed_missing_at": "2026-05-09T14:00:00Z",
+                    "confirmed_missing_at": "2026-05-09T14:01:00Z"
+                }
+            }
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let resp_body = response.into_body().collect().await.unwrap().to_bytes();
+        let resp: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(resp["error"], "unsupported_evidence");
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_close_api_rejects_estimated() {
+        let (app, _event_bus, _pm) = create_test_app_with_event_bus(100).await;
+
+        let body = serde_json::json!({
+            "position_id": Uuid::now_v7(),
+            "evidence": {
+                "source": "estimated",
+                "data": {
+                    "estimation_basis": "trailing_stop_at_detection",
+                    "exit_price": "95000.00",
+                    "evaluator": "op:ldamasio",
+                    "detected_at": "2026-05-09T14:30:00Z"
+                }
+            }
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/reconcile-close")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let resp_body = response.into_body().collect().await.unwrap().to_bytes();
+        let resp: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+        assert_eq!(resp["error"], "unsupported_evidence");
     }
 }

--- a/v3/robsond/src/api.rs
+++ b/v3/robsond/src/api.rs
@@ -975,29 +975,33 @@ where
         ReconciliationEvidence::AccountSnapshot(_) => {
             return Err((
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::to_value(ReconcileCloseErrorResponse {
-                    error: "unsupported_evidence".to_string(),
-                    details: Some(
-                        "account_snapshot evidence is not supported in Slice 5B1".to_string(),
-                    ),
-                    position_id: None,
-                    current_state: None,
-                })
-                .unwrap()),
+                Json(
+                    serde_json::to_value(ReconcileCloseErrorResponse {
+                        error: "unsupported_evidence".to_string(),
+                        details: Some(
+                            "account_snapshot evidence is not supported in Slice 5B1".to_string(),
+                        ),
+                        position_id: None,
+                        current_state: None,
+                    })
+                    .unwrap(),
+                ),
             ));
         },
         ReconciliationEvidence::Estimated(_) => {
             return Err((
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::to_value(ReconcileCloseErrorResponse {
-                    error: "unsupported_evidence".to_string(),
-                    details: Some(
-                        "estimated evidence is not supported in Slice 5B1".to_string(),
-                    ),
-                    position_id: None,
-                    current_state: None,
-                })
-                .unwrap()),
+                Json(
+                    serde_json::to_value(ReconcileCloseErrorResponse {
+                        error: "unsupported_evidence".to_string(),
+                        details: Some(
+                            "estimated evidence is not supported in Slice 5B1".to_string(),
+                        ),
+                        position_id: None,
+                        current_state: None,
+                    })
+                    .unwrap(),
+                ),
             ));
         },
         _ => {},
@@ -1028,13 +1032,15 @@ where
     let outcome = manager.reconcile_close(input).await.map_err(|e| match e {
         DaemonError::PositionNotFound(id) => (
             StatusCode::NOT_FOUND,
-            Json(serde_json::to_value(ReconcileCloseErrorResponse {
-                error: "position_not_found".to_string(),
-                details: None,
-                position_id: Some(id),
-                current_state: None,
-            })
-            .unwrap()),
+            Json(
+                serde_json::to_value(ReconcileCloseErrorResponse {
+                    error: "position_not_found".to_string(),
+                    details: None,
+                    position_id: Some(id),
+                    current_state: None,
+                })
+                .unwrap(),
+            ),
         ),
         other => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1045,23 +1051,32 @@ where
     match outcome {
         crate::position_manager::ReconcileCloseOutcome::Closed => {
             // Reload position to get the realized PnL from state.
-            let position = manager
-                .get_position(req.position_id)
-                .await
-                .ok()
-                .flatten();
+            let position = manager.get_position(req.position_id).await.ok().flatten();
             let (realized_pnl, exit_price_val, closure_evidence) = match &position {
                 Some(p) => match &p.state {
-                    PositionState::Closed { realized_pnl, exit_price: ep, exit_reason, .. } => {
+                    PositionState::Closed {
+                        realized_pnl,
+                        exit_price: ep,
+                        exit_reason,
+                        ..
+                    } => {
                         let ce = serde_json::json!({
                             "kind": "reconciled",
                             "exit_reason": format!("{:?}", exit_reason),
                         });
                         (*realized_pnl, ep.as_decimal(), ce)
                     },
-                    _ => (rust_decimal::Decimal::ZERO, rust_decimal::Decimal::ZERO, serde_json::json!({})),
+                    _ => (
+                        rust_decimal::Decimal::ZERO,
+                        rust_decimal::Decimal::ZERO,
+                        serde_json::json!({}),
+                    ),
                 },
-                None => (rust_decimal::Decimal::ZERO, rust_decimal::Decimal::ZERO, serde_json::json!({})),
+                None => (
+                    rust_decimal::Decimal::ZERO,
+                    rust_decimal::Decimal::ZERO,
+                    serde_json::json!({}),
+                ),
             };
             let resp = ReconcileCloseSuccessResponse {
                 status: "closed".to_string(),
@@ -1083,50 +1098,55 @@ where
                 .unwrap_or_else(|| "unknown".to_string());
             Err((
                 StatusCode::CONFLICT,
-                Json(serde_json::to_value(ReconcileCloseErrorResponse {
-                    error: "position_not_active".to_string(),
-                    details: Some("Position is already terminal".to_string()),
-                    position_id: Some(req.position_id),
-                    current_state: Some(current_state),
-                })
-                .unwrap()),
+                Json(
+                    serde_json::to_value(ReconcileCloseErrorResponse {
+                        error: "position_not_active".to_string(),
+                        details: Some("Position is already terminal".to_string()),
+                        position_id: Some(req.position_id),
+                        current_state: Some(current_state),
+                    })
+                    .unwrap(),
+                ),
             ))
         },
         crate::position_manager::ReconcileCloseOutcome::SkippedNonActive { state } => Err((
             StatusCode::CONFLICT,
-            Json(serde_json::to_value(ReconcileCloseErrorResponse {
-                error: "position_not_active".to_string(),
-                details: Some(format!("Position is in {} state, expected Active", state)),
-                position_id: Some(req.position_id),
-                current_state: Some(state),
-            })
-            .unwrap()),
+            Json(
+                serde_json::to_value(ReconcileCloseErrorResponse {
+                    error: "position_not_active".to_string(),
+                    details: Some(format!("Position is in {} state, expected Active", state)),
+                    position_id: Some(req.position_id),
+                    current_state: Some(state),
+                })
+                .unwrap(),
+            ),
         )),
         crate::position_manager::ReconcileCloseOutcome::RejectedUnsupportedEvidence { source } => {
             Err((
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::to_value(ReconcileCloseErrorResponse {
-                    error: "unsupported_evidence".to_string(),
-                    details: Some(format!(
-                        "{} evidence is not supported in Slice 5B1",
-                        source
-                    )),
-                    position_id: None,
-                    current_state: None,
-                })
-                .unwrap()),
+                Json(
+                    serde_json::to_value(ReconcileCloseErrorResponse {
+                        error: "unsupported_evidence".to_string(),
+                        details: Some(format!("{} evidence is not supported in Slice 5B1", source)),
+                        position_id: None,
+                        current_state: None,
+                    })
+                    .unwrap(),
+                ),
             ))
         },
         crate::position_manager::ReconcileCloseOutcome::RejectedInconsistentEvidence { field } => {
             Err((
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::to_value(ReconcileCloseErrorResponse {
-                    error: "inconsistent_evidence".to_string(),
-                    details: Some(format!("field={} mismatches evidence", field)),
-                    position_id: Some(req.position_id),
-                    current_state: None,
-                })
-                .unwrap()),
+                Json(
+                    serde_json::to_value(ReconcileCloseErrorResponse {
+                        error: "inconsistent_evidence".to_string(),
+                        details: Some(format!("field={} mismatches evidence", field)),
+                        position_id: Some(req.position_id),
+                        current_state: None,
+                    })
+                    .unwrap(),
+                ),
             ))
         },
     }
@@ -2239,14 +2259,7 @@ mod tests {
         };
         position.updated_at = now;
 
-        position_manager
-            .read()
-            .await
-            .store()
-            .positions()
-            .save(&position)
-            .await
-            .unwrap();
+        position_manager.read().await.store().positions().save(&position).await.unwrap();
         position
     }
 
@@ -2282,7 +2295,8 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_close_api_success_order_fill() {
         let (app, _event_bus, pm) = create_test_app_with_event_bus(100).await;
-        let pos = save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
+        let pos =
+            save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
 
         let body = serde_json::json!({
             "position_id": pos.id,
@@ -2311,7 +2325,8 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_close_api_success_user_trade() {
         let (app, _event_bus, pm) = create_test_app_with_event_bus(100).await;
-        let pos = save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
+        let pos =
+            save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
 
         let body = serde_json::json!({
             "position_id": pos.id,
@@ -2373,13 +2388,7 @@ mod tests {
         let symbol = Symbol::from_pair("BTCUSDT").unwrap();
         let mut pos = Position::new(account_id, symbol, Side::Long);
         pos.updated_at = chrono::Utc::now();
-        pm.read()
-            .await
-            .store()
-            .positions()
-            .save(&pos)
-            .await
-            .unwrap();
+        pm.read().await.store().positions().save(&pos).await.unwrap();
 
         let body = serde_json::json!({
             "position_id": pos.id,
@@ -2407,7 +2416,8 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_close_api_inconsistent_evidence() {
         let (app, _event_bus, pm) = create_test_app_with_event_bus(100).await;
-        let pos = save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
+        let pos =
+            save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
 
         // Evidence says fill_price=90, but the serialized ReconciliationEvidence
         // will have fill_price=90. The input to reconcile_close will use the
@@ -2424,7 +2434,8 @@ mod tests {
             "position_id": pos.id,
             "evidence": make_order_fill_evidence_json("90", "1")
         });
-        let response = app.clone()
+        let response = app
+            .clone()
             .oneshot(
                 Request::builder()
                     .method("POST")
@@ -2495,7 +2506,8 @@ mod tests {
             (create_router(state), event_bus, position_manager)
         };
 
-        let _pos = save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
+        let _pos =
+            save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
 
         let body = serde_json::json!({
             "position_id": Uuid::now_v7(),
@@ -2520,7 +2532,8 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_close_api_idempotent() {
         let (app, _event_bus, pm) = create_test_app_with_event_bus(100).await;
-        let pos = save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
+        let pos =
+            save_active_position_for_api(&pm, "BTCUSDT", Side::Long, dec!(100), dec!(1)).await;
 
         let body = serde_json::json!({
             "position_id": pos.id,


### PR DESCRIPTION
## Summary

Implements Slice 5B1 of `TD-2026-05-05-001 - Core Position Lifecycle Drift`.

This PR adds the manual recovery path for stale-Active positions:

* new `robson-cli` crate;
* `robson-cli reconcile-close` command;
* `POST /reconcile-close` endpoint in `robsond`;
* operator-driven close using real evidence only;
* runbook updated with real command, samples and exit codes.

## Scope

This PR implements only Slice 5B1: manual recovery.

Included:

* `OrderFillRecord` evidence support;
* `UserTradeRecord` evidence support;
* CLI-side evidence validation;
* API-side evidence validation;
* Bearer-auth protected mutating endpoint;
* API response with full `ClosureEvidence::Reconciled(...)`;
* rejection of invalid real evidence fields;
* rejection of unsupported evidence sources;
* runbook update.

Explicitly not included:

* no startup `auto_reconcile`;
* no `AccountSnapshot` support;
* no `Estimated` support;
* no frontend changes;
* no changes to `ReconciliationWorker`;
* no changes to `PositionManager::reconcile_close`;
* no changes to domain evidence types.

## Safety notes

The manual close path only accepts real evidence:

* `order_fill_record`;
* `user_trade_record`.

The following are rejected by both CLI and API:

* `account_snapshot`;
* `estimated`.

The API also rejects invalid real evidence fields:

* `fill_price <= 0`;
* `filled_quantity <= 0`;
* `fee < 0`;
* empty `fee_asset`;
* empty `exchange_order_id`;
* empty `exchange_trade_id` for user trade evidence.

## Tests and checks

Validated:

- `cargo +nightly fmt --all --check`
- `cargo test -p robson-cli`
- `cargo test -p robsond --lib reconcile_close_api`
- `cargo test -p robsond --lib`
- `cargo test -p robsond --tests --features postgres`
- `cargo clippy -p robson-cli --all-targets -- -D warnings`
- `cargo build --release -p robson-cli`

Known note:

- strict `clippy -D warnings` for `robsond` still reports preexisting warnings outside this slice. They were not changed in this PR.
