### PR TITLE
feat(v3): Slice 5B2B auto-reconcile + v3 scope finalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,7 +131,8 @@ infra/ansible/inventory/contabo/passwords.yml
 
 # Temporary inventory with passwords (NEVER COMMIT)
 infra/ansible/inventory/contabo/hosts.ini.local
-apps/backend/monolith/.old/
+# Django monolith — retired in v3, never tracked, excluded to prevent accidental staging
+apps/backend/
 
 # Coverage reports
 .coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,10 @@ The repository contains the Rust runtime (canonical) under `v3/`, the SvelteKit 
 
 Use these identifiers consistently:
 
-- `MIG-v2.5#N`: migration steps from v2 to v2.5
-- `MIG-v3#N`: migration steps from v2.5 to v3
-- `QE-PN`: QueryEngine implementation phases
+- `MIG-v2.5#N`: migration steps from v2 to v2.5 (all complete)
+- `MIG-v3#N`: migration steps from v2.5 to v3 (in progress — see `docs/architecture/v3-migration-plan.md`)
+- `MIG-v4#N`: items deferred to v4 (see `docs/architecture/v4-backlog.md`)
+- `QE-PN`: QueryEngine implementation phases (QE-P1–P4 complete; QE-P5 deferred to v4)
 - `Stage N`: runtime or control-loop pipeline stages inside a single execution tick
 - `VAL-N`: operational validation gates — runbook-format procedures required before go-live events (see `docs/runbooks/val-*.md`)
 
@@ -70,7 +71,8 @@ Prefer these status terms:
 - `implemented`: code and tests/docs in repo support the feature
 - `pending`: not yet implemented or not yet accepted
 - `operational rollout`: code may exist, but real deployment/activation is not yet repository-verified
-- `deferred`: intentionally postponed
+- `deferred`: intentionally postponed to a later version (v4+)
+- `abandoned`: explicitly dropped from scope — will not be implemented (reason must be documented)
 - `follow-up required`: architectural direction is decided, but code alignment is still pending
 
 Repository status rule:
@@ -115,7 +117,7 @@ Application and agent code must never provision databases directly.
 6. **Never run Postgres integration tests against a production `DATABASE_URL`**. `sqlx::test` creates and drops databases on the target server. `scripts/test-pg.sh` enforces this with a naming guard; do not bypass it.
 7. **Migration ownership**: migrations live in `v3/migrations/`. If you add a migration, verify that existing `sqlx::test`-based tests still pass with the updated schema. Do not apply migrations manually to shared environments.
 
-### Test tiers (v2 Rust)
+### Test tiers (v3 Rust)
 
 | Tier | Command | Requires database |
 |---|---|---|
@@ -132,20 +134,36 @@ CI must pass the first two tiers unconditionally. The third tier requires a prov
 - Leave the worktree clean after committing and pushing.
 - Do not silently preserve stale compatibility files; convert them into thin adapters or remove them.
 
+## Policy Invariants
+
+These are architectural constraints that MUST NOT be violated by any agent or human:
+
+10. **No static exposure hard limits.** `max_open_positions`, `max_total_exposure_pct`, and `max_single_position_pct` were eliminated in MIG-v3#11 (ADR-0024). The only static constraint is `risk_per_trade_pct = 1%` and `max_monthly_drawdown_pct = 4%` of `capital_base`. Slot availability governs entry capacity. There is no daily loss limit. Funding rate does not determine exposure limits in long positions.
+11. **`Estimated` evidence is permanently blocked in `reconcile_close`.** Only `OrderFillRecord` and `UserTradeRecord` are accepted for automated reconciled closes. If evidence is unavailable, the daemon aborts startup and requires manual operator intervention via `robson-cli reconcile-close`.
+12. **No LLM, no autonomous trading.** v3 has zero LLM coupling. The operator decides WHEN to trade. Robson decides HOW MUCH and enforces THAT risk rules are never violated. QE-P5 (Context Governance) is deferred to v4.
+
 ## High-Value Source Files
 
 Start here for v3/runtime work:
 
-- `docs/architecture/v3-migration-plan.md`
+- `docs/architecture/v3-migration-plan.md` — authoritative roadmap and status
+- `docs/architecture/v4-backlog.md` — items explicitly deferred to v4
 - `docs/architecture/v3-runtime-spec.md`
 - `docs/architecture/v3-query-query-engine.md`
 - `docs/architecture/v3-control-loop.md`
 - `docs/architecture/v3-architectural-decisions.md`
+- `docs/policies/UNTRACKED-POSITION-RECONCILIATION.md`
+- `docs/policies/SYMBOL-AGNOSTIC-POLICIES.md`
+- `docs/adr/ADR-0022-robson-authored-position-invariant.md`
+- `docs/adr/ADR-0023-symbol-agnostic-policy-invariant.md`
+- `docs/adr/ADR-0024-trading-policy-layer.md`
 
 Implementation reality for the current Rust executor/runtime boundary:
 
 - `v3/robsond/src/query_engine.rs`
 - `v3/robson-exec/src/executor.rs`
+- `v3/robsond/src/reconciliation_worker.rs`
+- `v3/robsond/src/position_manager.rs`
 
 ## Adapter Policy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,27 +10,34 @@ If this file and `AGENTS.md` ever diverge, `AGENTS.md` is the source of truth.
 1. Read `AGENTS.md` first for project-wide rules.
 2. Keep repository content in English.
 3. Use canonical planning identifiers:
-   - `MIG-v2.5#N`
-   - `MIG-v3#N`
+   - `MIG-v2.5#N` (all complete)
+   - `MIG-v3#N` (in progress)
+   - `MIG-v4#N` (backlog — see `docs/architecture/v4-backlog.md`)
    - `QE-PN`
    - `Stage N`
 4. Use repository-verified status semantics for migration and architecture docs.
 5. Keep current implementation clearly separated from target architecture.
+6. `abandoned` = explicitly dropped from v3 scope (documented in v3-migration-plan.md).
+7. `deferred` = moved to v4 backlog (documented in v4-backlog.md).
 
 ## High-Value Files
 
 - `AGENTS.md`
+- `docs/architecture/v3-migration-plan.md`
+- `docs/architecture/v4-backlog.md`
 - `docs/policies/UNTRACKED-POSITION-RECONCILIATION.md`
 - `docs/policies/SYMBOL-AGNOSTIC-POLICIES.md`
 - `docs/adr/ADR-0022-robson-authored-position-invariant.md`
 - `docs/adr/ADR-0023-symbol-agnostic-policy-invariant.md`
-- `docs/architecture/v3-migration-plan.md`
+- `docs/adr/ADR-0024-trading-policy-layer.md`
 - `docs/architecture/v3-runtime-spec.md`
 - `docs/architecture/v3-query-query-engine.md`
 - `docs/architecture/v3-control-loop.md`
 - `docs/architecture/v3-architectural-decisions.md`
 - `v3/robsond/src/query_engine.rs`
 - `v3/robson-exec/src/executor.rs`
+- `v3/robsond/src/reconciliation_worker.rs`
+- `v3/robsond/src/position_manager.rs`
 
 ## Core Invariants (must never be violated)
 
@@ -43,6 +50,12 @@ If this file and `AGENTS.md` ever diverge, `AGENTS.md` is the source of truth.
 - **Technical Stop from chart analysis** — never `entry × (1 − pct)`. See ADR-0021.
 - **Opportunity detection vs Technical Stop Analysis** are separate responsibilities.
   See ADR-0021.
+- **No static hard limits** — `max_open_positions`, `max_total_exposure_pct`, and
+  `max_single_position_pct` were eliminated in MIG-v3#11. Only slot logic and the
+  4% monthly drawdown policy govern entry capacity. See ADR-0024.
+- **Estimated evidence is permanently blocked** — `reconcile_close` rejects
+  `ReconciliationEvidence::Estimated`. Only `OrderFillRecord` and `UserTradeRecord`
+  are valid for automated reconciled closes in v3.
 
 ## Commit Policy
 

--- a/docs/agents/td-2026-05-05-001-execution-memory.md
+++ b/docs/agents/td-2026-05-05-001-execution-memory.md
@@ -1,7 +1,7 @@
 # TD-2026-05-05-001 — Execution Memory
 
 **TD**: Core Position Lifecycle Drift
-**Last updated**: 2026-05-11
+**Last updated**: 2026-05-12
 **Scope**: `robsond` reconciliation — stale-Active positions not present on the exchange
 
 ---
@@ -20,43 +20,49 @@
 | 5B1 | `robson-cli reconcile-close` + `POST /reconcile-close` | DONE | PR #60 |
 | Hotfix | Dockerfile: include `robson-cli` workspace member | DONE | PR #61, commit `1b275638` |
 | 5B2A | Evidence helper refactor in `reconciliation_worker.rs` | DONE | commits `20283d9e` + `26e82837` |
-| 5B2B | Startup `auto_reconcile` config + two-phase algorithm | PLANNED | — |
-| 5B2C | Runbook finalization + testnet drill | PLANNED | — |
+| 5B2B | Startup `auto_reconcile` config + two-phase algorithm | DONE (v4 opt-in) | commit `5458c36e` |
+| 5B2C | Runbook finalization + testnet drill for `auto_reconcile` | 🔄 Deferred to MIG-v4#3 | — |
 
 **`main` HEAD** (as of 2026-05-11): `26e82837`
+**Branch `feat/…-5b2b-auto-reconcile` HEAD** (as of 2026-05-12): `5458c36e` — pending merge to main.
+
+**TD status**: Open. Remaining v3 work is zero (all Slices done or deferred). TD will be
+closed once Slices 0–5B2B are merged and the `docs/technical-debt.md` entry is updated.
 
 ---
 
-## Architecture Decisions (do not reopen without escalation)
+## Architecture Decisions (final for v3 — do not reopen without escalation)
 
 ### Startup policy
-- **`abort` is the default** and the safe baseline. No change planned.
-- **`auto_reconcile` is opt-in** via `ROBSON_RECONCILIATION_ON_STARTUP_STALE_ACTIVE=auto_reconcile`.
-- `auto_reconcile` is **two-phase / all-or-nothing**:
+- **`abort` is the default** and the production baseline for v3.
+- **`auto_reconcile` is implemented** (Slice 5B2B) but **not production-enabled in v3**.
+  Enable only in v4 after testnet drill (MIG-v4#3).
+- `auto_reconcile` is two-phase / all-or-nothing:
   1. Detect all stale-Active positions.
   2. Collect real evidence for each (`OrderFillRecord` or `UserTradeRecord`).
   3. If any position lacks real evidence → abort with exit 78. No position closed.
   4. If all have unambiguous real evidence → apply `reconcile_close` for all.
 
-### Evidence restrictions for startup auto-close
-- `OrderFillRecord` and `UserTradeRecord`: allowed for auto-close at startup.
-- `AccountSnapshot`: **not allowed** for startup auto-close.
-- `Estimated`: **never** auto-closes at startup — always downgrades to abort.
+### Evidence restrictions (v3 final)
+- `OrderFillRecord` and `UserTradeRecord`: accepted.
+- `AccountSnapshot`: rejected.
+- `Estimated`: **permanently hard-blocked** — `reconcile_close` returns
+  `RejectedUnsupportedEvidence { source: "estimated" }` and logs a warning. No operator
+  confirmation path exists in v3. Estimated auto-close is deferred to MIG-v4#7.
 
-### Operator-driven manual path (Slice 5B1)
-- Same evidence restriction: `OrderFillRecord` and `UserTradeRecord` only.
-- `POST /reconcile-close` + `robson-cli reconcile-close` are live.
-- Use this path for all startup-gate scenarios until 5B2B is merged.
+### Operator-driven manual path (v3 production path)
+- `POST /reconcile-close` + `robson-cli reconcile-close` (Slice 5B1) are the only
+  production reconciliation paths in v3.
+- No "second operator" requirement. Single operator is the v3 model.
 
 ---
 
-## Next Implementation Sequence
+## Next Implementation Sequence (v3 remaining)
 
-1. **5B2B** — implement `startup_reverse_reconciliation()` with two-phase logic.
-   Accept `auto_reconcile` in `StartupStaleActivePolicy` parser.
-   Add integration tests (happy path, Estimated-downgrade, partial-evidence abort).
-2. **5B2C** — finalize runbook Path C section. Execute testnet drill.
-3. Only after testnet drill passes → consider enabling `auto_reconcile` in production.
+1. Merge current branch (`feat/…-5b2b-auto-reconcile`) to main.
+2. Close TD in `docs/technical-debt.md`.
+
+v4 follow-up: MIG-v4#3 (testnet drill + production enable of `auto_reconcile`).
 
 ---
 
@@ -74,16 +80,7 @@
 ## Key Documents
 
 - [Implementation Guide](../implementation/TD-2026-05-05-001-CORE-LIFECYCLE-DRIFT.md) — slice plan, amendments, algorithm decisions
-- [Runbook](../runbooks/td-2026-05-05-001-stale-active-recovery.md) — operator recovery procedure (Paths A/B live, Path C planned)
+- [Runbook](../runbooks/td-2026-05-05-001-stale-active-recovery.md) — operator recovery (Paths A/B live)
 - [Policy I3](../policies/UNTRACKED-POSITION-RECONCILIATION.md) — I3 invariant text
 - [ADR-0022](../adr/ADR-0022-robson-authored-position-invariant.md) — invariant authority
-
----
-
-## Open Questions / Blockers
-
-None blocking 5B2B. Preconditions before enabling `auto_reconcile` in production:
-
-- [ ] Slice 5B2B merged and CI green.
-- [ ] Testnet drill (Slice 5B2C) completed with successful outcome recorded in runbook Run Log.
-- [ ] Second authorized operator confirmed for first production `auto_reconcile` run.
+- [v4 backlog](../architecture/v4-backlog.md) — MIG-v4#3, MIG-v4#7

--- a/docs/architecture/v3-migration-plan.md
+++ b/docs/architecture/v3-migration-plan.md
@@ -94,9 +94,11 @@ every reference uses a canonical identifier with a prefix:
 - `QE-P5` is NOT a migration step; it is a deferred QueryEngine phase (Context Governance, v3+ with LLM).
 - `Stage N` is a pipeline stage within a single execution tick (e.g., Stage 1: Observe). Not a project milestone.
 
-**Quick status reference** (as of 2026-04-18, repository-verified):
+**Quick status reference** (as of 2026-05-12, repository-verified):
 
 Status rule for this table: code-backed items may be marked done from repository evidence; operational rollout items stay pending unless the repository contains explicit rollout confirmation.
+
+**Abandoned items** are decisions made by the operator (2026-05-12) to drop scope that conflicted with v3 architecture or policy. They do not appear in v4 backlog unless noted.
 
 | ID | Description | Status |
 |----|-------------|--------|
@@ -111,26 +113,26 @@ Status rule for this table: code-backed items may be marked done from repository
 | MIG-v2.5#9 | Contract tests for daemon API | ✅ Done (2026-04-10) — 29 tests |
 | MIG-v2.5#10 | EventLog replay determinism test | ✅ Done (2026-04-05) |
 | MIG-v3#1 | Promote robsond as primary runtime | ✅ Done (2026-04-10) — Django execution CronJobs suspended, robsond sole execution path |
-| MIG-v3#2 | Replace Django API with thin gateway | ✅ Done (2026-04-16) — robsond serves API/SSE directly; separate gateway unnecessary; frontend still on Django (→ MIG-v3#3) |
-| MIG-v3#3 | Frontend direct connection to SSE | Pending |
-| MIG-v3#4 | Dynamic risk limits | Pending |
-| MIG-v3#5 | Operator control surface in UI | Pending |
-| MIG-v3#6 | Hash-chained EventLog | Pending |
-| MIG-v3#7 | PaymentRail trait | Pending |
-| MIG-v3#8 | Chaos testing suite | Pending |
-| MIG-v3#9 | Position Reconciliation Worker (ADR-0022 — Robson-authored position invariant) | ✅ Implemented — `PositionState::Cancelled` added; disarmed positions no longer recorded as `Closed` |
-| MIG-v3#10 | Symbol-agnostic documentation + test sweep (ADR-0023) | ✅ Implemented — `EntryLifecycleStage` computed projection (`entry_lifecycle_stage` fn in `robson-domain/src/events.rs`) |
-| MIG-v3#11 | Policy Layer + Dynamic Slot Calculation (ADR-0024) | Done — repository-verified (2db23ad2, corrected by 0b3653a7); `robson-domain::policy` with `TradingPolicy` and `TechStopConfig`; `RiskGate` consumes policy; static `max_open_positions`, `max_total_exposure_pct`, `max_single_position_pct` eliminated; dynamic slot calculation uses best-effort in-memory `capital_base` (persisted base lands in MIG-v3#12) |
-| MIG-v3#12 | Monthly State Persistence — `MonthBoundaryReset` + `monthly_state` projection | ✅ Implemented — `realized_loss` and `trades_opened` persisted in `monthly_state`; projection handlers for `EntryFilled` and `PositionClosed` events; `load_monthly_state` replaces O(n) recomputation; strict separation: `monthly_state` = ledger, `positions_current` = live execution state. **Follow-up (Option 2 — Slot Count from API Only)**: `/status` exposes explicit `new_slots_available`, `occupied_slots`, and `slot_cells_total` fields. |
-| MIG-v3#13 | Migrate exchange layer from Isolated Margin to USD-M Futures | Done — exchange connector switched from SAPI isolated-margin endpoints to FAPI USD-M Futures endpoints; position management now operates on Binance USD-M Futures testnet (`testnet.binancefuture.com`) and production |
-| MIG-v3#14 | Risk Dashboard — monthly budget bar, realized-loss display, slot breakdown | Pending — deferred from MIG-v3#12 frontend work. Option 1 (full dashboard UI) was evaluated and postponed in favor of Option 2 (API-only slot exposure). Tentatively a dedicated dashboard story; no implementation date set. |
+| MIG-v3#2 | Replace Django API with thin gateway | ✅ Done (2026-04-16) — robsond serves API/SSE directly; no separate gateway needed |
+| MIG-v3#3 | Frontend direct connection to SSE | ✅ Done (2026-05-12) — Django retired. Canonical frontend is SvelteKit at `apps/frontend/` (`@robson/frontend-v2`). SSE endpoint is live in robsond (`/events`). React/nginx legacy frontend removed from working tree. |
+| MIG-v3#4 | Dynamic risk limits | ❌ Abandoned (2026-05-12) — superseded by MIG-v3#11 + ADR-0024. No static hard limits exist. The only monthly constraint is the 4% drawdown policy encoded in `TradingPolicy`. Dynamic limits beyond the slot model conflict with policy invariants and were dropped from scope. |
+| MIG-v3#5 | Operator control surface in UI | ❌ Abandoned (2026-05-12) — pause/resume do not apply in the slot model; panic close belongs in the backend CLI; risk-limit adjustment from UI contradicts policy invariants (ADR-0024). This was a pre-v3 concept that lost relevance after the slot architecture was finalized. |
+| MIG-v3#6 | Hash-chained EventLog | 🔄 Deferred to MIG-v4#1 — good integrity property, not required for v3 launch. |
+| MIG-v3#7 | PaymentRail trait | 🔄 Deferred to MIG-v4#2 — TRON/payment rail abstraction is architecture-ready but inactive. See ADR table entry #12. |
+| MIG-v3#8 | Chaos testing suite | ⏳ Pending — kept in v3 scope. Required for production-grade confidence before full autonomous operation. |
+| MIG-v3#9 | Position Reconciliation Worker — UNTRACKED side (ADR-0022) | ✅ Done — symmetric reconciliation loop, `reconcile_close`, startup abort gate, `robson-cli reconcile-close`, and `POST /reconcile-close` implemented (TD-2026-05-05-001 Slices 0–5B2B). |
+| MIG-v3#10 | Symbol-agnostic documentation + test sweep (ADR-0023) | ✅ Done — `EntryLifecycleStage` computed projection in `robson-domain/src/events.rs`. |
+| MIG-v3#11 | Policy Layer + Dynamic Slot Calculation (ADR-0024) | ✅ Done (2db23ad2, corrected 0b3653a7) — `TradingPolicy`, `TechStopConfig`; `RiskGate` consumes policy; all static exposure caps eliminated. |
+| MIG-v3#12 | Monthly State Persistence — `MonthBoundaryReset` + `monthly_state` projection | ✅ Done — `realized_loss` and `trades_opened` in `monthly_state`; `/status` exposes `new_slots_available`, `occupied_slots`, `slot_cells_total`. |
+| MIG-v3#13 | Migrate exchange layer from Isolated Margin to USD-M Futures | ✅ Done — FAPI endpoints, testnet and production. |
+| MIG-v3#14 | Risk Dashboard — monthly budget bar, realized-loss display, slot breakdown | ⏳ Pending — kept in v3 scope. All business logic and policy stays in backend; frontend renders only. See ADR-0034. |
 | QE-P1 | Passive Wrapper (Non-Breaking) | ✅ Done |
 | QE-P2 | Blocking Governance | ✅ Done (2026-04-04) |
 | QE-P3 | Approval Gates | ✅ Done (2026-04-05) |
 | QE-P4 | Full Audit & Replay | ✅ Done (2026-04-05) |
-| QE-P5 | Context Governance (LLM) | Deferred (v3+) |
-| VAL-001 | Testnet E2E validation (arm -> signal -> fill -> trailing stop -> exit) | Phase 1 PASS (2026-04-16) / Phase 2 ready for redeploy-and-run. The static exposure blocker found on 2026-04-18 was resolved by MIG-v3#11 (`2db23ad2`, corrected by `0b3653a7`) and testnet config commit `c3b1bc3`; `RiskGate` now uses ADR-0024 dynamic slots instead of legacy 15%/30% exposure caps. Remaining work: build/deploy latest image, sync ArgoCD, execute the Phase 2 runbook, and record exchange/fill/trailing-stop evidence. See [ADR-0024](../adr/ADR-0024-trading-policy-layer.md) and [runbooks/val-001-testnet-e2e-validation.md](../runbooks/val-001-testnet-e2e-validation.md) |
-| VAL-002 | Real capital activation (Binance real keys + monitor enabled in prod) | Pending — blocked on VAL-001 PASS + MIG-v3#12 (monthly state persistence required before real capital) |
+| QE-P5 | Context Governance (LLM) | 🔄 Deferred to MIG-v4#5 — no LLM integration in v3. |
+| VAL-001 | Testnet E2E validation (arm → signal → fill → trailing stop → exit) | ✅ PASS (2026-04-22) — full event sequence `position_armed → position_closed` confirmed, `cycle_id` on all orders, PnL calculated, 0 UNTRACKED. See `docs/runbooks/val-001-testnet-e2e-validation.md` Run Log. |
+| VAL-002 | Real capital activation (real Binance keys + monitor enabled in prod) | ✅ PASS (2026-04-22) — sha-9448ce20, monitor active, 0 UNTRACKED in 10 min. See `docs/runbooks/val-002-real-capital-activation.md` Run Log. |
 
 ### MIG-v2.5#2 Technical Notes (2026-04-05, validated 2026-04-10)
 

--- a/docs/architecture/v3-runtime-spec.md
+++ b/docs/architecture/v3-runtime-spec.md
@@ -343,31 +343,24 @@ covers the **write side** (nothing leaves the Runtime without governance). This
 invariant adds the **read side**: nothing sits on the exchange that did not leave the
 Runtime.
 
-> **TARGET ARCHITECTURE — FOLLOW-UP REQUIRED (MIG-v3#9)**: The Position Reconciliation
-> Worker described below is not yet implemented. Current startup recovery restores
-> positions from EventLog replay + projection but does NOT scan for UNTRACKED positions.
-> The Safety Net monitors for rogue positions but does not implement the ADR-0022
-> classification flow. Until MIG-v3#9 is complete, the operator must manually verify
-> that the Binance account holds no externally-opened positions before and after daemon
-> restarts.
+The Runtime owns a long-lived **Position Reconciliation Worker** (implemented — MIG-v3#9,
+TD-2026-05-05-001 Slices 0–5B2B) that enforces both sides of the invariant:
 
-Operationally, the Runtime owns a long-lived **Position Reconciliation Worker** that:
+**Exchange → Robson (UNTRACKED close)**:
+- Scans Binance for open positions across all account types and all symbols.
+- Classifies positions without a matching `entry_order_placed` event as UNTRACKED.
+- Closes UNTRACKED positions with exit reason `UNTRACKED_ON_EXCHANGE` and alerts CRITICAL.
 
-- Scans Binance for open positions across **all account types** (spot, isolated margin,
-  cross margin, futures) and **all symbols** — not gated by `allowed_symbols` and not
-  gated by `ROBSON_POSITION_MONITOR_ENABLED`.
-- Looks up each open position by exchange order id in `event_log`.
-- Classifies positions without a matching `entry_order_placed` event as **UNTRACKED**.
-- Closes UNTRACKED positions at market via the Safety Net close path (exit reason
-  `UNTRACKED_ON_EXCHANGE`) and alerts the operator at severity `CRITICAL`.
+**Robson → Exchange (stale-Active close)**:
+- Iterates every local `Active` position and checks for its presence on the exchange.
+- If absent (liquidation, manual close, insurance stop fill outside daemon): gathers
+  `OrderFillRecord` or `UserTradeRecord` evidence and calls `reconcile_close`.
+- If evidence is unavailable: aborts startup with exit 78 (operator must use
+  `robson-cli reconcile-close` manually — see `docs/runbooks/td-2026-05-05-001-stale-active-recovery.md`).
 
-Follow-up required (target architecture):
-
-- Exchange-order-id index on `event_log` for O(1) lookup by the reconciliation worker.
-- Dedicated `safety_net` close path for UNTRACKED positions.
-- Startup reconciliation gate: the daemon must enter `StartupReconciling` before
-  accepting observations; new entries blocked until the UNTRACKED set is empty.
-- Operator panic override endpoint (`POST /reconciliation/suspend`, max TTL 300 s).
+`Estimated` evidence is **permanently blocked** in v3 — `reconcile_close` returns
+`RejectedUnsupportedEvidence` for any `Estimated` input. See Policy I3 in
+`docs/policies/UNTRACKED-POSITION-RECONCILIATION.md`.
 
 ---
 
@@ -515,27 +508,19 @@ violation (ADR-0022).
 
 ### Scenario 5: UNTRACKED Position Detected
 
-> **TARGET ARCHITECTURE — FOLLOW-UP REQUIRED (MIG-v3#9)**: This scenario is not yet
-> implemented. The reconciliation worker, `StartupReconciling` state, and
-> `position_untracked_detected` event type do not exist in the current codebase.
+Implemented — `ReconciliationWorker` (MIG-v3#9, TD-2026-05-05-001).
 
-Triggered when the Position Reconciliation Worker finds an open exchange position
-for which no matching `entry_order_placed` event exists in `event_log`. See
+Triggered when the reconciliation worker finds an open exchange position for which
+no matching `entry_order_placed` event exists in `event_log`. See
 [ADR-0022](../adr/ADR-0022-robson-authored-position-invariant.md) and
 [docs/policies/UNTRACKED-POSITION-RECONCILIATION.md](../policies/UNTRACKED-POSITION-RECONCILIATION.md).
 
-1. Persist `position_untracked_detected` with evidence: exchange order id, symbol,
-   side, quantity, open timestamp.
-2. Emit a CRITICAL operator alert.
-3. Close the position at market via the Safety Net close path, tagged exit reason
-   `UNTRACKED_ON_EXCHANGE`.
-4. Persist `untracked_position_closed` with the resulting fill.
-5. Do NOT reconstruct an `entry_order_placed` event. Do NOT adopt the position into
-   RuntimeState before closing it.
+1. Emit a CRITICAL operator alert.
+2. Close the position via `reconcile_close` with exit reason `UNTRACKED_ON_EXCHANGE`.
+3. Persist the `PositionClosed` event with `ClosureEvidence::Reconciled(...)`.
+4. Do NOT reconstruct an `entry_order_placed` event. Do NOT adopt the position.
 
-This path is unconditional — not gated by `ROBSON_POSITION_MONITOR_ENABLED` or
-`allowed_symbols`. The only permitted override is an operator-issued
-`POST /reconciliation/suspend` (max TTL 300 s, fully audited — v3 target).
-
-At daemon startup, the Runtime MUST enter `StartupReconciling` and resolve all
-UNTRACKED positions before accepting non-critical observations.
+At daemon startup: if stale-Active positions are detected, the daemon aborts with
+exit code 78 (default `abort` policy). The operator resolves them via
+`robson-cli reconcile-close` before restarting. See
+`docs/runbooks/td-2026-05-05-001-stale-active-recovery.md`.

--- a/docs/architecture/v4-backlog.md
+++ b/docs/architecture/v4-backlog.md
@@ -1,0 +1,44 @@
+# ROBSON v4 — Backlog
+
+**Status**: Living document — items accumulate as v3 scope is finalized.
+**Owner**: Operator (Leandro Damasio)
+**Last updated**: 2026-05-12
+
+Items in this backlog were explicitly deferred from v3 scope. They are not forgotten —
+they are intentionally parked until v3 is declared complete.
+
+---
+
+## Deferred Items
+
+| ID | Description | Origin | Rationale |
+|----|-------------|--------|-----------|
+| MIG-v4#1 | Hash-chained EventLog | was MIG-v3#6 | Good integrity property; append-only PostgreSQL is sufficient for v3 single-operator. Prioritize when audit requirements grow or multi-operator is introduced. |
+| MIG-v4#2 | PaymentRail trait (TRON/TRC-20) | was MIG-v3#7 | Architecture is TRON-ready (see ADR table #12 in v3-migration-plan.md). Activate when FINMA stablecoin guidance is clear and Zero Hash obtains Swiss-compatible license. |
+| MIG-v4#3 | Startup `auto_reconcile` policy | was TD-2026-05-05-001 Slice 5B2C | Config knob exists (`StartupStaleActivePolicy::AutoReconcile`) but is not production-enabled in v3. v3 uses manual `robson-cli reconcile-close` (Path A/B). Enable `auto_reconcile` in v4 after full testnet drill. |
+| MIG-v4#4 | Multi-user / multi-tenant support | — | v3 is single-operator by design (ADR-0007). Introduce when a second operator joins or a client-facing product is scoped. |
+| MIG-v4#5 | LLM / Context Governance (QE-P5) | was QE-P5 | No LLM in v3. When LLM reasoning is added, it enters via `ReasoningPort` trait (already defined in v3-runtime-spec.md). The Runtime governs context and output. |
+| MIG-v4#6 | Backtesting / Simulation (`robson-sim`) | — | Deferred from v3 launch. Trigger: operator wants to validate strategy changes before arming. |
+| MIG-v4#7 | Estimated-evidence auto-close path | — | `Estimated` is hard-blocked in v3 `reconcile_close`. A future operator-confirmed estimated close (with PnL bounds) could be designed for v4, guarded by explicit human approval flow. |
+| MIG-v4#8 | Operator control surface in UI | was MIG-v3#5 | The concept needs redesign in the slot model context before any implementation. Panic close and CLI already cover v3 needs. |
+
+---
+
+## Constraints Inherited by All v4 Work
+
+1. **Single Runtime authority** — all exchange actions pass through `robsond` GovernedAction. No direct exchange access from any other component.
+2. **Policy-first** — ADR-0022, ADR-0023, ADR-0024 invariants apply to v4 as well. No feature may introduce static exposure caps, hard-coded symbols, or non-audited closes.
+3. **Estimated evidence remains operator-confirmed** — any v4 auto-close path that uses estimated PnL MUST require explicit operator confirmation before persisting the terminal event.
+4. **English only** — all code, comments, and documentation.
+
+---
+
+## v3 Finalization Criteria (for reference)
+
+v3 is complete when all of the following are repository-verified:
+
+- [ ] TD-2026-05-05-001 closed (`docs/technical-debt.md` Status: Closed)
+- [ ] MIG-v3#8 Chaos testing suite merged and CI green
+- [ ] MIG-v3#14 Risk Dashboard shipped in `apps/frontend/` and deployed
+- [ ] `v3-migration-plan.md` has no items marked `⏳ Pending`
+- [ ] Production running ≥ 30 days with 0 `position_untracked_detected` events (Grafana/Loki)

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -10,70 +10,42 @@ Each item should stay short and actionable. Long investigations belong in
 
 ## TD-2026-05-05-001: Core Position Lifecycle Drift
 
-**Status**: Open
-**Severity**: High
+**Status**: Pending closure — code complete, branch pending merge
+**Severity**: High → Resolved
 **Area**: `robsond`, reconciliation, position lifecycle
 **Discovered**: 2026-05-05
+**Resolved by**: TD-2026-05-05-001 Slices 0–5B2B (commits `28b7a58e`→`5458c36e`)
 
-### Summary
+### Resolution Summary
 
-Robson can continue projecting a core position as `Active` even after the
-exchange position has already disappeared or been liquidated outside the normal
-Robson `PositionClosed` flow.
+All slices implemented and merged (pending final PR merge from branch
+`feat/td-2026-05-05-001-slice-5b2b-auto-reconcile`):
 
-The existing reconciliation worker protects one side of the invariant: it
-detects exchange-open positions that Robson is not tracking and closes them as
-UNTRACKED. It does not yet protect the opposite side: Robson-tracked core
-positions that no longer exist on the exchange.
+- **Symmetric reconciliation**: `ReconciliationWorker` now iterates both sides —
+  exchange→Robson (UNTRACKED close) and Robson→exchange (stale-Active close).
+- **Evidence pipeline**: `ExchangePort` provides `get_order_by_exchange_id` and
+  `get_user_trades_since`. Only `OrderFillRecord` and `UserTradeRecord` are valid.
+  `Estimated` is permanently hard-blocked.
+- **Startup abort gate**: exit code 78 on any stale-Active at startup (default policy).
+- **Manual recovery path**: `robson-cli reconcile-close` + `POST /reconcile-close`.
+- **Startup `auto_reconcile`**: implemented (opt-in), deferred to production use in v4
+  (MIG-v4#3 in `docs/architecture/v4-backlog.md`).
 
-### Impact
+### What Remains (v3)
 
-- The dashboard can show an occupied slot for a position that should be terminal.
-- Monthly slot accounting can remain conservative because the stale position
-  still occupies a slot.
-- Realized PnL, `closed_at`, and final lifecycle state are not authoritative
-  until a proper close event is recorded.
-- Operators may see `Active` on the operation detail page even when the exchange
-  no longer has the position open.
+- [ ] Merge branch `feat/td-2026-05-05-001-slice-5b2b-auto-reconcile` to main.
+- [ ] Update this entry Status to `Closed` after merge.
 
-### Current Mitigation
+### What is Deferred (v4)
 
-The 2026-05-05 slot variation fix makes `/status` and `/positions/:id` expose
-`variation_pct` from backend business logic instead of letting the frontend
-interpret `pnl` as a percentage.
-
-For `Active` positions, the API now fetches a live exchange price for display.
-If the observed price has crossed the trailing stop, the displayed variation is
-valued at the stop price instead of remaining at the stale in-memory
-`current_price`. This improves operator visibility but does not close the
-position lifecycle drift.
-
-The monthly slot history UI now renders historical months as full dashboard
-snapshots. In past months, unused capacity is labeled `Expired Slot` instead of
-`Free Slot`, which keeps the current-month live vocabulary separate from the
-historical view.
-
-### Required Fix
-
-Add core-position reconciliation for tracked positions that are missing on the
-exchange:
-
-1. Query active Robson core positions.
-2. Query open exchange positions.
-3. For each Robson `Active` position missing on the exchange, determine the
-   safest terminal event source:
-   - Prefer exchange order/trade history if available.
-   - Otherwise record an explicit reconciliation-close event with conservative
-     reason and evidence.
-4. Emit/persist `PositionClosed` through the same eventlog/projector path used
-   by normal exits.
-5. Ensure monthly accounting and slot availability are recalculated from the
-   terminal projection.
-6. Add regression coverage for "Robson active, exchange missing".
+- Testnet drill for startup `auto_reconcile` (MIG-v4#3).
+- Estimated-evidence operator-confirmed close path (MIG-v4#7).
 
 ### References
 
+- `docs/agents/td-2026-05-05-001-execution-memory.md`
+- `docs/implementation/TD-2026-05-05-001-CORE-LIFECYCLE-DRIFT.md`
+- `docs/runbooks/td-2026-05-05-001-stale-active-recovery.md`
 - `v3/robsond/src/reconciliation_worker.rs`
 - `v3/robsond/src/position_manager.rs`
 - `docs/policies/UNTRACKED-POSITION-RECONCILIATION.md`
-- `docs/operations/2026-05-05-v3-slot-variation-fix.md`

--- a/v3/robsond/src/config.rs
+++ b/v3/robsond/src/config.rs
@@ -157,8 +157,9 @@ pub enum StartupStaleActivePolicy {
     /// Fail closed: log CRITICAL, return exit code 78, refuse to start.
     #[default]
     Abort,
-    /// Attempt to gather real fill evidence and reconcile-close each stale-active
-    /// position at startup. Fails closed if any position lacks unambiguous evidence.
+    /// Attempt to gather real fill evidence and reconcile-close each
+    /// stale-active position at startup. Fails closed if any position lacks
+    /// unambiguous evidence.
     AutoReconcile,
 }
 

--- a/v3/robsond/src/config.rs
+++ b/v3/robsond/src/config.rs
@@ -149,18 +149,24 @@ impl Default for PositionMonitorConfig {
 /// Policy controlling daemon behavior when stale-Active positions are detected
 /// at startup (Amendment §3 of TD-2026-05-05-001).
 ///
-/// In Slice 5A only `Abort` is accepted. Unknown values produce a config error.
+/// `Abort` is the default fail-closed behavior. `AutoReconcile` is an
+/// opt-in two-phase startup reconciliation path (Slice 5B2B).
+/// Unknown values produce a config error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum StartupStaleActivePolicy {
     /// Fail closed: log CRITICAL, return exit code 78, refuse to start.
     #[default]
     Abort,
+    /// Attempt to gather real fill evidence and reconcile-close each stale-active
+    /// position at startup. Fails closed if any position lacks unambiguous evidence.
+    AutoReconcile,
 }
 
 impl std::fmt::Display for StartupStaleActivePolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Abort => write!(f, "abort"),
+            Self::AutoReconcile => write!(f, "auto_reconcile"),
         }
     }
 }
@@ -171,9 +177,10 @@ impl std::str::FromStr for StartupStaleActivePolicy {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "abort" => Ok(Self::Abort),
+            "auto_reconcile" => Ok(Self::AutoReconcile),
             other => Err(format!(
                 "Unknown ROBSON_RECONCILIATION_ON_STARTUP_STALE_ACTIVE value: \"{}\". \
-                 Accepted: abort",
+                 Accepted: abort, auto_reconcile",
                 other
             )),
         }
@@ -771,17 +778,51 @@ mod tests {
     }
 
     #[test]
+    fn test_load_startup_policy_auto_reconcile_from_env() {
+        let _lock = env_lock().lock().unwrap();
+        let _env = EnvGuard::new(&[
+            ("ROBSON_RECONCILIATION_INTERVAL_SECS", None),
+            ("ROBSON_RECONCILIATION_MISSING_GRACE_SECS", None),
+            ("ROBSON_RECONCILIATION_ON_STARTUP_STALE_ACTIVE", Some("auto_reconcile")),
+        ]);
+
+        let config = Config::load_reconciliation_config().unwrap();
+        assert_eq!(config.on_startup_stale_active, StartupStaleActivePolicy::AutoReconcile);
+    }
+
+    #[test]
     fn test_load_startup_policy_unknown_is_config_error() {
         let _lock = env_lock().lock().unwrap();
         let _env = EnvGuard::new(&[(
             "ROBSON_RECONCILIATION_ON_STARTUP_STALE_ACTIVE",
-            Some("auto_reconcile"),
+            Some("invalid_policy"),
         )]);
 
         let err = Config::load_reconciliation_config().unwrap_err();
         assert!(
-            matches!(err, DaemonError::Config(ref msg) if msg.contains("auto_reconcile")),
+            matches!(err, DaemonError::Config(ref msg) if msg.contains("invalid_policy")),
             "expected config error for unknown policy, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_startup_stale_active_policy_from_str() {
+        assert_eq!(
+            "abort".parse::<StartupStaleActivePolicy>().unwrap(),
+            StartupStaleActivePolicy::Abort
+        );
+        assert_eq!(
+            "auto_reconcile".parse::<StartupStaleActivePolicy>().unwrap(),
+            StartupStaleActivePolicy::AutoReconcile
+        );
+        assert!(
+            "unknown".parse::<StartupStaleActivePolicy>().is_err(),
+            "unknown policy should fail"
+        );
+        let err = "unknown".parse::<StartupStaleActivePolicy>().unwrap_err();
+        assert!(
+            err.contains("abort, auto_reconcile"),
+            "error should list accepted values: {err}"
         );
     }
 }

--- a/v3/robsond/src/daemon.rs
+++ b/v3/robsond/src/daemon.rs
@@ -819,8 +819,9 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
 
     /// Two-phase startup auto-reconcile for stale-active positions.
     ///
-    /// Phase 1 (read-only): gather real evidence for every stale-active position.
-    /// Phase 2 (write): reconcile-close each position that passed Phase 1.
+    /// Phase 1 (read-only): gather real evidence for every stale-active
+    /// position. Phase 2 (write): reconcile-close each position that passed
+    /// Phase 1.
     ///
     /// Fail-closed: if Phase 1 fails for any position, no writes occur and the
     /// daemon exits with code 78.
@@ -879,7 +880,9 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
                         robson_domain::ReconciliationEvidence::UserTradeRecord(_) => "user_trade",
                         other => {
                             let variant = match other {
-                                robson_domain::ReconciliationEvidence::AccountSnapshot(_) => "account_snapshot",
+                                robson_domain::ReconciliationEvidence::AccountSnapshot(_) => {
+                                    "account_snapshot"
+                                },
                                 robson_domain::ReconciliationEvidence::Estimated(_) => "estimated",
                                 _ => "unknown",
                             };
@@ -953,8 +956,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
                 entry_price: p.entry_price.map(|pr| pr.as_decimal()),
             })
             .collect();
-        self.apply_startup_auto_reconcile_batch(inputs, stale_infos)
-            .await?;
+        self.apply_startup_auto_reconcile_batch(inputs, stale_infos).await?;
 
         info!(
             count = stale_actives.len(),
@@ -1971,12 +1973,17 @@ mod tests {
             matches!(err, DaemonError::StartupStaleActiveDetected { count: 1, .. }),
             "Abort policy must fail with stale-active, got: {err:?}"
         );
-        let stored_abort = daemon_abort.store.positions().find_by_id(pid_abort).await.unwrap().unwrap();
-        assert!(matches!(stored_abort.state, PositionState::Active { .. }), "Abort must leave position Active");
+        let stored_abort =
+            daemon_abort.store.positions().find_by_id(pid_abort).await.unwrap().unwrap();
+        assert!(
+            matches!(stored_abort.state, PositionState::Active { .. }),
+            "Abort must leave position Active"
+        );
 
         // --- AutoReconcile path ---
         let mut config_auto = Config::test();
-        config_auto.reconciliation.on_startup_stale_active = StartupStaleActivePolicy::AutoReconcile;
+        config_auto.reconciliation.on_startup_stale_active =
+            StartupStaleActivePolicy::AutoReconcile;
         let daemon_auto = Daemon::new_stub(config_auto);
 
         let mut pos_auto = active_position(symbol.clone(), Side::Long);
@@ -1985,21 +1992,18 @@ mod tests {
         daemon_auto.store.positions().save(&pos_auto).await.unwrap();
 
         let now = chrono::Utc::now();
-        daemon_auto.exchange.set_order_result(
-            "EX-ORDER-1",
-            order_result("EX-ORDER-1", dec!(90), dec!(0.010), now),
-        );
+        daemon_auto
+            .exchange
+            .set_order_result("EX-ORDER-1", order_result("EX-ORDER-1", dec!(90), dec!(0.010), now));
 
         daemon_auto.run_startup_stale_active_gate().await.unwrap();
-        let stored_auto = daemon_auto.store.positions().find_by_id(pid_auto).await.unwrap().unwrap();
+        let stored_auto =
+            daemon_auto.store.positions().find_by_id(pid_auto).await.unwrap().unwrap();
         assert!(
-            matches!(
-                stored_auto.state,
-                PositionState::Closed {
-                    exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
-                    ..
-                }
-            ),
+            matches!(stored_auto.state, PositionState::Closed {
+                exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+                ..
+            }),
             "AutoReconcile policy must close stale-active with real evidence"
         );
     }
@@ -2051,13 +2055,10 @@ mod tests {
         daemon.run_startup_auto_reconcile().await.unwrap();
 
         let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
-        assert!(matches!(
-            stored.state,
-            PositionState::Closed {
-                exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
-                ..
-            }
-        ));
+        assert!(matches!(stored.state, PositionState::Closed {
+            exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+            ..
+        }));
     }
 
     #[tokio::test]
@@ -2071,27 +2072,21 @@ mod tests {
         daemon.store.positions().save(&position).await.unwrap();
 
         let now = chrono::Utc::now();
-        daemon.exchange.set_user_trades(
-            &symbol.as_pair(),
-            vec![user_trade(
-                "TRADE-1",
-                "EX-ORDER-2",
-                dec!(90),
-                dec!(0.010),
-                now,
-            )],
-        );
+        daemon.exchange.set_user_trades(&symbol.as_pair(), vec![user_trade(
+            "TRADE-1",
+            "EX-ORDER-2",
+            dec!(90),
+            dec!(0.010),
+            now,
+        )]);
 
         daemon.run_startup_auto_reconcile().await.unwrap();
 
         let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
-        assert!(matches!(
-            stored.state,
-            PositionState::Closed {
-                exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
-                ..
-            }
-        ));
+        assert!(matches!(stored.state, PositionState::Closed {
+            exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+            ..
+        }));
     }
 
     #[tokio::test]
@@ -2186,9 +2181,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_startup_auto_reconcile_batch_rejected_unsupported_evidence() {
-        use robson_domain::{
-            AccountSnapshotEvidence, Price, Quantity, ReconciliationEvidence,
-        };
+        use robson_domain::{AccountSnapshotEvidence, Price, Quantity, ReconciliationEvidence};
         let daemon = Daemon::new_stub(config_with_auto_reconcile());
         let symbol = robson_domain::Symbol::from_pair("BTCUSDT").unwrap();
 
@@ -2212,16 +2205,13 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(
-                vec![input],
-                vec![StartupStaleActiveInfo {
-                    position_id: pid,
-                    symbol: symbol.as_pair(),
-                    side: "Long".to_string(),
-                    quantity: dec!(0.010),
-                    entry_price: Some(dec!(100)),
-                }],
-            )
+            .apply_startup_auto_reconcile_batch(vec![input], vec![StartupStaleActiveInfo {
+                position_id: pid,
+                symbol: symbol.as_pair(),
+                side: "Long".to_string(),
+                quantity: dec!(0.010),
+                entry_price: Some(dec!(100)),
+            }])
             .await
             .unwrap_err();
 
@@ -2231,7 +2221,10 @@ mod tests {
         );
 
         let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
-        assert!(matches!(stored.state, PositionState::Active { .. }), "position must remain Active");
+        assert!(
+            matches!(stored.state, PositionState::Active { .. }),
+            "position must remain Active"
+        );
     }
 
     #[tokio::test]
@@ -2272,16 +2265,13 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(
-                vec![input],
-                vec![StartupStaleActiveInfo {
-                    position_id: pid,
-                    symbol: symbol.as_pair(),
-                    side: "Long".to_string(),
-                    quantity: dec!(0.010),
-                    entry_price: Some(dec!(100)),
-                }],
-            )
+            .apply_startup_auto_reconcile_batch(vec![input], vec![StartupStaleActiveInfo {
+                position_id: pid,
+                symbol: symbol.as_pair(),
+                side: "Long".to_string(),
+                quantity: dec!(0.010),
+                entry_price: Some(dec!(100)),
+            }])
             .await
             .unwrap_err();
 
@@ -2293,9 +2283,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_startup_auto_reconcile_batch_rejected_inconsistent_evidence() {
-        use robson_domain::{
-            OrderFillEvidence, Price, Quantity, ReconciliationEvidence,
-        };
+        use robson_domain::{OrderFillEvidence, Price, Quantity, ReconciliationEvidence};
         let daemon = Daemon::new_stub(config_with_auto_reconcile());
         let symbol = robson_domain::Symbol::from_pair("BTCUSDT").unwrap();
 
@@ -2323,16 +2311,13 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(
-                vec![input],
-                vec![StartupStaleActiveInfo {
-                    position_id: pid,
-                    symbol: symbol.as_pair(),
-                    side: "Long".to_string(),
-                    quantity: dec!(0.010),
-                    entry_price: Some(dec!(100)),
-                }],
-            )
+            .apply_startup_auto_reconcile_batch(vec![input], vec![StartupStaleActiveInfo {
+                position_id: pid,
+                symbol: symbol.as_pair(),
+                side: "Long".to_string(),
+                quantity: dec!(0.010),
+                entry_price: Some(dec!(100)),
+            }])
             .await
             .unwrap_err();
 
@@ -2342,14 +2327,17 @@ mod tests {
         );
 
         let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
-        assert!(matches!(stored.state, PositionState::Active { .. }), "position must remain Active");
+        assert!(
+            matches!(stored.state, PositionState::Active { .. }),
+            "position must remain Active"
+        );
     }
 
     #[tokio::test]
     async fn test_startup_auto_reconcile_batch_fail_fast_stops_at_first_rejection() {
         use robson_domain::{
-            AccountSnapshotEvidence, OrderFillEvidence, Price, Quantity,
-            ReconciliationEvidence, Symbol,
+            AccountSnapshotEvidence, OrderFillEvidence, Price, Quantity, ReconciliationEvidence,
+            Symbol,
         };
         let daemon = Daemon::new_stub(config_with_auto_reconcile());
         let symbol_a = Symbol::from_pair("BTCUSDT").unwrap();
@@ -2400,25 +2388,22 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(
-                vec![input_a, input_b],
-                vec![
-                    StartupStaleActiveInfo {
-                        position_id: pid_a,
-                        symbol: symbol_a.as_pair(),
-                        side: "Long".to_string(),
-                        quantity: dec!(0.010),
-                        entry_price: Some(dec!(100)),
-                    },
-                    StartupStaleActiveInfo {
-                        position_id: pid_b,
-                        symbol: symbol_b.as_pair(),
-                        side: "Long".to_string(),
-                        quantity: dec!(0.010),
-                        entry_price: Some(dec!(100)),
-                    },
-                ],
-            )
+            .apply_startup_auto_reconcile_batch(vec![input_a, input_b], vec![
+                StartupStaleActiveInfo {
+                    position_id: pid_a,
+                    symbol: symbol_a.as_pair(),
+                    side: "Long".to_string(),
+                    quantity: dec!(0.010),
+                    entry_price: Some(dec!(100)),
+                },
+                StartupStaleActiveInfo {
+                    position_id: pid_b,
+                    symbol: symbol_b.as_pair(),
+                    side: "Long".to_string(),
+                    quantity: dec!(0.010),
+                    entry_price: Some(dec!(100)),
+                },
+            ])
             .await
             .unwrap_err();
 
@@ -2429,10 +2414,16 @@ mod tests {
 
         // pos_a was never going to be closed (rejected first)
         let stored_a = daemon.store.positions().find_by_id(pid_a).await.unwrap().unwrap();
-        assert!(matches!(stored_a.state, PositionState::Active { .. }), "pos_a must remain Active");
+        assert!(
+            matches!(stored_a.state, PositionState::Active { .. }),
+            "pos_a must remain Active"
+        );
 
         // pos_b must also remain Active because the batch stopped at pos_a
         let stored_b = daemon.store.positions().find_by_id(pid_b).await.unwrap().unwrap();
-        assert!(matches!(stored_b.state, PositionState::Active { .. }), "pos_b must remain Active (fail-fast)");
+        assert!(
+            matches!(stored_b.state, PositionState::Active { .. }),
+            "pos_b must remain Active (fail-fast)"
+        );
     }
 }

--- a/v3/robsond/src/daemon.rs
+++ b/v3/robsond/src/daemon.rs
@@ -57,10 +57,10 @@ use crate::{
     error::{DaemonError, DaemonResult, StartupStaleActiveInfo},
     event_bus::{DaemonEvent, EventBus},
     market_data::MarketDataManager,
-    position_manager::PositionManager,
+    position_manager::{PositionManager, ReconcileCloseOutcome, ReconciledCloseInput},
     position_monitor::{PositionMonitor, PositionMonitorConfig as RuntimePositionMonitorConfig},
     query_engine::{QueryRecorder, TracingQueryRecorder},
-    reconciliation_worker::ReconciliationWorker,
+    reconciliation_worker::{gather_real_evidence, ReconciliationWorker},
 };
 
 // =============================================================================
@@ -813,7 +813,217 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
     async fn run_startup_stale_active_gate(&self) -> DaemonResult<()> {
         match self.config.reconciliation.on_startup_stale_active {
             StartupStaleActivePolicy::Abort => self.abort_if_stale_active().await,
+            StartupStaleActivePolicy::AutoReconcile => self.run_startup_auto_reconcile().await,
         }
+    }
+
+    /// Two-phase startup auto-reconcile for stale-active positions.
+    ///
+    /// Phase 1 (read-only): gather real evidence for every stale-active position.
+    /// Phase 2 (write): reconcile-close each position that passed Phase 1.
+    ///
+    /// Fail-closed: if Phase 1 fails for any position, no writes occur and the
+    /// daemon exits with code 78.
+    async fn run_startup_auto_reconcile(&self) -> DaemonResult<()> {
+        // ------------------------------------------------------------------
+        // Phase 0 — detect stale-active
+        // ------------------------------------------------------------------
+        let exchange_positions = self.exchange.get_all_open_positions().await?;
+        let local_positions = self.store.positions().find_active().await?;
+
+        let mut stale_actives: Vec<&robson_domain::Position> = Vec::new();
+        for position in &local_positions {
+            if !matches!(position.state, PositionState::Active { .. }) {
+                continue;
+            }
+            let present_on_exchange = exchange_positions
+                .iter()
+                .any(|ep| ep.symbol == position.symbol && ep.side == position.side);
+            if !present_on_exchange {
+                stale_actives.push(position);
+            }
+        }
+
+        if stale_actives.is_empty() {
+            info!(
+                count = 0,
+                "Startup stale-active auto-reconcile: clean, no stale-active positions"
+            );
+            return Ok(());
+        }
+
+        info!(
+            count = stale_actives.len(),
+            "Startup stale-active auto-reconcile: detected stale-active positions"
+        );
+
+        // ------------------------------------------------------------------
+        // Phase 1 — read-only evidence gathering (all-or-nothing)
+        // ------------------------------------------------------------------
+        let mut inputs: Vec<ReconciledCloseInput> = Vec::with_capacity(stale_actives.len());
+        for position in &stale_actives {
+            let observed_at_floor = position.entry_filled_at.unwrap_or(position.created_at);
+
+            match gather_real_evidence(
+                &self.exchange,
+                &self.store,
+                position,
+                position.quantity,
+                observed_at_floor,
+            )
+            .await?
+            {
+                Some(input) => {
+                    let evidence_source = match &input.evidence {
+                        robson_domain::ReconciliationEvidence::OrderFillRecord(_) => "order_fill",
+                        robson_domain::ReconciliationEvidence::UserTradeRecord(_) => "user_trade",
+                        other => {
+                            let variant = match other {
+                                robson_domain::ReconciliationEvidence::AccountSnapshot(_) => "account_snapshot",
+                                robson_domain::ReconciliationEvidence::Estimated(_) => "estimated",
+                                _ => "unknown",
+                            };
+                            error!(
+                                position_id = %position.id,
+                                symbol = %position.symbol.as_pair(),
+                                side = ?position.side,
+                                evidence_source = %variant,
+                                "Startup auto-reconcile: unsupported evidence type gathered in Phase 1"
+                            );
+                            let infos: Vec<StartupStaleActiveInfo> = stale_actives
+                                .iter()
+                                .map(|p| StartupStaleActiveInfo {
+                                    position_id: p.id,
+                                    symbol: p.symbol.as_pair(),
+                                    side: format!("{:?}", p.side),
+                                    quantity: p.quantity.as_decimal(),
+                                    entry_price: p.entry_price.map(|pr| pr.as_decimal()),
+                                })
+                                .collect();
+                            return Err(DaemonError::StartupStaleActiveDetected {
+                                count: stale_actives.len(),
+                                positions: infos,
+                            });
+                        },
+                    };
+                    info!(
+                        position_id = %position.id,
+                        symbol = %position.symbol.as_pair(),
+                        side = ?position.side,
+                        %evidence_source,
+                        "Startup auto-reconcile: real evidence gathered"
+                    );
+                    inputs.push(input);
+                },
+                None => {
+                    error!(
+                        position_id = %position.id,
+                        symbol = %position.symbol.as_pair(),
+                        side = ?position.side,
+                        "Startup auto-reconcile: no unambiguous real evidence for stale-active position"
+                    );
+                    let infos: Vec<StartupStaleActiveInfo> = stale_actives
+                        .iter()
+                        .map(|p| StartupStaleActiveInfo {
+                            position_id: p.id,
+                            symbol: p.symbol.as_pair(),
+                            side: format!("{:?}", p.side),
+                            quantity: p.quantity.as_decimal(),
+                            entry_price: p.entry_price.map(|pr| pr.as_decimal()),
+                        })
+                        .collect();
+                    return Err(DaemonError::StartupStaleActiveDetected {
+                        count: stale_actives.len(),
+                        positions: infos,
+                    });
+                },
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Phase 2 — apply reconcile-close for each validated input (fail-fast)
+        // ------------------------------------------------------------------
+        let stale_infos: Vec<StartupStaleActiveInfo> = stale_actives
+            .iter()
+            .map(|p| StartupStaleActiveInfo {
+                position_id: p.id,
+                symbol: p.symbol.as_pair(),
+                side: format!("{:?}", p.side),
+                quantity: p.quantity.as_decimal(),
+                entry_price: p.entry_price.map(|pr| pr.as_decimal()),
+            })
+            .collect();
+        self.apply_startup_auto_reconcile_batch(inputs, stale_infos)
+            .await?;
+
+        info!(
+            count = stale_actives.len(),
+            "Startup stale-active auto-reconcile: all positions reconciled and closed"
+        );
+        Ok(())
+    }
+
+    /// Apply reconcile-close for a batch of validated inputs.
+    ///
+    /// Fail-fast: stops at the first rejection and does not process subsequent
+    /// inputs. This reduces blast radius when an unexpected inconsistency
+    /// occurs during startup reconciliation.
+    async fn apply_startup_auto_reconcile_batch(
+        &self,
+        inputs: Vec<ReconciledCloseInput>,
+        stale_infos: Vec<StartupStaleActiveInfo>,
+    ) -> DaemonResult<()> {
+        for input in inputs {
+            let position_id = input.position_id;
+            let outcome = {
+                let manager = self.position_manager.read().await;
+                manager.reconcile_close(input).await?
+            };
+
+            match outcome {
+                ReconcileCloseOutcome::Closed | ReconcileCloseOutcome::AlreadyTerminal => {
+                    info!(
+                        position_id = %position_id,
+                        outcome = ?outcome,
+                        "Startup auto-reconcile: position closed"
+                    );
+                },
+                ReconcileCloseOutcome::RejectedUnsupportedEvidence { source } => {
+                    error!(
+                        position_id = %position_id,
+                        %source,
+                        "Startup auto-reconcile CRITICAL: reconcile_close rejected unsupported evidence"
+                    );
+                    return Err(DaemonError::StartupStaleActiveDetected {
+                        count: stale_infos.len(),
+                        positions: stale_infos,
+                    });
+                },
+                ReconcileCloseOutcome::RejectedInconsistentEvidence { field } => {
+                    error!(
+                        position_id = %position_id,
+                        %field,
+                        "Startup auto-reconcile CRITICAL: reconcile_close rejected inconsistent evidence"
+                    );
+                    return Err(DaemonError::StartupStaleActiveDetected {
+                        count: stale_infos.len(),
+                        positions: stale_infos,
+                    });
+                },
+                ReconcileCloseOutcome::SkippedNonActive { state } => {
+                    error!(
+                        position_id = %position_id,
+                        %state,
+                        "Startup auto-reconcile CRITICAL: reconcile_close skipped non-active position"
+                    );
+                    return Err(DaemonError::StartupStaleActiveDetected {
+                        count: stale_infos.len(),
+                        positions: stale_infos,
+                    });
+                },
+            }
+        }
+        Ok(())
     }
 
     async fn abort_if_stale_active(&self) -> DaemonResult<()> {
@@ -1666,5 +1876,563 @@ mod tests {
         daemon.store.positions().save(&pos).await.unwrap();
 
         daemon.abort_if_stale_active().await.unwrap();
+    }
+
+    // -------------------------------------------------------------------------
+    // TD-2026-05-05-001 Slice 5B2B — Startup auto-reconcile tests
+    // -------------------------------------------------------------------------
+
+    fn config_with_auto_reconcile() -> Config {
+        let mut config = Config::test();
+        config.reconciliation.on_startup_stale_active = StartupStaleActivePolicy::AutoReconcile;
+        config
+    }
+
+    fn order_result(
+        exchange_order_id: &str,
+        price: rust_decimal::Decimal,
+        quantity: rust_decimal::Decimal,
+        filled_at: chrono::DateTime<chrono::Utc>,
+    ) -> robson_exec::OrderResult {
+        use robson_domain::{Price, Quantity};
+        robson_exec::OrderResult {
+            exchange_order_id: exchange_order_id.to_string(),
+            client_order_id: format!("client-{exchange_order_id}"),
+            fill_price: Price::new(price).unwrap(),
+            filled_quantity: Quantity::new(quantity).unwrap(),
+            fee: rust_decimal_macros::dec!(0.01),
+            fee_asset: "USDT".to_string(),
+            filled_at,
+        }
+    }
+
+    fn user_trade(
+        exchange_trade_id: &str,
+        exchange_order_id: &str,
+        price: rust_decimal::Decimal,
+        quantity: rust_decimal::Decimal,
+        filled_at: chrono::DateTime<chrono::Utc>,
+    ) -> robson_exec::UserTradeRecord {
+        use robson_domain::{Price, Quantity};
+        robson_exec::UserTradeRecord {
+            exchange_order_id: exchange_order_id.to_string(),
+            exchange_trade_id: exchange_trade_id.to_string(),
+            fill_price: Price::new(price).unwrap(),
+            filled_quantity: Quantity::new(quantity).unwrap(),
+            fee: rust_decimal_macros::dec!(0.01),
+            fee_asset: "USDT".to_string(),
+            filled_at,
+        }
+    }
+
+    async fn attach_insurance_order(
+        store: &std::sync::Arc<robson_store::MemoryStore>,
+        position: &mut robson_domain::Position,
+        exchange_order_id: &str,
+    ) {
+        use robson_domain::{Order, OrderSide, Price};
+        let order = {
+            let mut order = Order::new_stop_loss_limit(
+                position.id,
+                position.symbol.clone(),
+                OrderSide::Sell,
+                position.quantity,
+                Price::new(rust_decimal_macros::dec!(99)).unwrap(),
+                Price::new(rust_decimal_macros::dec!(99)).unwrap(),
+            );
+            order.exchange_order_id = Some(exchange_order_id.to_string());
+            order
+        };
+
+        if let PositionState::Active { insurance_stop_id, .. } = &mut position.state {
+            *insurance_stop_id = Some(order.id);
+        }
+        position.insurance_stop_id = Some(order.id);
+        store.orders().save(&order).await.unwrap();
+        store.positions().save(position).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_startup_dispatch_abort_vs_auto_reconcile_is_observable() {
+        use robson_domain::Symbol;
+        let symbol = Symbol::from_pair("BTCUSDT").unwrap();
+
+        // --- Abort path ---
+        let mut config_abort = Config::test();
+        config_abort.reconciliation.on_startup_stale_active = StartupStaleActivePolicy::Abort;
+        let daemon_abort = Daemon::new_stub(config_abort);
+
+        let pos_abort = active_position(symbol.clone(), Side::Long);
+        let pid_abort = pos_abort.id;
+        daemon_abort.store.positions().save(&pos_abort).await.unwrap();
+
+        let err = daemon_abort.run_startup_stale_active_gate().await.unwrap_err();
+        assert!(
+            matches!(err, DaemonError::StartupStaleActiveDetected { count: 1, .. }),
+            "Abort policy must fail with stale-active, got: {err:?}"
+        );
+        let stored_abort = daemon_abort.store.positions().find_by_id(pid_abort).await.unwrap().unwrap();
+        assert!(matches!(stored_abort.state, PositionState::Active { .. }), "Abort must leave position Active");
+
+        // --- AutoReconcile path ---
+        let mut config_auto = Config::test();
+        config_auto.reconciliation.on_startup_stale_active = StartupStaleActivePolicy::AutoReconcile;
+        let daemon_auto = Daemon::new_stub(config_auto);
+
+        let mut pos_auto = active_position(symbol.clone(), Side::Long);
+        let pid_auto = pos_auto.id;
+        attach_insurance_order(&daemon_auto.store, &mut pos_auto, "EX-ORDER-1").await;
+        daemon_auto.store.positions().save(&pos_auto).await.unwrap();
+
+        let now = chrono::Utc::now();
+        daemon_auto.exchange.set_order_result(
+            "EX-ORDER-1",
+            order_result("EX-ORDER-1", dec!(90), dec!(0.010), now),
+        );
+
+        daemon_auto.run_startup_stale_active_gate().await.unwrap();
+        let stored_auto = daemon_auto.store.positions().find_by_id(pid_auto).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                stored_auto.state,
+                PositionState::Closed {
+                    exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+                    ..
+                }
+            ),
+            "AutoReconcile policy must close stale-active with real evidence"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_zero_stale_active_returns_ok() {
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+        daemon.run_startup_auto_reconcile().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_active_on_exchange_not_closed() {
+        use robson_domain::Symbol;
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+        let symbol = Symbol::from_pair("BTCUSDT").unwrap();
+
+        let position = active_position(symbol.clone(), Side::Long);
+        let pid = position.id;
+        daemon.store.positions().save(&position).await.unwrap();
+        daemon.exchange.set_open_position(
+            symbol,
+            Side::Long,
+            position.quantity,
+            position.entry_price.unwrap(),
+        );
+
+        daemon.run_startup_auto_reconcile().await.unwrap();
+
+        let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
+        assert!(matches!(stored.state, PositionState::Active { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_order_fill_closes_position() {
+        use robson_domain::Symbol;
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+        let symbol = Symbol::from_pair("BTCUSDT").unwrap();
+
+        let mut position = active_position(symbol.clone(), Side::Long);
+        let pid = position.id;
+        attach_insurance_order(&daemon.store, &mut position, "EX-ORDER-1").await;
+        daemon.store.positions().save(&position).await.unwrap();
+
+        let now = chrono::Utc::now();
+        daemon
+            .exchange
+            .set_order_result("EX-ORDER-1", order_result("EX-ORDER-1", dec!(90), dec!(0.010), now));
+
+        daemon.run_startup_auto_reconcile().await.unwrap();
+
+        let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
+        assert!(matches!(
+            stored.state,
+            PositionState::Closed {
+                exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_user_trade_closes_position() {
+        use robson_domain::Symbol;
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+        let symbol = Symbol::from_pair("BTCUSDT").unwrap();
+
+        let position = active_position(symbol.clone(), Side::Long);
+        let pid = position.id;
+        daemon.store.positions().save(&position).await.unwrap();
+
+        let now = chrono::Utc::now();
+        daemon.exchange.set_user_trades(
+            &symbol.as_pair(),
+            vec![user_trade(
+                "TRADE-1",
+                "EX-ORDER-2",
+                dec!(90),
+                dec!(0.010),
+                now,
+            )],
+        );
+
+        daemon.run_startup_auto_reconcile().await.unwrap();
+
+        let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
+        assert!(matches!(
+            stored.state,
+            PositionState::Closed {
+                exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_no_evidence_returns_typed_error() {
+        use robson_domain::Symbol;
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+
+        let position = active_position(Symbol::from_pair("BTCUSDT").unwrap(), Side::Long);
+        daemon.store.positions().save(&position).await.unwrap();
+
+        let err = daemon.run_startup_auto_reconcile().await.unwrap_err();
+        assert!(
+            matches!(err, DaemonError::StartupStaleActiveDetected { count: 1, .. }),
+            "expected StartupStaleActiveDetected, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_phase1_all_or_nothing() {
+        use robson_domain::Symbol;
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+        let symbol_a = Symbol::from_pair("BTCUSDT").unwrap();
+        let symbol_b = Symbol::from_pair("ETHUSDT").unwrap();
+
+        let mut pos_a = active_position(symbol_a.clone(), Side::Long);
+        let pid_a = pos_a.id;
+        attach_insurance_order(&daemon.store, &mut pos_a, "EX-ORDER-A").await;
+        daemon.store.positions().save(&pos_a).await.unwrap();
+
+        let pos_b = active_position(symbol_b.clone(), Side::Long);
+        let pid_b = pos_b.id;
+        daemon.store.positions().save(&pos_b).await.unwrap();
+
+        let now = chrono::Utc::now();
+        daemon
+            .exchange
+            .set_order_result("EX-ORDER-A", order_result("EX-ORDER-A", dec!(90), dec!(0.010), now));
+        // pos_b has no evidence
+
+        let err = daemon.run_startup_auto_reconcile().await.unwrap_err();
+        assert!(
+            matches!(err, DaemonError::StartupStaleActiveDetected { count: 2, .. }),
+            "expected StartupStaleActiveDetected for batch, got: {err:?}"
+        );
+
+        let stored_a = daemon.store.positions().find_by_id(pid_a).await.unwrap().unwrap();
+        let stored_b = daemon.store.positions().find_by_id(pid_b).await.unwrap().unwrap();
+        assert!(
+            matches!(stored_a.state, PositionState::Active { .. }),
+            "pos_a must remain Active"
+        );
+        assert!(
+            matches!(stored_b.state, PositionState::Active { .. }),
+            "pos_b must remain Active"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_entering_not_processed() {
+        use robson_domain::Symbol;
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+
+        let mut pos = active_position(Symbol::from_pair("BTCUSDT").unwrap(), Side::Long);
+        pos.state = PositionState::Entering {
+            entry_order_id: uuid::Uuid::now_v7(),
+            expected_entry: Price::new(dec!(100)).unwrap(),
+            signal_id: uuid::Uuid::now_v7(),
+        };
+        daemon.store.positions().save(&pos).await.unwrap();
+
+        daemon.run_startup_auto_reconcile().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_exiting_not_processed() {
+        use robson_domain::{ExitReason, Symbol};
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+
+        let mut pos = active_position(Symbol::from_pair("BTCUSDT").unwrap(), Side::Long);
+        pos.state = PositionState::Exiting {
+            exit_order_id: uuid::Uuid::now_v7(),
+            exit_reason: ExitReason::TrailingStop,
+        };
+        daemon.store.positions().save(&pos).await.unwrap();
+
+        daemon.run_startup_auto_reconcile().await.unwrap();
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 2 fail-fast tests via apply_startup_auto_reconcile_batch
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_batch_rejected_unsupported_evidence() {
+        use robson_domain::{
+            AccountSnapshotEvidence, Price, Quantity, ReconciliationEvidence,
+        };
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+        let symbol = robson_domain::Symbol::from_pair("BTCUSDT").unwrap();
+
+        let position = active_position(symbol.clone(), Side::Long);
+        let pid = position.id;
+        daemon.store.positions().save(&position).await.unwrap();
+
+        let now = chrono::Utc::now();
+        let input = ReconciledCloseInput {
+            position_id: pid,
+            exit_price: Price::new(dec!(90)).unwrap(),
+            filled_quantity: Quantity::new(dec!(0.010)).unwrap(),
+            fee: dec!(0.01),
+            fee_asset: "USDT".to_string(),
+            closed_at: now,
+            evidence: ReconciliationEvidence::AccountSnapshot(AccountSnapshotEvidence {
+                first_observed_missing_at: now,
+                confirmed_missing_at: now,
+                futures_balance_delta: None,
+            }),
+        };
+
+        let err = daemon
+            .apply_startup_auto_reconcile_batch(
+                vec![input],
+                vec![StartupStaleActiveInfo {
+                    position_id: pid,
+                    symbol: symbol.as_pair(),
+                    side: "Long".to_string(),
+                    quantity: dec!(0.010),
+                    entry_price: Some(dec!(100)),
+                }],
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, DaemonError::StartupStaleActiveDetected { count: 1, .. }),
+            "expected fail-fast on unsupported evidence, got: {err:?}"
+        );
+
+        let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
+        assert!(matches!(stored.state, PositionState::Active { .. }), "position must remain Active");
+    }
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_batch_skipped_non_active() {
+        use robson_domain::{
+            ExitReason, OrderFillEvidence, Price, Quantity, ReconciliationEvidence,
+        };
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+        let symbol = robson_domain::Symbol::from_pair("BTCUSDT").unwrap();
+
+        let mut position = active_position(symbol.clone(), Side::Long);
+        let pid = position.id;
+        daemon.store.positions().save(&position).await.unwrap();
+
+        // Mutate to Exiting before calling the batch helper
+        position.state = PositionState::Exiting {
+            exit_order_id: uuid::Uuid::now_v7(),
+            exit_reason: ExitReason::TrailingStop,
+        };
+        daemon.store.positions().save(&position).await.unwrap();
+
+        let now = chrono::Utc::now();
+        let input = ReconciledCloseInput {
+            position_id: pid,
+            exit_price: Price::new(dec!(90)).unwrap(),
+            filled_quantity: Quantity::new(dec!(0.010)).unwrap(),
+            fee: dec!(0.01),
+            fee_asset: "USDT".to_string(),
+            closed_at: now,
+            evidence: ReconciliationEvidence::OrderFillRecord(OrderFillEvidence {
+                exchange_order_id: "EX-ORDER-1".to_string(),
+                fill_price: Price::new(dec!(90)).unwrap(),
+                filled_quantity: Quantity::new(dec!(0.010)).unwrap(),
+                fee: dec!(0.01),
+                fee_asset: "USDT".to_string(),
+                filled_at: now,
+            }),
+        };
+
+        let err = daemon
+            .apply_startup_auto_reconcile_batch(
+                vec![input],
+                vec![StartupStaleActiveInfo {
+                    position_id: pid,
+                    symbol: symbol.as_pair(),
+                    side: "Long".to_string(),
+                    quantity: dec!(0.010),
+                    entry_price: Some(dec!(100)),
+                }],
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, DaemonError::StartupStaleActiveDetected { count: 1, .. }),
+            "expected fail-fast on skipped non-active, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_batch_rejected_inconsistent_evidence() {
+        use robson_domain::{
+            OrderFillEvidence, Price, Quantity, ReconciliationEvidence,
+        };
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+        let symbol = robson_domain::Symbol::from_pair("BTCUSDT").unwrap();
+
+        let position = active_position(symbol.clone(), Side::Long);
+        let pid = position.id;
+        daemon.store.positions().save(&position).await.unwrap();
+
+        let now = chrono::Utc::now();
+        // exit_price (95) != evidence.fill_price (90) → inconsistent
+        let input = ReconciledCloseInput {
+            position_id: pid,
+            exit_price: Price::new(dec!(95)).unwrap(),
+            filled_quantity: Quantity::new(dec!(0.010)).unwrap(),
+            fee: dec!(0.01),
+            fee_asset: "USDT".to_string(),
+            closed_at: now,
+            evidence: ReconciliationEvidence::OrderFillRecord(OrderFillEvidence {
+                exchange_order_id: "EX-ORDER-1".to_string(),
+                fill_price: Price::new(dec!(90)).unwrap(),
+                filled_quantity: Quantity::new(dec!(0.010)).unwrap(),
+                fee: dec!(0.01),
+                fee_asset: "USDT".to_string(),
+                filled_at: now,
+            }),
+        };
+
+        let err = daemon
+            .apply_startup_auto_reconcile_batch(
+                vec![input],
+                vec![StartupStaleActiveInfo {
+                    position_id: pid,
+                    symbol: symbol.as_pair(),
+                    side: "Long".to_string(),
+                    quantity: dec!(0.010),
+                    entry_price: Some(dec!(100)),
+                }],
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, DaemonError::StartupStaleActiveDetected { count: 1, .. }),
+            "expected fail-fast on inconsistent evidence, got: {err:?}"
+        );
+
+        let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
+        assert!(matches!(stored.state, PositionState::Active { .. }), "position must remain Active");
+    }
+
+    #[tokio::test]
+    async fn test_startup_auto_reconcile_batch_fail_fast_stops_at_first_rejection() {
+        use robson_domain::{
+            AccountSnapshotEvidence, OrderFillEvidence, Price, Quantity,
+            ReconciliationEvidence, Symbol,
+        };
+        let daemon = Daemon::new_stub(config_with_auto_reconcile());
+        let symbol_a = Symbol::from_pair("BTCUSDT").unwrap();
+        let symbol_b = Symbol::from_pair("ETHUSDT").unwrap();
+
+        let pos_a = active_position(symbol_a.clone(), Side::Long);
+        let pid_a = pos_a.id;
+        daemon.store.positions().save(&pos_a).await.unwrap();
+
+        let mut pos_b = active_position(symbol_b.clone(), Side::Long);
+        let pid_b = pos_b.id;
+        attach_insurance_order(&daemon.store, &mut pos_b, "EX-ORDER-B").await;
+        daemon.store.positions().save(&pos_b).await.unwrap();
+
+        let now = chrono::Utc::now();
+
+        // First input: unsupported evidence (will be rejected)
+        let input_a = ReconciledCloseInput {
+            position_id: pid_a,
+            exit_price: Price::new(dec!(90)).unwrap(),
+            filled_quantity: Quantity::new(dec!(0.010)).unwrap(),
+            fee: dec!(0.01),
+            fee_asset: "USDT".to_string(),
+            closed_at: now,
+            evidence: ReconciliationEvidence::AccountSnapshot(AccountSnapshotEvidence {
+                first_observed_missing_at: now,
+                confirmed_missing_at: now,
+                futures_balance_delta: None,
+            }),
+        };
+
+        // Second input: valid order-fill evidence (would close if executed)
+        let input_b = ReconciledCloseInput {
+            position_id: pid_b,
+            exit_price: Price::new(dec!(90)).unwrap(),
+            filled_quantity: Quantity::new(dec!(0.010)).unwrap(),
+            fee: dec!(0.01),
+            fee_asset: "USDT".to_string(),
+            closed_at: now,
+            evidence: ReconciliationEvidence::OrderFillRecord(OrderFillEvidence {
+                exchange_order_id: "EX-ORDER-B".to_string(),
+                fill_price: Price::new(dec!(90)).unwrap(),
+                filled_quantity: Quantity::new(dec!(0.010)).unwrap(),
+                fee: dec!(0.01),
+                fee_asset: "USDT".to_string(),
+                filled_at: now,
+            }),
+        };
+
+        let err = daemon
+            .apply_startup_auto_reconcile_batch(
+                vec![input_a, input_b],
+                vec![
+                    StartupStaleActiveInfo {
+                        position_id: pid_a,
+                        symbol: symbol_a.as_pair(),
+                        side: "Long".to_string(),
+                        quantity: dec!(0.010),
+                        entry_price: Some(dec!(100)),
+                    },
+                    StartupStaleActiveInfo {
+                        position_id: pid_b,
+                        symbol: symbol_b.as_pair(),
+                        side: "Long".to_string(),
+                        quantity: dec!(0.010),
+                        entry_price: Some(dec!(100)),
+                    },
+                ],
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, DaemonError::StartupStaleActiveDetected { count: 2, .. }),
+            "expected fail-fast on first rejection, got: {err:?}"
+        );
+
+        // pos_a was never going to be closed (rejected first)
+        let stored_a = daemon.store.positions().find_by_id(pid_a).await.unwrap().unwrap();
+        assert!(matches!(stored_a.state, PositionState::Active { .. }), "pos_a must remain Active");
+
+        // pos_b must also remain Active because the batch stopped at pos_a
+        let stored_b = daemon.store.positions().find_by_id(pid_b).await.unwrap().unwrap();
+        assert!(matches!(stored_b.state, PositionState::Active { .. }), "pos_b must remain Active (fail-fast)");
     }
 }

--- a/v3/robsond/src/position_manager.rs
+++ b/v3/robsond/src/position_manager.rs
@@ -2702,7 +2702,9 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
             ReconciliationEvidence::Estimated(_) => {
                 warn!(
                     position_id = %input.position_id,
-                    "Reverse reconciliation close rejected: estimated evidence is not allowed in Slice 4A"
+                    "reconcile_close rejected: Estimated evidence is permanently \
+                     disallowed in v3. Only OrderFillRecord and UserTradeRecord are \
+                     accepted. Operator must intervene manually."
                 );
                 return Ok(ReconcileCloseOutcome::RejectedUnsupportedEvidence {
                     source: "estimated",


### PR DESCRIPTION
## Summary

- **Slice 5B2B** (`5458c36e`): implement `startup_reverse_reconciliation()` with two-phase all-or-nothing algorithm. Accepts `auto_reconcile` in `StartupStaleActivePolicy`. Adds integration tests (happy path, Estimated-downgrade, partial-evidence abort). Config via `ROBSON_RECONCILIATION_ON_STARTUP_STALE_ACTIVE=auto_reconcile` — **default remains `abort` (fail-closed)**. Production does NOT enable `auto_reconcile` in v3; deferred to MIG-v4#3.
- **v3 scope finalization** (`d4c0b488`): operator decisions 2026-05-12 applied across docs and code:
  - MIG-v3#3 ✅ Done (Django retired, SvelteKit canonical)
  - MIG-v3#4 ❌ Abandoned (superseded by MIG-v3#11 + ADR-0024; static limits eliminated)
  - MIG-v3#5 ❌ Abandoned (pause/resume/override inapplicable in slot model)
  - MIG-v3#6, #7, QE-P5 → MIG-v4
  - VAL-001 and VAL-002 corrected to ✅ PASS in migration plan
  - `docs/architecture/v4-backlog.md` created with MIG-v4#1–8
  - `Estimated` evidence hard-block message made permanent (no longer "Slice 4A" temporary)
  - Stale "TARGET ARCHITECTURE — FOLLOW-UP REQUIRED (MIG-v3#9)" notes removed from `v3-runtime-spec.md`
  - `apps/backend/` added to `.gitignore`
  - AGENTS.md and CLAUDE.md updated with policy invariants, v4 vocabulary, and updated high-value files

## Test plan

- [x] `cargo test -p robsond --lib reconcile_close_rejects_estimated` passes
- [x] `cargo fmt --all --check` passes
- [x] `startup_auto_reconcile` integration tests in `daemon.rs` cover: zero stale, active-on-exchange (no close), OrderFill close, UserTrade close, no-evidence abort, Estimated-downgrade abort, partial-evidence abort
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)