### PR TITLE
[codex] update changelog for repository cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed - Repository Cleanup and Layout Normalization (2026-05-13)
+
+- Removed dead legacy roots from the repository: `apps/`, `data/`,
+  `k8s/`, `pyproject.toml`, and `sonar-project.properties`.
+- Moved the worktree helper from `devtools/` to `scripts/` and updated
+  the live developer and deployment docs to match the current layout.
+- Updated the pull request template and frontend deployment runbook to
+  reference the current Rust + SvelteKit + `rbx-infra` structure.
+
 ### Fixed - v2 CI/CD Pipeline (2026-04-14)
 
 - **rustfmt.toml restored**: Rich nightly-only configuration (`imports_granularity`,


### PR DESCRIPTION
## Summary

Add the repository cleanup entry to the changelog now that the previous structural cleanup PR has already been merged.

## Changes

- Document the removal of dead legacy roots in `CHANGELOG.md`
- Record the `devtools/` to `scripts/` helper move
- Keep the changelog aligned with the current v2.5-era repository layout

## Validation

- `git diff --check`
- Confirmed the changelog entry is the only new content intended for this follow-up PR
