### PR TITLE
fix(connectors): apply timeout to response body read in Binance REST client

### DIFF
--- a/robson-connectors/src/binance_rest.rs
+++ b/robson-connectors/src/binance_rest.rs
@@ -168,8 +168,10 @@ impl BinanceRestClient {
                 .map_err(|e| BinanceRestError::RequestFailed(e.to_string()))?;
 
         let status = response.status();
-        let body =
-            response.text().await.map_err(|e| BinanceRestError::ParseError(e.to_string()))?;
+        let body = timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS), response.text())
+            .await
+            .map_err(|_| BinanceRestError::Timeout)?
+            .map_err(|e| BinanceRestError::ParseError(e.to_string()))?;
 
         if !status.is_success() {
             if let Ok(err) = serde_json::from_str::<BinanceErrorResponse>(&body) {
@@ -199,8 +201,10 @@ impl BinanceRestClient {
         .map_err(|e| BinanceRestError::RequestFailed(e.to_string()))?;
 
         let status = response.status();
-        let body =
-            response.text().await.map_err(|e| BinanceRestError::ParseError(e.to_string()))?;
+        let body = timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS), response.text())
+            .await
+            .map_err(|_| BinanceRestError::Timeout)?
+            .map_err(|e| BinanceRestError::ParseError(e.to_string()))?;
 
         if !status.is_success() {
             if let Ok(err) = serde_json::from_str::<BinanceErrorResponse>(&body) {
@@ -230,8 +234,10 @@ impl BinanceRestClient {
         .map_err(|e| BinanceRestError::RequestFailed(e.to_string()))?;
 
         let status = response.status();
-        let body =
-            response.text().await.map_err(|e| BinanceRestError::ParseError(e.to_string()))?;
+        let body = timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS), response.text())
+            .await
+            .map_err(|_| BinanceRestError::Timeout)?
+            .map_err(|e| BinanceRestError::ParseError(e.to_string()))?;
 
         if !status.is_success() {
             if let Ok(err) = serde_json::from_str::<BinanceErrorResponse>(&body) {
@@ -261,8 +267,10 @@ impl BinanceRestClient {
         .map_err(|e| BinanceRestError::RequestFailed(e.to_string()))?;
 
         let status = response.status();
-        let body =
-            response.text().await.map_err(|e| BinanceRestError::ParseError(e.to_string()))?;
+        let body = timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS), response.text())
+            .await
+            .map_err(|_| BinanceRestError::Timeout)?
+            .map_err(|e| BinanceRestError::ParseError(e.to_string()))?;
 
         if !status.is_success() {
             if let Ok(err) = serde_json::from_str::<BinanceErrorResponse>(&body) {


### PR DESCRIPTION
## Summary

- `response.text().await` was outside the `tokio::time::timeout` wrapper in all four HTTP methods (`get_public`, `get_signed`, `post_signed`, `delete_signed`)
- The timeout only covered `.send()` — TCP connect + TLS + HTTP request — but **not** the response body read
- If Binance sent HTTP headers but stalled on the body, the call would hang indefinitely with no timeout, no error, and no log output

## Impact observed in production

The BTCUSDT detector task called `fetch_candles` (via `get_public /fapi/v1/klines`) on the first market tick after an `immediate` mode position was armed. The REST call completed headers but stalled on body, freezing the detector task permanently. The daemon produced zero log output for 10+ minutes while remaining alive (liveness probe still passed via the HTTP server running on a separate tokio task).

## Fix

Wraps `response.text()` in `timeout(REQUEST_TIMEOUT_SECS, ...)` in all four methods. A stalled body read now returns `BinanceRestError::Timeout` within 10 seconds, which the detector logs as WARN and retries on the next tick.

## Test plan

- [ ] Arm a position with `immediate` mode — should execute within seconds of the first market tick
- [ ] Verify WARN logs appear on timeout rather than silent hang if Binance REST is degraded
- [ ] Existing unit tests pass (`cargo test -p robson-connectors`)

🤖 Generated with [Claude Code](https://claude.com/code)