### PR TITLE
fix(v3): slot count and entry mode label for Armed positions

### DIFF
--- a/apps/frontend/src/lib/api/robson.ts
+++ b/apps/frontend/src/lib/api/robson.ts
@@ -16,6 +16,8 @@ export type Position = {
   symbol: string;
   side: "Long" | "Short" | string;
   state: PositionState;
+  entry_mode?: string | null;
+  approval_mode?: string | null;
   entry_price: number | null;
   entry_filled_at: string | null;
   tech_stop_distance: number | null;

--- a/apps/frontend/src/lib/presentation/labels.ts
+++ b/apps/frontend/src/lib/presentation/labels.ts
@@ -15,6 +15,16 @@ export function positionStateLabel(state: PositionState): string {
   return key;
 }
 
+export function entryModeLabel(mode?: string | null): string {
+  switch (mode) {
+    case 'immediate':           return 'immediate — awaiting manual signal';
+    case 'confirmed_reversal':  return 'awaiting entry signal · reversal pattern';
+    case 'confirmed_key_level': return 'awaiting entry signal · key level';
+    case 'confirmed_trend':
+    default:                    return 'awaiting entry signal · SMA crossover';
+  }
+}
+
 export function positionSummaryLines(p: Position): string[] {
   const lines: string[] = [];
   const state = p.state;
@@ -22,7 +32,9 @@ export function positionSummaryLines(p: Position): string[] {
 
   if (typeof state === 'string') {
     if (state === 'Armed') {
-      lines.push(label('ARMED', 'awaiting entry signal · SMA crossover'));
+      const modeLabel = entryModeLabel(p.entry_mode);
+      const approvalLabel = p.approval_mode === 'human_confirmation' ? ' · awaiting approval' : '';
+      lines.push(label('ARMED', `${modeLabel}${approvalLabel}`));
       lines.push(label('LEVERAGE', '10x (fixed)'));
     } else if (state === 'Active') {
       const details = [];

--- a/v3/robsond/src/api.rs
+++ b/v3/robsond/src/api.rs
@@ -137,6 +137,10 @@ pub struct PositionSummary {
     pub state: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub entry_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<Decimal>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entry_price: Option<Decimal>,
@@ -1403,10 +1407,33 @@ where
         _ => None,
     };
 
-    position_to_summary(position, live_price)
+    let entry_policy = manager.entry_policy_for_position(position.id).await;
+    let entry_mode = Some(
+        match entry_policy.mode {
+            robson_domain::EntryPolicy::Immediate => "immediate",
+            robson_domain::EntryPolicy::ConfirmedTrend => "confirmed_trend",
+            robson_domain::EntryPolicy::ConfirmedReversal => "confirmed_reversal",
+            robson_domain::EntryPolicy::ConfirmedKeyLevel => "confirmed_key_level",
+        }
+        .to_string(),
+    );
+    let approval_mode = Some(
+        match entry_policy.approval {
+            robson_domain::ApprovalPolicy::Automatic => "automatic",
+            robson_domain::ApprovalPolicy::HumanConfirmation => "human_confirmation",
+        }
+        .to_string(),
+    );
+
+    position_to_summary(position, live_price, entry_mode, approval_mode)
 }
 
-fn position_to_summary(position: &Position, live_price: Option<Price>) -> PositionSummary {
+fn position_to_summary(
+    position: &Position,
+    live_price: Option<Price>,
+    entry_mode: Option<String>,
+    approval_mode: Option<String>,
+) -> PositionSummary {
     let (state_str, entry_price, trailing_stop, current_price, pnl, variation_pct) = match &position
         .state
     {
@@ -1470,6 +1497,8 @@ fn position_to_summary(position: &Position, live_price: Option<Price>) -> Positi
         side: format!("{:?}", position.side),
         state: state_str,
         created_at: position.created_at,
+        entry_mode,
+        approval_mode,
         quantity: if position.quantity.as_decimal() > Decimal::ZERO {
             Some(position.quantity.as_decimal())
         } else {
@@ -1560,7 +1589,7 @@ where
 
     let mut summaries = Vec::with_capacity(positions.len());
     for position in &positions {
-        summaries.push(position_to_summary(position, None));
+        summaries.push(position_to_summary_with_live_price(manager, position).await);
     }
 
     Ok(summaries)
@@ -1667,7 +1696,8 @@ mod tests {
             last_emitted_stop: None,
         };
 
-        let summary = position_to_summary(&position, Some(Price::new(dec!(98)).unwrap()));
+        let summary =
+            position_to_summary(&position, Some(Price::new(dec!(98)).unwrap()), None, None);
 
         assert_eq!(summary.current_price, Some(dec!(98)));
         assert_eq!(summary.pnl, Some(dec!(-4)));
@@ -1689,7 +1719,8 @@ mod tests {
             last_emitted_stop: None,
         };
 
-        let summary = position_to_summary(&position, Some(Price::new(dec!(90)).unwrap()));
+        let summary =
+            position_to_summary(&position, Some(Price::new(dec!(90)).unwrap()), None, None);
 
         assert_eq!(summary.current_price, Some(dec!(90)));
         assert_eq!(summary.pnl, Some(dec!(-10)));
@@ -1708,7 +1739,7 @@ mod tests {
             exit_reason: robson_domain::ExitReason::UserPanic,
         };
 
-        let summary = position_to_summary(&position, None);
+        let summary = position_to_summary(&position, None, None, None);
 
         assert_eq!(summary.current_price, Some(dec!(90)));
         assert_eq!(summary.pnl, Some(dec!(20)));
@@ -2202,8 +2233,9 @@ mod tests {
         let status: StatusResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(status.active_positions, 1);
         assert_eq!(status.occupied_slots, 1);
-        assert_eq!(status.new_slots_available, 4);
-        assert_eq!(status.slot_cells_total, 5);
+        // Armed positions reserve a slot; new_slots drops by 1 (was 4, now 3).
+        assert_eq!(status.new_slots_available, 3);
+        assert_eq!(status.slot_cells_total, 4);
         assert_eq!(status.pending_approvals.len(), 1);
         assert_eq!(status.pending_approvals[0].query_id, query_id);
         assert_eq!(status.pending_approvals[0].position_id, Some(position.id));

--- a/v3/robsond/src/position_manager.rs
+++ b/v3/robsond/src/position_manager.rs
@@ -890,7 +890,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
         }
     }
 
-    async fn entry_policy_for_position(&self, position_id: PositionId) -> EntryPolicyConfig {
+    pub async fn entry_policy_for_position(&self, position_id: PositionId) -> EntryPolicyConfig {
         let entry_policies = self.entry_policies.read().await;
         entry_policies.get(&position_id).copied().unwrap_or_default()
     }
@@ -3063,9 +3063,18 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
             })
             .sum();
 
-        Ok(self
-            .trading_policy
-            .slots_available(capital_base, monthly.realized_loss, latent_risk))
+        let policy_slots =
+            self.trading_policy
+                .slots_available(capital_base, monthly.realized_loss, latent_risk);
+
+        // Armed positions have no measurable latent risk (no entry or stop yet),
+        // but each one reserves a future slot. Subtract them so the operator
+        // cannot arm more positions than the budget allows.
+        let all_open = self.store.positions().find_active().await?;
+        let armed_count =
+            all_open.iter().filter(|p| matches!(p.state, PositionState::Armed)).count() as u32;
+
+        Ok(policy_slots.saturating_sub(armed_count))
     }
 
     // =========================================================================


### PR DESCRIPTION
## Bugs corrigidos

### Bug 1 — Slot count não diminuía ao armar posição

`compute_slots_available()` usava `find_risk_open()` (Entering + Active) para calcular latent risk. Posições Armed têm latent risk = 0 (sem entry/stop ainda), então armar uma posição não reduzia `new_slots_available` — o grid expandia de 4 para 5 células em vez de manter 4 com 1 ocupada.

**Fix:** `compute_slots_available()` subtrai `armed_count` do resultado da policy. Cada posição Armed reserva 1 slot da capacidade disponível.

### Bug 2 — Label "SMA crossover" hardcoded para todos os modos

`PositionSummary` não incluía `entry_mode` / `approval_mode`. `labels.ts` usava string hardcoded para o estado Armed, independente do modo selecionado.

**Fix:**
- `PositionSummary` ganha `entry_mode` e `approval_mode` (opcionais, skip_serializing_if None)
- `position_to_summary_with_live_price` busca `entry_policy_for_position` e popula os campos
- `entryModeLabel()` helper em `labels.ts` mapeia os 4 modos para labels corretos
- Tipo `Position` no frontend ganha `entry_mode?` e `approval_mode?`

**Labels por modo:**
| mode | label |
|------|-------|
| `confirmed_trend` | `awaiting entry signal · SMA crossover` |
| `immediate` | `immediate — awaiting manual signal` |
| `confirmed_reversal` | `awaiting entry signal · reversal pattern` |
| `confirmed_key_level` | `awaiting entry signal · key level` |

## Verificação

- `cargo test --workspace`: 586 passed, 23 ignored ✅
- `cargo +nightly fmt --all --check`: ✅
- `pnpm check`: 0 errors, 4 pre-existing warnings ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)