### PR TITLE
feat: armed-position risk in capital_base, disarm UI, README v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,214 +2,172 @@
 
 [![Backend Tests](https://github.com/ldamasio/robson/actions/workflows/backend-tests.yml/badge.svg)](https://github.com/ldamasio/robson/actions/workflows/backend-tests.yml)
 
-Robson is an execution and risk management engine designed for leveraged cryptocurrency markets. It is not a trading bot. It does not generate signals, predict prices, or optimize entries.
+Robson is an execution and risk management engine for leveraged cryptocurrency markets. It is not an autonomous trading bot. It does not decide what to trade, predict prices, or scan for opportunities.
 
-Robson is concerned with what happens **after** a trading decision is made: how orders are executed, how risk is enforced, how positions are managed through their lifecycle, and how failures are handled safely under volatile conditions.
+Robson is concerned with what happens **after** a trading decision is made: position sizing from chart-derived stops, governed order execution, lifecycle management through entry to settlement, and safe failure handling under volatile conditions.
 
-The system provides a multi-tenant runtime with deterministic execution semantics, explicit risk controls, full auditability, and a clear separation between signal interpretation and order execution.
+The system provides a single-operator runtime with a slot-based monthly risk model, deterministic execution semantics, and full auditability at every state transition.
 
-## AI-First Repository Rules
+## Risk Model at a Glance
 
-Canonical AI-first repository instructions live in [AGENTS.md](AGENTS.md).
+- **Monthly budget**: 4% of `capital_base` — hard limit enforced by a circuit breaker
+- **Per-trade risk**: 1% of `capital_base` (derived from position size, never set directly)
+- **Position sizing**: `size = (capital_base × 1%) / technical_stop_distance`
+- **Technical stop**: always from chart analysis (second S/R level, 15m timeframe) — never a percentage of entry price
+- **Slot capacity**: 4 concurrent positions maximum
 
-Vendor-specific files such as [CLAUDE.md](CLAUDE.md) are compatibility adapters and should remain thin.
+`capital_base` is set once at month start as a pessimistic snapshot: `wallet_balance − carried_risk(Entering + Active + Armed)`. It is immutable for the duration of the month.
+
+## Position Lifecycle
+
+```
+Armed → Entering → Active → Exiting → Closed
+  └─ Cancelled (disarmed before entry)
+  └─ Error (unrecoverable, requires operator action)
+```
+
+The operator **arms** a position by specifying a symbol, direction (Long/Short), and an entry mode. Robson's detector then monitors the market and fires an entry signal when the chosen condition is met. The signal is routed through the query engine and risk gate before any order reaches the exchange.
+
+**Entry modes** (what triggers the entry signal):
+- `confirmed_trend` — SMA crossover signal (default)
+- `confirmed_reversal` — reversal candlestick pattern
+- `confirmed_key_level` — key level breakout
+- `immediate` — operator injects signal manually via API
+
+**Approval modes** (whether human confirmation is required):
+- `automatic` — entry proceeds without operator action (default)
+- `human_confirmation` — operator must approve via dashboard before the order is placed
 
 ## Why Robson Exists
 
 Most open-source trading systems conflate signal generation with execution. The result is software where risk management is an afterthought bolted onto an indicator library.
 
-Robson inverts this. The execution and risk layers are the primary concern. Signal interpretation exists as an input boundary, not as the core of the system.
+Robson inverts this. The execution and risk layers are the primary concern. The operator makes the trading decision — Robson executes it deterministically, sizes it correctly, and enforces the stop.
 
-This design reflects a simple observation: in leveraged markets, **how** you execute matters more than **what** you execute. A sound signal with poor execution, missing stop logic, or uncontrolled position sizing will lose capital. Robson exists to make the execution path deterministic, auditable, and safe by default.
+In leveraged markets, **how** you execute matters more than **what** you execute. A sound signal with poor execution, missing stop logic, or uncontrolled position sizing will lose capital. Robson exists to make the execution path deterministic, auditable, and safe by default.
 
 ## Architecture
 
-The system follows a **Hexagonal Architecture (Ports & Adapters)** within a Django monolith, with clear domain boundaries between execution, risk, and external integrations.
+The canonical runtime is written in Rust and lives under `v3/`. The SvelteKit operations dashboard lives under `apps/frontend/`.
 
 ```
+v3/
+  robson-domain/       # Pure domain logic — no external dependencies
+  robson-engine/       # Decision engine (risk calculations, position sizing)
+  robson-exec/         # Execution layer (port definitions, orchestration)
+  robson-connectors/   # Exchange adapters (Binance Futures)
+  robson-store/        # PostgreSQL persistence (SQLx)
+  robsond/             # Runtime daemon (Axum HTTP API, control loop)
+  robson-sim/          # Backtesting and simulation
+  cli/                 # Operator CLI (Bun / TypeScript)
+
 apps/
-  backend/
-    monolith/
-      api/
-        application/      # Hexagonal core (ports, use cases, adapters)
-        models/           # Domain models and state persistence
-        views/            # REST API surface
-        tests/            # Test suite
-  frontend/               # Operations dashboard (React/Vite)
-cli/                      # Execution CLI (Go + C router)
-main.c                    # CLI entrypoint (C router)
-infra/                    # Terraform, Ansible, K8s, GitOps, Observability, DB
-docs/                     # ADRs, architecture, developer guides
+  frontend/            # SvelteKit operations dashboard
+
+docs/
+  adr/                 # Architecture Decision Records
+  architecture/        # System specs, migration plans, v4 backlog
+  policies/            # Risk and reconciliation policies
+  runbooks/            # Operational procedures
 ```
 
 ### Core Subsystems
 
-**Execution Engine** — Manages the full order lifecycle: plan creation, pre-execution validation, dry-run simulation, and live execution. All state transitions are explicit and auditable. The engine enforces a strict `PLAN -> VALIDATE -> EXECUTE` pipeline that prevents unvalidated orders from reaching the exchange.
+**Execution Engine** — Manages the full position lifecycle through explicit state transitions. Every transition is governed by the query engine and produces an immutable audit event. No implicit side effects.
 
-**Risk Engine** — Enforces position-level and portfolio-level constraints before and during execution. This includes market stop exits, liquidation distance checks, maximum position sizing, and controlled teardown of positions that violate risk parameters. Every exit carries an explicit reason code.
+**Risk Engine** — Enforces per-position and portfolio-level constraints before and during execution. Position sizing is derived from the Golden Rule. Every exit carries a typed reason code.
 
-**Signal Layer** — An input boundary, not a decision-maker. Robson accepts signals (pattern detections, external triggers, manual commands) and routes them through validation and risk checks before any execution occurs. The signal layer includes a deterministic, idempotent pattern detection engine (Hammer, Inverted Hammer, Bullish/Bearish Engulfing, Morning Star, Head & Shoulders, Inverted H&S) that operates as a diagnostic tool, not an autonomous trading agent.
+**Detector** — Monitors market conditions for the entry mode chosen at ARM time. Fires a single entry signal when conditions are met. It is a governed input boundary — signals do not bypass the risk gate.
 
-**Event and State System** — All position state transitions, risk events, execution outcomes, and external flows (deposits, withdrawals) are recorded as an append-only audit trail. Portfolio valuation is tracked in BTC terms to reflect actual purchasing power independent of fiat inflation.
+**Reconciliation Worker** — Continuously verifies that every open position on the Binance account traces to a `robsond`-authored entry. Untracked positions are automatically closed. This invariant is non-negotiable (ADR-0022).
 
-**API and Multi-Tenant Layer** — A REST API provides programmatic access to execution plans, portfolio state, and risk parameters. The system supports multiple isolated tenants with per-client data boundaries.
+**Query Engine** — Every state transition passes through a lifecycle-tracked `ExecutionQuery`: `Accepted → Processing → RiskChecked → Acting → Completed / Denied / Failed`. Denials are governed outcomes, not errors.
 
-### Determinism and Traceability
+**Event Stream** — All domain events are persisted and broadcast via SSE. The dashboard updates in real time.
 
-Every execution path through the system produces a traceable sequence of events: plan creation, validation result, risk check outcome, execution attempt, and final state. There are no implicit side effects. The same inputs under the same market conditions produce the same execution behavior.
-
-## Risk Management
-
-Risk is not a feature of Robson. It is the architecture.
-
-**Market Stop Exits** — Positions carry explicit stop parameters. When market conditions breach these thresholds, the system initiates controlled exits without waiting for external signals.
-
-**Liquidation Protection** — For leveraged positions, the system monitors liquidation distance and enforces minimum margin requirements. Positions approaching liquidation thresholds are flagged or closed before the exchange liquidation engine intervenes.
-
-**Explicit Exit Reasons** — Every closed position carries a typed exit reason (stop hit, risk limit, manual close, validation failure, timeout). There are no silent exits.
-
-**Controlled Position Lifecycle** — Positions move through defined states with validated transitions. A position cannot be modified without passing through the risk layer. Orphaned or inconsistent positions are detected and surfaced.
-
-**Dry-Run by Default** — The execution pipeline defaults to simulation mode. Live execution requires explicit flags (`--live --acknowledge-risk`) and a prior passing validation. This makes it structurally difficult to execute unintended orders.
-
-## Observability
-
-**Event Tracking** — All system events (order submissions, risk checks, state transitions, external sync operations) are recorded with timestamps, context, and causality links.
-
-**State Transitions** — Position and order state changes are logged as discrete events, enabling reconstruction of the full lifecycle of any position at any point in time.
-
-**Portfolio Audit Trail** — External capital flows (deposits, withdrawals) are synchronized from the exchange and recorded. Portfolio valuation history is maintained for forensic analysis.
-
-**Debugging** — The `PLAN -> VALIDATE -> EXECUTE` pipeline produces structured output at each stage, making it possible to diagnose failures without reproducing market conditions.
-
-### REST API
+## API
 
 ```
-GET /api/portfolio/btc/total/              # Current portfolio value (BTC)
-GET /api/portfolio/btc/profit/             # Profit since inception (BTC)
-GET /api/portfolio/btc/history/            # Historical valuation series
-GET /api/portfolio/deposits-withdrawals/   # External capital flows
+GET  /health                          # Health check
+GET  /status                          # Positions, slots, monthly risk state
+GET  /positions?month=YYYY-MM         # Monthly position history
+GET  /positions/{id}                  # Single position detail
+POST /positions                       # Arm a new position
+POST /positions/{id}/signal           # Inject entry signal (immediate mode)
+DEL  /positions/{id}                  # Cancel Armed / close Active position
+POST /queries/{id}/approve            # Approve a pending human-confirmation query
+GET  /monthly-halt                    # Monthly halt status
+POST /monthly-halt                    # Trigger halt manually (kill switch)
+POST /panic                           # Emergency close all open positions
+GET  /safety/status                   # Reconciliation worker status
+GET  /events                          # SSE event stream (bearer token via query param)
 ```
-
-### CLI
-
-```bash
-# Execution pipeline
-robson plan buy BTCUSDT 0.001 --limit 50000
-robson validate <plan-id> --client-id 1 --strategy-id 5
-robson execute <plan-id> --client-id 1                          # dry-run (default)
-robson execute <plan-id> --client-id 1 --live --acknowledge-risk  # live
-
-# Pattern detection (diagnostic)
-python manage.py detect_patterns BTCUSDT 15m --all
-python manage.py detect_patterns BTCUSDT 1h --candlestick
-python manage.py detect_patterns BTCUSDT 4h --chart
-
-# Portfolio state
-python manage.py portfolio_btc --profit
-python manage.py sync_deposits --days-back 90
-```
-
-### CLI Architecture
-
-```
-robson (C router)
-  └─> robson-go (Go + Cobra)
-       └─> python manage.py {validate_plan,execute_plan} (Django)
-```
-
-The CLI is a thin routing layer. All business logic, risk validation, and execution semantics remain in the application core.
-
-## Positioning
-
-**Robson is not a trading bot.**
-
-It does not tell you what to buy. It does not scan for opportunities. It does not promise returns.
-
-Robson is:
-
-- An **execution system** that manages the lifecycle of orders from plan to settlement
-- A **risk-aware runtime** that enforces safety invariants on every position
-- An **experimental platform** for building and testing financial execution infrastructure
-
-It is designed for engineers and researchers who need a controlled, auditable environment for studying execution behavior in leveraged markets.
 
 ## Development
 
 ### Prerequisites
 
+- Rust stable + nightly (nightly required for `rustfmt`)
+- PostgreSQL
+- [pnpm](https://pnpm.io) — frontend (`apps/frontend/`)
+- [Bun](https://bun.sh) — operator CLI (`v3/cli/`)
+- [`just`](https://just.systems) — task runner
+
+### Backend (Rust)
+
 ```bash
-git clone https://github.com/ldamasio/robson.git
+cd v3
+
+# Build
+cargo build
+
+# Unit and in-memory tests (no database needed)
+cargo test --all
+
+# Format (nightly rustfmt)
+cargo +nightly fmt --all
+
+# Lint
+cargo clippy --all-targets -- -D warnings
+
+# PostgreSQL integration tests (requires DATABASE_URL)
+just v2-db-up        # start local database container
+just v2-test-pg      # run integration tests against real DB
 ```
 
-### Backend
-
-```bash
-cd apps/backend/monolith/
-cp .env.development.example .env
-python -m venv .venv
-source .venv/bin/activate
-pip install --upgrade pip
-pip install -r requirements.txt
-export DJANGO_SETTINGS_MODULE=backend.settings
-
-# Database
-cd .. && make dev-db-up && cd monolith
-./bin/dj makemigrations api
-./bin/dj migrate
-./bin/dj test
-./bin/dj runserver
-```
-
-### Frontend
+### Frontend (SvelteKit)
 
 ```bash
 cd apps/frontend
-nvm use 14
-npm i
-npm start
+pnpm install
+pnpm dev             # development server
+pnpm check           # type check (svelte-check + tsc)
+pnpm build           # production build
 ```
 
-### Build CLI
+### CLI (Bun)
 
 ```bash
-make build-cli
-make test-cli
-make install-cli    # optional: install to system PATH
+cd v3/cli
+bun install
+bun run dev          # run CLI in development mode
+bun test             # run tests
 ```
 
-### Task Runner
+### Environment
 
-Install [just](https://just.systems) for daily development tasks:
-
-```bash
-just --list         # see all tasks
-just setup          # first-time setup
-just db-up          # start database
-just db-migrate     # run migrations
-just test           # run all tests
-just dev-backend    # start backend server
-just dev-frontend   # start frontend server
-just info           # environment info
-```
+Copy `.env.example` and configure `DATABASE_URL` and exchange credentials. The daemon reads configuration from environment variables and a `robsond.toml` file.
 
 ## Deployment
 
-Production deployments are performed via GitOps (GitHub Actions + ArgoCD + k3s) with Traefik ingress and cert-manager-managed TLS. Shared infrastructure automation belongs outside this repository; this repository focuses on the Robson application.
+Production deployments are performed via GitOps (GitHub Actions + ArgoCD + k3s) with Traefik ingress and cert-manager-managed TLS. Infrastructure automation is managed separately in `rbx-infra`.
 
-The `./bin/dj` script and `docker-compose.dev.yml` are for local development only.
+See `docs/runbooks/` for deployment and operational procedures.
 
-See `docs/infra/K3S-CLUSTER-GUIDE.md` and `docs/runbooks/argocd-initial-setup.md` for deployment details.
+## AI-First Repository Rules
 
-## Contributing
-
-Robson is open source. Contributions are welcome.
-
-- `docs/DEVELOPER.md` — development setup and workflow
-- `docs/STYLE_GUIDE.md` — code conventions
-- `docs/ARCHITECTURE.md` — system design
-- `docs/COMMAND-RUNNERS.md` — CLI tool guidelines
+Canonical AI-first instructions live in [AGENTS.md](AGENTS.md). Vendor-specific files such as [CLAUDE.md](CLAUDE.md) are compatibility adapters and must remain thin.
 
 ## License
 
-Open source. See repository for license details.
+Open source. See [LICENSE](LICENSE) for details.

--- a/apps/frontend/src/routes/(authed)/dashboard/+page.svelte
+++ b/apps/frontend/src/routes/(authed)/dashboard/+page.svelte
@@ -328,6 +328,15 @@
       // error handled by next poll refresh
     }
   }
+
+  async function disarm(positionId: string) {
+    try {
+      await robsonApi.closePosition(positionId);
+      void load();
+    } catch {
+      // next poll will refresh state
+    }
+  }
 </script>
 
 <svelte:head>
@@ -482,39 +491,75 @@
         {:else}
           <Grid cols={2} gap={4}>
             {#each displayOps as op}
-              <a href="/operation/{op.id}" class="op-card-link">
-                <Card>
-                  <Stack gap={2}>
-                    <Row justify="between" align="start">
-                      <div class="eyebrow">{positionLabel(op)}</div>
-                      <span
-                        class="state-pill"
-                        class:inherited={isInheritedForMonth(op, selectedMonth)}
-                      >
-                        {monthStateLabel(op)}
-                      </span>
-                    </Row>
-                    <Row justify="between">
-                      <span class="meta">{positionStateLabel(op.state)}</span>
-                      {#if variationFor(op) !== null}
+              {#if op.state === "Armed"}
+                <div class="op-card-link">
+                  <Card>
+                    <Stack gap={2}>
+                      <Row justify="between" align="start">
+                        <div class="eyebrow">{positionLabel(op)}</div>
                         <span
-                          class="mono"
-                          class:ok={(variationFor(op) ?? 0) > 0}
-                          class:err={(variationFor(op) ?? 0) < 0}
-                        >
-                          {(variationFor(op) ?? 0) > 0 ? "+" : ""}{variationFor(
+                          class="state-pill"
+                          class:inherited={isInheritedForMonth(
                             op,
-                          )?.toFixed(2)}%
+                            selectedMonth,
+                          )}
+                        >
+                          {monthStateLabel(op)}
                         </span>
-                      {/if}
-                    </Row>
-                    <div class="meta dim">{positionMetaLine(op)}</div>
-                    <pre class="history-summary">{positionSummaryLines(op).join(
-                        "\n",
-                      )}</pre>
-                  </Stack>
-                </Card>
-              </a>
+                      </Row>
+                      <Row justify="between">
+                        <span class="meta">{positionStateLabel(op.state)}</span>
+                      </Row>
+                      <div class="meta dim">{positionMetaLine(op)}</div>
+                      <pre class="history-summary">{positionSummaryLines(
+                          op,
+                        ).join("\n")}</pre>
+                      <Row justify="end">
+                        <button class="btn-disarm" onclick={() => disarm(op.id)}
+                          >DISARM</button
+                        >
+                      </Row>
+                    </Stack>
+                  </Card>
+                </div>
+              {:else}
+                <a href="/operation/{op.id}" class="op-card-link">
+                  <Card>
+                    <Stack gap={2}>
+                      <Row justify="between" align="start">
+                        <div class="eyebrow">{positionLabel(op)}</div>
+                        <span
+                          class="state-pill"
+                          class:inherited={isInheritedForMonth(
+                            op,
+                            selectedMonth,
+                          )}
+                        >
+                          {monthStateLabel(op)}
+                        </span>
+                      </Row>
+                      <Row justify="between">
+                        <span class="meta">{positionStateLabel(op.state)}</span>
+                        {#if variationFor(op) !== null}
+                          <span
+                            class="mono"
+                            class:ok={(variationFor(op) ?? 0) > 0}
+                            class:err={(variationFor(op) ?? 0) < 0}
+                          >
+                            {(variationFor(op) ?? 0) > 0
+                              ? "+"
+                              : ""}{variationFor(op)?.toFixed(2)}%
+                          </span>
+                        {/if}
+                      </Row>
+                      <div class="meta dim">{positionMetaLine(op)}</div>
+                      <pre class="history-summary">{positionSummaryLines(
+                          op,
+                        ).join("\n")}</pre>
+                    </Stack>
+                  </Card>
+                </a>
+              {/if}
             {/each}
           </Grid>
         {/if}
@@ -851,6 +896,21 @@
   }
   .btn-approve:hover {
     background: var(--cyan-subtle);
+  }
+  .btn-disarm {
+    background: transparent;
+    border: 1px solid var(--color-err, #e55);
+    color: var(--color-err, #e55);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    padding: 4px 10px;
+    cursor: pointer;
+    border-radius: 2px;
+    transition: background 0.15s;
+  }
+  .btn-disarm:hover {
+    background: color-mix(in srgb, var(--color-err, #e55) 15%, transparent);
   }
   .btn-nav {
     font-family: var(--font-mono);

--- a/v3/robsond/src/api.rs
+++ b/v3/robsond/src/api.rs
@@ -2233,9 +2233,10 @@ mod tests {
         let status: StatusResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(status.active_positions, 1);
         assert_eq!(status.occupied_slots, 1);
-        // Armed positions reserve a slot; new_slots drops by 1 (was 4, now 3).
-        assert_eq!(status.new_slots_available, 3);
-        assert_eq!(status.slot_cells_total, 4);
+        // Armed-position risk is reflected in capital_base at month boundary,
+        // not subtracted from the live slot count.
+        assert_eq!(status.new_slots_available, 4);
+        assert_eq!(status.slot_cells_total, 5);
         assert_eq!(status.pending_approvals.len(), 1);
         assert_eq!(status.pending_approvals[0].query_id, query_id);
         assert_eq!(status.pending_approvals[0].position_id, Some(position.id));

--- a/v3/robsond/src/daemon.rs
+++ b/v3/robsond/src/daemon.rs
@@ -719,7 +719,34 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
         }
 
         let open_positions = self.store.positions().find_risk_open().await?;
-        let carried_risk = Self::calculate_carried_risk(&open_positions);
+        let carried_risk_committed = Self::calculate_carried_risk(&open_positions);
+
+        // Armed positions have no measurable committed risk yet, but each will
+        // risk exactly 1% of capital when triggered. Use the previous month's
+        // capital_base to avoid a circular month-boundary calculation.
+        let (prev_year, prev_month_num) = if now.month() == 1 {
+            (now.year() - 1, 12u32)
+        } else {
+            (now.year(), now.month() - 1)
+        };
+        let prev_month = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+            chrono::NaiveDate::from_ymd_opt(prev_year, prev_month_num, 1)
+                .expect("previous month date must be valid")
+                .and_hms_opt(0, 0, 0)
+                .expect("midnight must be valid"),
+            chrono::Utc,
+        );
+        let prev_capital = {
+            let manager = self.position_manager.read().await;
+            manager.load_capital_base_for_month(prev_month).await.unwrap_or(Decimal::ZERO)
+        };
+        let all_open_positions = self.store.positions().find_active().await?;
+        let armed_count = all_open_positions
+            .iter()
+            .filter(|p| matches!(p.state, PositionState::Armed))
+            .count() as u32;
+        let armed_risk = prev_capital * Decimal::new(1, 2) * Decimal::from(armed_count);
+        let carried_risk = carried_risk_committed + armed_risk;
 
         // current_equity per ADR-0024 §6: wallet balance from the exchange.
         // The capital_base is pessimistic: it subtracts carried_risk (worst case
@@ -763,6 +790,9 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
             month = now.month(),
             %capital_base,
             %carried_risk,
+            %carried_risk_committed,
+            armed_count,
+            %armed_risk,
             "Month boundary processed"
         );
 
@@ -1531,7 +1561,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};
-    use robson_domain::{PositionState, Price, Quantity, Side, TechnicalStopDistance};
+    use robson_domain::{PositionState, Price, Quantity, RiskConfig, Side, TechnicalStopDistance};
     #[cfg(feature = "postgres")]
     use robson_eventlog::{
         append_event, query_events, ActorType, Event, QueryOptions, QUERY_STATE_CHANGED_EVENT_TYPE,
@@ -1625,6 +1655,44 @@ mod tests {
 
         assert_eq!(month_events.len(), 1, "month boundary must emit once per in-process month");
         assert_eq!(month_events[0], (dec!(10000), dec!(0), 5, 2026));
+    }
+
+    #[tokio::test]
+    async fn test_month_boundary_includes_armed_risk_in_carried_risk() {
+        let daemon = Daemon::new_stub(Config::test());
+        {
+            let manager = daemon.position_manager.read().await;
+            manager
+                .arm_position(
+                    Symbol::from_pair("BTCUSDT").unwrap(),
+                    Side::Long,
+                    RiskConfig::new(dec!(10000)).unwrap(),
+                    None,
+                    uuid::Uuid::now_v7(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let now = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 1).single().unwrap();
+        daemon.handle_month_boundary(now).await.unwrap();
+
+        let events = daemon.store.events().get_all_events().await.unwrap();
+        let month_event = events
+            .iter()
+            .find_map(|event| match event {
+                robson_domain::Event::MonthBoundaryReset {
+                    capital_base,
+                    carried_positions_risk,
+                    month,
+                    year,
+                    ..
+                } => Some((*capital_base, *carried_positions_risk, *month, *year)),
+                _ => None,
+            })
+            .expect("month boundary event must be emitted");
+
+        assert_eq!(month_event, (dec!(9900), dec!(100), 5, 2026));
     }
 
     #[test]

--- a/v3/robsond/src/position_manager.rs
+++ b/v3/robsond/src/position_manager.rs
@@ -1732,6 +1732,12 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
             timestamp: chrono::Utc::now(),
         });
 
+        // Clean up entry policy entry to prevent HashMap growth.
+        {
+            let mut policies = self.entry_policies.write().await;
+            policies.remove(&position_id);
+        }
+
         Ok(())
     }
 
@@ -3067,14 +3073,9 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
             self.trading_policy
                 .slots_available(capital_base, monthly.realized_loss, latent_risk);
 
-        // Armed positions have no measurable latent risk (no entry or stop yet),
-        // but each one reserves a future slot. Subtract them so the operator
-        // cannot arm more positions than the budget allows.
-        let all_open = self.store.positions().find_active().await?;
-        let armed_count =
-            all_open.iter().filter(|p| matches!(p.state, PositionState::Armed)).count() as u32;
-
-        Ok(policy_slots.saturating_sub(armed_count))
+        // Armed positions' risk is reflected in capital_base at month boundary.
+        // The slot count is purely budget-driven.
+        Ok(policy_slots)
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

- **fix(robsond)**: `handle_month_boundary` now includes inherited Armed positions in `carried_risk`. Each Armed slot is pessimistically valued at `prev_capital_base × 1%`, making `capital_base` more conservative without introducing a circular dependency. The `compute_slots_available` no longer subtracts `armed_count` — the slot count remains purely budget-driven (4 slots in clean state).
- **fix(robsond)**: `disarm_position` now removes the position's entry from the `entry_policies` HashMap, fixing a memory leak.
- **fix(robsond)**: regression test `test_month_boundary_includes_armed_risk_in_carried_risk` pins the new boundary behaviour.
- **feat(frontend)**: Armed position cards now render as non-navigating divs with a DISARM button that calls `DELETE /positions/{id}` and reloads status.
- **docs**: README rewritten for v3 — Rust runtime, slot-based risk model, SvelteKit dashboard, correct prerequisites (pnpm for frontend, Bun for CLI).

## Policy context

The previous `armed_count` subtraction from `new_slots_available` (introduced in PR #67) was a design error: the new month must always start with 4 available slots. Armed positions' risk belongs in `capital_base` (pessimistic reservation), not in the slot display/gate. The monthly halt circuit breaker remains the hard server-side enforcement of the 4% limit.

## Test plan

- [ ] `cargo test --all` — 587 passed, 23 ignored
- [ ] `cargo +nightly fmt --all` — clean
- [ ] `pnpm check` — 0 errors (4 pre-existing warnings in shared design components)
- [ ] Deploy to prod and verify: Armed cards show DISARM button; new month starts with 4 available slots regardless of inherited Armed count

🤖 Generated with [Claude Code](https://claude.com/claude-code)