### PR TITLE
fix(docker): include robson-cli workspace member in robsond build

### DIFF
--- a/v3/Dockerfile
+++ b/v3/Dockerfile
@@ -24,6 +24,7 @@ COPY v3/robson-db/ ./robson-db/
 COPY v3/migrations/ ./migrations/
 COPY v3/robson-testkit/ ./robson-testkit/
 COPY v3/robson-sim/ ./robson-sim/
+COPY v3/robson-cli/ ./robson-cli/
 COPY v3/robsond/ ./robsond/
 
 # Build release binary with postgres feature for production
@@ -63,4 +64,3 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 
 # Run daemon
 CMD ["robsond"]
-


### PR DESCRIPTION
## Summary

Fixes the Robson deploy Docker build after adding `robson-cli` to the v3 Cargo workspace.

The production Dockerfile builds `robsond` from the workspace root, so every workspace member declared in `v3/Cargo.toml` must be present inside the image build context. `robson-cli` was added to the workspace in Slice 5B1 but was not copied into `/app`, causing Cargo to fail while loading the workspace.

## Change

- Adds `COPY v3/robson-cli/ ./robson-cli/` to `v3/Dockerfile`.

## Validation

- Ran Docker build with `-f ./v3/Dockerfile .`.
- Build passed the previous failure point.
- `cargo build --release -p robsond --features postgres` completed successfully inside the image.
- Final image layer write failed locally due to `no space left on device`, unrelated to the manifest fix.