### PR TITLE
fix(frontend): pass entry_mode/approval_mode through normalizePosition

### DIFF
--- a/frontend/src/lib/api/robson.ts
+++ b/frontend/src/lib/api/robson.ts
@@ -199,6 +199,8 @@ function normalizePosition(raw: unknown): Position {
     symbol: String(p.symbol ?? ""),
     side: String(p.side ?? ""),
     state: (p.state ?? "Error") as PositionState,
+    entry_mode: p.entry_mode == null ? null : String(p.entry_mode),
+    approval_mode: p.approval_mode == null ? null : String(p.approval_mode),
     entry_price: toNumber(p.entry_price),
     entry_filled_at:
       p.entry_filled_at == null ? null : String(p.entry_filled_at),

--- a/frontend/src/lib/presentation/labels.ts
+++ b/frontend/src/lib/presentation/labels.ts
@@ -17,7 +17,7 @@ export function positionStateLabel(state: PositionState): string {
 
 export function entryModeLabel(mode?: string | null): string {
   switch (mode) {
-    case 'immediate':           return 'immediate — awaiting manual signal';
+    case 'immediate':           return 'immediate — no signal required';
     case 'confirmed_reversal':  return 'awaiting entry signal · reversal pattern';
     case 'confirmed_key_level': return 'awaiting entry signal · key level';
     case 'confirmed_trend':


### PR DESCRIPTION
## Summary

- `normalizePosition` in `robson.ts` was discarding `entry_mode` and `approval_mode` from the raw API response, so `p.entry_mode` was always `undefined` in the UI
- `entryModeLabel(undefined)` fell through to the `default` case → always showed **"awaiting entry signal · SMA crossover"** regardless of the actual configured mode
- Corrects the `immediate` label from the misleading `"immediate — awaiting manual signal"` to `"immediate — no signal required"`

## Root cause

`normalizePosition` explicitly maps every field from the raw response but `entry_mode` and `approval_mode` were never added to the mapping — they were silently dropped. The backend has been returning these fields correctly all along.

## Related

A separate backend issue was identified during investigation: `entry_policies` (in-memory HashMap) is not restored after daemon restart. `EntryPolicyResolved` events are persisted but the projector treats them as audit-only and does not rebuild the map, and Armed positions recovered on startup have no detector task re-spawned. This will be tracked separately in the v4 backlog.

## Test plan

- [ ] Arm a position with `IMMEDIATE` mode — UI should show `immediate — no signal required`
- [ ] Arm a position with `CONFIRMED TREND` — UI should show `awaiting entry signal · SMA crossover`
- [ ] Arm with `CONFIRMED REVERSAL` — UI should show `awaiting entry signal · reversal pattern`
- [ ] Arm with `CONFIRMED KEY LEVEL` — UI should show `awaiting entry signal · key level`

🤖 Generated with [Claude Code](https://claude.com/code)