### PR TITLE
docs(robson): update lifecycle drift execution memory

### DIFF
--- a/docs/adr/ADR-0022-robson-authored-position-invariant.md
+++ b/docs/adr/ADR-0022-robson-authored-position-invariant.md
@@ -1,8 +1,8 @@
 # ADR-0022 — Robson-Authored Position Invariant
 
 **Date**: 2026-04-18
-**Last Amended**: 2026-05-08 (I3 — Reverse Reconciliation; see Amendments)
-**Status**: DECIDED — FOLLOW-UP REQUIRED (reconciliation worker + close path are target architecture; reverse reconciliation per I3 in flight under TD-2026-05-05-001)
+**Last Amended**: 2026-05-11 (5B1 live + 5B2A merged; see Amendments)
+**Status**: DECIDED — IN PROGRESS (I3 runtime steady-state and startup abort live; manual recovery 5B1 live; startup auto_reconcile 5B2B planned)
 **Deciders**: RBX Systems (operator + architecture)
 
 ---
@@ -265,3 +265,20 @@ This ADR remains the canonical authority for the existence and
 non-negotiability of the invariant; the policy holds the operational
 detail and may evolve as I3's mechanics are refined without re-amending
 this ADR.
+
+### 2026-05-09 — Slice 5B1: manual recovery path live
+
+Operator-driven manual recovery is live via `robson-cli reconcile-close` and
+`POST /reconcile-close`. Runbook §Recovery Command is now operational for
+`OrderFillRecord` and `UserTradeRecord` evidence. `AccountSnapshot` and
+`Estimated` remain rejected for the operator-CLI path.
+
+### 2026-05-11 — Slice 5B2A: evidence helper refactor merged
+
+`reconciliation_worker.rs` evidence helpers refactored (no behavior change).
+Startup `auto_reconcile` (Slice 5B2B) remains planned.
+
+**Invariant preserved**: auto-close at startup requires real exchange evidence
+(`OrderFillRecord` or `UserTradeRecord`) and is all-or-nothing — any position
+lacking evidence aborts startup with exit 78, consistent with the Robson-authored
+position invariant's fail-closed guarantee.

--- a/docs/agents/td-2026-05-05-001-execution-memory.md
+++ b/docs/agents/td-2026-05-05-001-execution-memory.md
@@ -1,0 +1,89 @@
+# TD-2026-05-05-001 — Execution Memory
+
+**TD**: Core Position Lifecycle Drift
+**Last updated**: 2026-05-11
+**Scope**: `robsond` reconciliation — stale-Active positions not present on the exchange
+
+---
+
+## Current State
+
+| Slice | Description | Status | PR / Commit |
+|-------|-------------|--------|-------------|
+| 0 | Baseline reproduction test | DONE | commit `28b7a58e` |
+| 1 | Domain: `ClosureEvidence` + `ExitReason::ReconciledMissingOnExchange` | DONE | commit `fbdc8f0e` |
+| 2 | Policy I3 + ADR-0022 amendment + runbook skeleton | DONE | commit `6d999a09` |
+| 3 | `ExchangePort` evidence retrieval methods | DONE | commit `0835150b` |
+| 4A | `PositionManager::reconcile_close` with real evidence | DONE | commit `93db6bb9` |
+| 4B | Symmetric stale-Active reconciliation worker loop | DONE | commit `2a87fb8e` |
+| 5A | Startup abort gate, config, exit code 78 | DONE | commit `33877728` |
+| 5B1 | `robson-cli reconcile-close` + `POST /reconcile-close` | DONE | PR #60 |
+| Hotfix | Dockerfile: include `robson-cli` workspace member | DONE | PR #61, commit `1b275638` |
+| 5B2A | Evidence helper refactor in `reconciliation_worker.rs` | DONE | commits `20283d9e` + `26e82837` |
+| 5B2B | Startup `auto_reconcile` config + two-phase algorithm | PLANNED | — |
+| 5B2C | Runbook finalization + testnet drill | PLANNED | — |
+
+**`main` HEAD** (as of 2026-05-11): `26e82837`
+
+---
+
+## Architecture Decisions (do not reopen without escalation)
+
+### Startup policy
+- **`abort` is the default** and the safe baseline. No change planned.
+- **`auto_reconcile` is opt-in** via `ROBSON_RECONCILIATION_ON_STARTUP_STALE_ACTIVE=auto_reconcile`.
+- `auto_reconcile` is **two-phase / all-or-nothing**:
+  1. Detect all stale-Active positions.
+  2. Collect real evidence for each (`OrderFillRecord` or `UserTradeRecord`).
+  3. If any position lacks real evidence → abort with exit 78. No position closed.
+  4. If all have unambiguous real evidence → apply `reconcile_close` for all.
+
+### Evidence restrictions for startup auto-close
+- `OrderFillRecord` and `UserTradeRecord`: allowed for auto-close at startup.
+- `AccountSnapshot`: **not allowed** for startup auto-close.
+- `Estimated`: **never** auto-closes at startup — always downgrades to abort.
+
+### Operator-driven manual path (Slice 5B1)
+- Same evidence restriction: `OrderFillRecord` and `UserTradeRecord` only.
+- `POST /reconcile-close` + `robson-cli reconcile-close` are live.
+- Use this path for all startup-gate scenarios until 5B2B is merged.
+
+---
+
+## Next Implementation Sequence
+
+1. **5B2B** — implement `startup_reverse_reconciliation()` with two-phase logic.
+   Accept `auto_reconcile` in `StartupStaleActivePolicy` parser.
+   Add integration tests (happy path, Estimated-downgrade, partial-evidence abort).
+2. **5B2C** — finalize runbook Path C section. Execute testnet drill.
+3. Only after testnet drill passes → consider enabling `auto_reconcile` in production.
+
+---
+
+## Agent Roles
+
+| Agent | Role |
+|-------|------|
+| GLM | Implementation for small scoped slices (Rust code) |
+| Codex | Diff review before push/PR |
+| Sonnet | Orchestration, docs, planning |
+| Opus | Optional — high-risk architecture decisions only |
+
+---
+
+## Key Documents
+
+- [Implementation Guide](../implementation/TD-2026-05-05-001-CORE-LIFECYCLE-DRIFT.md) — slice plan, amendments, algorithm decisions
+- [Runbook](../runbooks/td-2026-05-05-001-stale-active-recovery.md) — operator recovery procedure (Paths A/B live, Path C planned)
+- [Policy I3](../policies/UNTRACKED-POSITION-RECONCILIATION.md) — I3 invariant text
+- [ADR-0022](../adr/ADR-0022-robson-authored-position-invariant.md) — invariant authority
+
+---
+
+## Open Questions / Blockers
+
+None blocking 5B2B. Preconditions before enabling `auto_reconcile` in production:
+
+- [ ] Slice 5B2B merged and CI green.
+- [ ] Testnet drill (Slice 5B2C) completed with successful outcome recorded in runbook Run Log.
+- [ ] Second authorized operator confirmed for first production `auto_reconcile` run.

--- a/docs/implementation/TD-2026-05-05-001-CORE-LIFECYCLE-DRIFT.md
+++ b/docs/implementation/TD-2026-05-05-001-CORE-LIFECYCLE-DRIFT.md
@@ -1,6 +1,6 @@
 # TD-2026-05-05-001 — Core Position Lifecycle Drift
 
-**Status**: In progress — Slices 0/1/2/3/4A/4B/5A done; Slice 5B next
+**Status**: In progress — Slices 0/1/2/3/4A/4B/5A/5B1/hotfix-docker/5B2A done; 5B2B/5B2C planned
 **Severity**: High
 **Area**: `robsond` reconciliation, position lifecycle
 **Discovered**: 2026-05-05
@@ -428,13 +428,106 @@ Tests added (210 lib tests passing):
 
 - **Commit**: `feat(robsond): startup gate abort path and config for stale-active drift (Slice 5A)`
 
-### Slice 5B — `auto_reconcile` path + robson-cli — NEXT
+### Slice 5B1 — `robson-cli reconcile-close` (operator-driven manual path) — DONE (2026-05-09, PR #60)
 
-- Implement Path B (`auto_reconcile`) per Amendment §3.
-- New CLI subcommand `robson-cli reconcile-close` for operator-driven closes
-  (Path A, operator-triggered).
-- **Tests**: integration (`#[sqlx::test]`) covering auto_reconcile path.
-- **Commit**: `feat(robsond): startup auto-reconcile path and operator CLI (Slice 5B)`
+Outcome:
+
+- New crate `v3/robson-cli` with `reconcile-close` subcommand.
+  Sends `POST /reconcile-close` to `robsond`; validates evidence shape
+  locally before the network call.
+- New `POST /reconcile-close` API endpoint in `robsond`.
+  Validates Bearer token, deserializes evidence, calls
+  `PositionManager::reconcile_close()`. Returns `realized_pnl` and
+  `exit_price` on success.
+- Only `OrderFillRecord` and `UserTradeRecord` evidence accepted.
+  `AccountSnapshot` and `Estimated` are rejected at both CLI and API level
+  (design decision: unambiguous real evidence only for operator-driven path).
+- Exit codes 0–6 documented in the runbook.
+- Runbook `docs/runbooks/td-2026-05-05-001-stale-active-recovery.md`
+  updated with sample commands and evidence JSON.
+
+Tests added (via `test(robsond): add /reconcile-close API tests`):
+API validation, evidence rejection, position-not-found (404), position-not-active
+(409), and evidence-inconsistent (400) paths covered.
+
+Scoped PR: #60.
+
+### Hotfix — Docker `robson-cli` workspace member — DONE (2026-05-09, PR #61)
+
+Outcome:
+
+- `v3/Dockerfile` updated to include `robson-cli` in the workspace build so
+  the `robson-cli` binary is present inside the `robsond` container image.
+- No algorithm change. Build-system fix only.
+- Commit `1b275638 fix(docker): include robson-cli workspace member in robsond build`.
+
+### Slice 5B2A — Evidence helper refactor in `reconciliation_worker.rs` — DONE (2026-05-11)
+
+Outcome:
+
+- Extracted shared evidence helper functions in
+  `v3/robsond/src/reconciliation_worker.rs` into dedicated private helpers.
+- Simplified the user-trade evidence helper (deduplication, cleaner logic).
+- **No behavior change.** Pure refactor — all existing tests continue passing.
+- Commits:
+  - `20283d9e refactor(robsond): extract reconciliation evidence helpers`
+  - `26e82837 refactor(robsond): simplify user trade evidence helper`
+
+5B2A is the preparatory refactor that makes `reconciliation_worker.rs` ready
+to receive the `auto_reconcile` startup logic in Slice 5B2B without conflating
+the refactor with the behavior change.
+
+---
+
+#### 5B2 Architectural Decision — Sub-slice breakdown and auto_reconcile algorithm
+
+5B is broken into three sub-slices:
+
+| Sub-slice | Scope | Status |
+|---|---|---|
+| 5B2A | Refactor evidence helpers — no behavior change | DONE |
+| 5B2B | Config + startup `auto_reconcile` opt-in algorithm | PLANNED |
+| 5B2C | Docs/runbook/testnet drill | PLANNED |
+
+**Startup `auto_reconcile` algorithm (for 5B2B) — two-phase / all-or-nothing:**
+
+1. Detect all stale-Active positions (same gate as the 5A abort path).
+2. Collect and validate real evidence for each position (`OrderFillRecord` or
+   `UserTradeRecord`) — no partial or estimated substitution.
+3. If any position lacks real unambiguous evidence → abort startup with exit
+   code 78 (same as `abort` policy). No position is closed.
+4. If all positions have real evidence → call `reconcile_close` for each.
+
+**Policy decisions for auto_reconcile (5B2B):**
+
+- `abort` remains the **default** and the safe baseline.
+- `auto_reconcile` is **opt-in** via
+  `ROBSON_RECONCILIATION_ON_STARTUP_STALE_ACTIVE = "auto_reconcile"`.
+- `auto_reconcile` may only auto-close using `OrderFillRecord` or
+  `UserTradeRecord`. No `AccountSnapshot` auto-close at startup.
+- `Estimated` evidence at startup always downgrades to `abort` behavior —
+  never auto-closes.
+- No partial closes: if any stale-Active lacks evidence, the entire startup
+  is aborted without closing any position.
+
+### Slice 5B2B — Startup `auto_reconcile` algorithm + config — PLANNED
+
+- Implement two-phase all-or-nothing `startup_reverse_reconciliation()`.
+- Accept `auto_reconcile` in `StartupStaleActivePolicy` (currently only
+  `abort` is parsed; unknown values produce a config error).
+- Add integration tests covering the auto_reconcile happy path, the
+  Estimated-downgrade path, and the partial-evidence abort path.
+- **Commit (suggested)**: `feat(robsond): startup auto-reconcile two-phase path (Slice 5B2B)`
+
+### Slice 5B2C — Runbook finalization + testnet drill — PLANNED
+
+- Finalize `docs/runbooks/td-2026-05-05-001-stale-active-recovery.md` with
+  the Path C (auto_reconcile) section and a drill checklist.
+- Execute one testnet drill (stale-Active seeded manually → daemon starts
+  with `auto_reconcile` → validates close outcome).
+- Only after testnet drill passes consider enabling `auto_reconcile` in
+  production config.
+- **Commit (suggested)**: `docs(runbooks): add auto_reconcile path and testnet drill checklist`
 
 ### Slice 6 — Slot/monthly accounting regression coverage
 
@@ -539,3 +632,6 @@ All asserted via `cargo test -p robsond` plus targeted Postgres tests under
 |---|---|---|
 | 2026-05-08 | Initial draft (Slice 0). Amendments §1, §2, §3 incorporated. | Claude Opus 4.7 |
 | 2026-05-09 | Slice 5A done: startup gate abort path, config, exit code 78, runbook. | Claude Sonnet 4.6 |
+| 2026-05-09 | Slice 5B1 done (PR #60): `robson-cli reconcile-close` + `POST /reconcile-close`. Operator-driven manual recovery live. | Claude Opus 4.7 |
+| 2026-05-09 | Hotfix done (PR #61): Dockerfile includes `robson-cli` workspace member. | Claude Sonnet 4.6 |
+| 2026-05-11 | Slice 5B2A done: evidence helper refactor in `reconciliation_worker.rs`. No behavior change. 5B2 architectural decision recorded (two-phase auto_reconcile algorithm, opt-in, all-or-nothing). 5B2B/5B2C marked PLANNED. | Claude Sonnet 4.6 |

--- a/docs/policies/UNTRACKED-POSITION-RECONCILIATION.md
+++ b/docs/policies/UNTRACKED-POSITION-RECONCILIATION.md
@@ -153,6 +153,31 @@ priority order**:
    the chosen `exit_price`, optional `evaluator` identity, and
    `detected_at`.
 
+#### I3 §E — Startup policy and operational status
+
+**Current operational state (as of 2026-05-11):**
+
+- I3 runtime steady-state reconciliation (worker loop) is **live** (Slice 4B).
+- Startup default is **fail-closed abort** — exit code 78 (Slice 5A).
+- Operator-driven manual recovery is **live** via `robson-cli reconcile-close`
+  and `POST /reconcile-close` (Slice 5B1). Accepts `OrderFillRecord` and
+  `UserTradeRecord` only.
+- Startup `auto_reconcile` is **planned** (Slice 5B2B) and is **not yet live**.
+
+**Rules for startup `auto_reconcile` (when it ships):**
+
+- Opt-in only: default remains `abort`.
+- Two-phase / all-or-nothing: collect evidence for all stale-Active positions
+  first; apply closes only if every position has real evidence.
+- Only `OrderFillRecord` or `UserTradeRecord` may auto-close positions at
+  startup. `AccountSnapshot` and `Estimated` do not qualify for startup
+  auto-close.
+- If any position lacks real evidence, abort with exit 78 (same as `abort`
+  policy). No partial close.
+
+Until Slice 5B2B is merged and validated via testnet drill (Slice 5B2C), use
+the operator manual path (Slice 5B1) for all startup-gate scenarios.
+
 #### I3 §D — Estimated evidence: never silent
 
 A reconciliation-close that reaches the `Estimated` branch MUST produce a
@@ -398,6 +423,8 @@ the reconciliation close is non-overridable.
 | Version | Date | Changes | Author |
 |---------|------|---------|--------|
 | 1.0 | 2026-04-18 | Initial policy creation | Engineering Team |
+| 1.1 | 2026-05-08 | Added §I3 — Reverse Reconciliation Invariant (TD-2026-05-05-001). | Claude Opus 4.7 |
+| 1.2 | 2026-05-11 | Added §I3 §E — startup policy and operational status. Reflects Slices 5A/5B1 live, 5B2A merged (refactor), 5B2B planned. | Claude Sonnet 4.6 |
 
 ---
 

--- a/docs/runbooks/td-2026-05-05-001-stale-active-recovery.md
+++ b/docs/runbooks/td-2026-05-05-001-stale-active-recovery.md
@@ -3,7 +3,7 @@
 **Severity**: Critical
 **Time to Execute**: 10–30 min per affected position (steady state); up to 60 min on first incident
 **Required Access**: `kubectl` for `robson` and `robson-testnet` namespaces, Binance Futures account access (web UI or `binance-cli`), `robsond` API token, `robson-cli` binary at the version that ships Slice 5B1
-**Status**: Slice 5B1 LIVE — operator-driven manual recovery available via `robson-cli reconcile-close`. Startup `auto_reconcile` is Slice 5B2 (future).
+**Status**: Slice 5B1 LIVE — operator-driven manual recovery available via `robson-cli reconcile-close`. Slice 5B2A merged (evidence helper refactor, no operational change). Startup `auto_reconcile` is Slice 5B2B (planned, not yet live).
 
 ---
 
@@ -272,6 +272,33 @@ Flags:
 
 ---
 
+## Recovery Paths Summary
+
+| Path | Label | Status | How |
+|------|-------|--------|-----|
+| A | Startup abort (fail-closed) | **LIVE** (Slice 5A) | Daemon exits 78; use Path B to resolve manually, then restart. |
+| B | Operator-driven manual close | **LIVE** (Slice 5B1) | `robson-cli reconcile-close` + `POST /reconcile-close`. |
+| C | Startup `auto_reconcile` | **PLANNED** (Slice 5B2B) | Opt-in config; not live yet. See below. |
+
+### Path C — Startup `auto_reconcile` (planned, Slice 5B2B)
+
+> **DO NOT enable in production.** No functional `auto_reconcile` config exists
+> until Slice 5B2B is merged. Setting `on_startup_stale_active = "auto_reconcile"`
+> today produces a config error.
+
+When Slice 5B2B ships, Path C will work as follows:
+
+- Enabled via `ROBSON_RECONCILIATION_ON_STARTUP_STALE_ACTIVE=auto_reconcile`.
+- **Two-phase / all-or-nothing**: the daemon first collects evidence for ALL
+  stale-Active positions, then applies `reconcile_close` to all only if every
+  position has real evidence (`OrderFillRecord` or `UserTradeRecord`).
+- If any position lacks real evidence → abort with exit 78. No position is closed.
+- `Estimated` evidence at startup always downgrades to abort — never auto-closes.
+- **Current fallback**: use Path B (manual) until 5B2B is merged and validated
+  on testnet (Slice 5B2C drill).
+
+---
+
 ## Post-Recovery Validation
 
 After the close (whether via the CLI or via a Slice 5 `auto_reconcile` startup phase), verify:
@@ -323,3 +350,4 @@ There is **no rollback** for a reconciled close. Once `Event::PositionClosed` is
 | 2026-05-08 | Initial skeleton (Slice 2 of TD-2026-05-05-001). Operational structure, evidence ordering, decision flow. CLI command deferred to Slice 5B. | Claude Opus 4.7 |
 | 2026-05-09 | Slice 5A: startup abort is live (exit 78). Added §Startup Abort section, updated status and recovery command note. | Claude Sonnet 4.6 |
 | 2026-05-09 | Slice 5B1: operator-driven manual recovery via `robson-cli reconcile-close` + `POST /reconcile-close`. OrderFillRecord and UserTradeRecord evidence accepted. AccountSnapshot/Estimated rejected. Exit codes 0-6 documented. | Claude Opus 4.7 |
+| 2026-05-11 | Slice 5B2A merged (evidence helper refactor, no operational change). Added Recovery Paths Summary table and Path C (planned) section. Status updated. | Claude Sonnet 4.6 |


### PR DESCRIPTION
## Summary

Updates the canonical documentation for `TD-2026-05-05-001 — Core Position Lifecycle Drift`.

This documents the current state after:

- PR #60: Slice 5B1 manual recovery
- PR #61: Docker hotfix for robson-cli workspace member
- Slice 5B2A: evidence helper refactor

## Changes

- Updates the TD implementation guide with the current slice status.
- Adds Recovery Paths A/B/C to the stale-active recovery runbook.
- Updates Policy I3 with the current operational state and planned startup auto_reconcile rules.
- Updates ADR-0022 with 5B1 and 5B2A amendments.
- Adds execution memory for future agent sessions.

## Notes

No code changes.

5B2B remains planned. Startup auto_reconcile is not live yet.