### PR TITLE
fix(daemon): re-spawn detectors for Armed positions after restart

### DIFF
--- a/migrations/20240101000013_add_entry_mode_to_positions.sql
+++ b/migrations/20240101000013_add_entry_mode_to_positions.sql
@@ -1,0 +1,11 @@
+-- Add entry_mode and approval_mode to positions_current so that the daemon
+-- can recover entry policies for Armed positions after a restart.
+--
+-- Before this migration, the entry_policy_resolved event was treated as
+-- audit-only and these values were only held in an in-memory HashMap inside
+-- PositionManager. A daemon restart would lose them, leaving recovered Armed
+-- positions with no detector task and no entry policy.
+
+ALTER TABLE positions_current
+    ADD COLUMN IF NOT EXISTS entry_mode    TEXT,
+    ADD COLUMN IF NOT EXISTS approval_mode TEXT;

--- a/robson-projector/src/apply.rs
+++ b/robson-projector/src/apply.rs
@@ -190,9 +190,7 @@ pub async fn apply_event_to_projections(pool: &PgPool, envelope: &EventEnvelope)
             handlers::positions::handle_position_armed(pool, envelope).await?
         },
         Some(ProjectionRoute::EntryPolicyResolved) => {
-            // Audit-only event. Records the resolved entry policy and strategy
-            // for replay and observability. Does not mutate
-            // positions_current.
+            handlers::positions::handle_entry_policy_resolved(pool, envelope).await?
         },
         Some(ProjectionRoute::PositionDisarmed) => {
             handlers::positions::handle_position_disarmed(pool, envelope).await?

--- a/robson-projector/src/handlers/positions.rs
+++ b/robson-projector/src/handlers/positions.rs
@@ -14,8 +14,8 @@ use crate::{
     error::{ProjectionError, Result},
     types::{
         EntryExecutionRejected, EntryOrderAccepted, EntryOrderFailed, EntryOrderPlaced,
-        EntryOrderRequested, EntrySignalReceived, ExitFilled, ExitOrderPlaced, PositionArmed,
-        PositionClosed, PositionClosedDomain, PositionDisarmed, PositionOpened,
+        EntryOrderRequested, EntryPolicyResolved, EntrySignalReceived, ExitFilled, ExitOrderPlaced,
+        PositionArmed, PositionClosed, PositionClosedDomain, PositionDisarmed, PositionOpened,
         TechnicalStopDistancePayload,
     },
 };
@@ -1121,6 +1121,42 @@ pub(crate) async fn handle_position_closed_domain(
     .bind(envelope.event_id)
     .bind(envelope.seq)
     .bind(envelope.occurred_at)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub(crate) async fn handle_entry_policy_resolved(
+    pool: &PgPool,
+    envelope: &EventEnvelope,
+) -> Result<()> {
+    let payload: EntryPolicyResolved =
+        serde_json::from_value(envelope.payload.clone()).map_err(|e| {
+            ProjectionError::InvalidPayload {
+                event_type: envelope.event_type.clone(),
+                reason: e.to_string(),
+            }
+        })?;
+
+    sqlx::query(
+        r#"
+        UPDATE positions_current
+           SET entry_mode    = $1,
+               approval_mode = $2,
+               last_event_id = $3,
+               last_seq      = $4,
+               updated_at    = $5
+         WHERE position_id = $6
+           AND last_seq < $4
+        "#,
+    )
+    .bind(&payload.entry_policy)
+    .bind(&payload.approval_policy)
+    .bind(envelope.event_id)
+    .bind(envelope.seq)
+    .bind(envelope.occurred_at)
+    .bind(payload.position_id)
     .execute(pool)
     .await?;
 

--- a/robson-projector/src/types.rs
+++ b/robson-projector/src/types.rs
@@ -386,7 +386,8 @@ pub struct ExitFilled {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntryPolicyResolved {
     pub position_id: Uuid,
-    /// "immediate" | "confirmed_trend" | "confirmed_reversal" | "confirmed_key_level"
+    /// "immediate" | "confirmed_trend" | "confirmed_reversal" |
+    /// "confirmed_key_level"
     pub entry_policy: String,
     /// "automatic" | "human_confirmation"
     pub approval_policy: String,

--- a/robson-projector/src/types.rs
+++ b/robson-projector/src/types.rs
@@ -378,6 +378,20 @@ pub struct ExitFilled {
     pub timestamp: chrono::DateTime<chrono::Utc>,
 }
 
+/// entry_policy_resolved payload
+///
+/// Emitted immediately after position_armed. Records the entry mode and
+/// approval policy chosen by the operator. Written to positions_current so
+/// the daemon can recover these values after a restart.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntryPolicyResolved {
+    pub position_id: Uuid,
+    /// "immediate" | "confirmed_trend" | "confirmed_reversal" | "confirmed_key_level"
+    pub entry_policy: String,
+    /// "automatic" | "human_confirmation"
+    pub approval_policy: String,
+}
+
 /// position_closed payload (robson-domain::Event::PositionClosed, lowercase)
 ///
 /// Emitted after the exit fill is confirmed, with final P&L summary.

--- a/robson-store/src/lib.rs
+++ b/robson-store/src/lib.rs
@@ -55,7 +55,7 @@ pub use error::StoreError;
 pub use memory::MemoryStore;
 #[cfg(feature = "postgres")]
 pub use postgres::{
-    find_active_from_projection, find_positions_overlapping_month, PgProjectionReader,
-    ProjectionRecovery,
+    find_active_from_projection, find_armed_entry_policies, find_positions_overlapping_month,
+    PgProjectionReader, ProjectionRecovery,
 };
 pub use repository::{EventRepository, OrderRepository, PositionRepository, Store};

--- a/robson-store/src/postgres.rs
+++ b/robson-store/src/postgres.rs
@@ -100,6 +100,8 @@ struct PositionCurrentRow {
     created_at: chrono::DateTime<chrono::Utc>,
     updated_at: chrono::DateTime<chrono::Utc>,
     closed_at: Option<chrono::DateTime<chrono::Utc>>,
+    entry_mode: Option<String>,
+    approval_mode: Option<String>,
 }
 
 /// Helper function to parse a row from positions_current query.
@@ -137,6 +139,8 @@ fn parse_position_row(row: &sqlx::postgres::PgRow) -> Result<PositionCurrentRow,
         created_at: row.try_get("created_at")?,
         updated_at: row.try_get("updated_at")?,
         closed_at: row.try_get("closed_at").ok(),
+        entry_mode: row.try_get("entry_mode").ok().flatten(),
+        approval_mode: row.try_get("approval_mode").ok().flatten(),
     })
 }
 
@@ -437,7 +441,9 @@ pub async fn find_active_from_projection(
             exit_reason,
             created_at,
             updated_at,
-            closed_at
+            closed_at,
+            entry_mode,
+            approval_mode
         FROM positions_current
         WHERE tenant_id = $1
           AND state IN ('armed', 'entering', 'active', 'exiting')
@@ -460,6 +466,46 @@ pub async fn find_active_from_projection(
     }
 
     Ok(positions)
+}
+
+/// Return (position_id, entry_mode, approval_mode) for all Armed positions that
+/// have persisted entry policy data. Used by daemon startup to re-spawn
+/// detector tasks after a crash/restart.
+pub async fn find_armed_entry_policies(
+    pool: &PgPool,
+    tenant_id: Uuid,
+) -> Result<Vec<(Uuid, String, String)>, StoreError> {
+    let rows = sqlx::query(
+        r#"
+        SELECT position_id, entry_mode, approval_mode
+          FROM positions_current
+         WHERE tenant_id = $1
+           AND state = 'armed'
+           AND entry_mode IS NOT NULL
+           AND approval_mode IS NOT NULL
+         ORDER BY created_at ASC
+        "#,
+    )
+    .bind(tenant_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| StoreError::Database(format!("Failed to read armed entry policies: {}", e)))?;
+
+    let mut result = Vec::new();
+    for row in rows {
+        let position_id: Uuid = row
+            .try_get("position_id")
+            .map_err(|e| StoreError::Database(format!("Failed to parse position_id: {}", e)))?;
+        let entry_mode: String = row
+            .try_get("entry_mode")
+            .map_err(|e| StoreError::Database(format!("Failed to parse entry_mode: {}", e)))?;
+        let approval_mode: String = row
+            .try_get("approval_mode")
+            .map_err(|e| StoreError::Database(format!("Failed to parse approval_mode: {}", e)))?;
+        result.push((position_id, entry_mode, approval_mode));
+    }
+
+    Ok(result)
 }
 
 /// Read all positions that overlapped a given month from the persisted

--- a/robsond/src/daemon.rs
+++ b/robsond/src/daemon.rs
@@ -25,8 +25,12 @@ use async_trait::async_trait;
 use chrono::{DateTime, Datelike, Utc};
 use robson_connectors::BinanceRestClient;
 use robson_domain::{Position, PositionId, PositionState, Symbol, TradingPolicy};
+#[cfg(feature = "postgres")]
+use robson_domain::{ApprovalPolicy, EntryPolicy, EntryPolicyConfig};
 use robson_engine::Engine;
 use robson_exec::{ExchangePort, Executor, IntentJournal, StubExchange};
+#[cfg(feature = "postgres")]
+use robson_store::find_armed_entry_policies;
 #[cfg(feature = "postgres")]
 use robson_store::PgDetectedPositionRepository;
 // Optional projection recovery for crash recovery
@@ -87,6 +91,25 @@ pub struct Daemon<E: ExchangePort + 'static, S: Store + 'static> {
     pg_pool: Option<Arc<sqlx::PgPool>>,
     /// Last month processed by the month-boundary poller.
     last_month_check: Arc<RwLock<(i32, u32)>>,
+}
+
+/// Parse entry_mode and approval_mode strings from DB into EntryPolicyConfig.
+/// Returns None for unknown variants so callers can log and skip.
+#[cfg(feature = "postgres")]
+fn parse_entry_policy_config(entry_mode: &str, approval_mode: &str) -> Option<EntryPolicyConfig> {
+    let mode = match entry_mode {
+        "immediate" => EntryPolicy::Immediate,
+        "confirmed_trend" => EntryPolicy::ConfirmedTrend,
+        "confirmed_reversal" => EntryPolicy::ConfirmedReversal,
+        "confirmed_key_level" => EntryPolicy::ConfirmedKeyLevel,
+        _ => return None,
+    };
+    let approval = match approval_mode {
+        "automatic" => ApprovalPolicy::Automatic,
+        "human_confirmation" => ApprovalPolicy::HumanConfirmation,
+        _ => return None,
+    };
+    Some(EntryPolicyConfig::new(mode, approval))
 }
 
 /// Default query recorder (tracing only, no persistence).
@@ -475,6 +498,12 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
 
         // 3. Restore active positions
         self.restore_positions().await?;
+
+        // 3b. Re-spawn detector tasks for Armed positions (entry policy recovery).
+        // entry_policies is in-memory only; restore it from the projection so
+        // Armed positions don't silently stall after a restart.
+        #[cfg(feature = "postgres")]
+        self.restore_armed_detectors().await;
 
         // 3a. Startup stale-active gate (fail-closed; exit code 78 on abort).
         // Runs immediately — no grace period. Must precede the UNTRACKED scan.
@@ -1246,6 +1275,67 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
         }
 
         Ok(())
+    }
+
+    /// Re-spawn detector tasks for Armed positions that were recovered from
+    /// the projection. Called once after `restore_positions()`.
+    ///
+    /// entry_policies is an in-memory HashMap that is lost on daemon restart.
+    /// This method reads the persisted entry_mode/approval_mode columns from
+    /// positions_current and calls PositionManager::restore_armed_position for
+    /// each Armed position that has a valid policy on record.
+    #[cfg(feature = "postgres")]
+    async fn restore_armed_detectors(&self) {
+        let (Some(pool), Some(tenant_id)) = (&self.pg_pool, self.config.projection.tenant_id)
+        else {
+            return;
+        };
+
+        let policies = match find_armed_entry_policies(pool, tenant_id).await {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(error = %e, "Could not load armed entry policies; Armed positions will not have detectors");
+                return;
+            },
+        };
+
+        if policies.is_empty() {
+            info!("No Armed positions with persisted entry policies found");
+            return;
+        }
+
+        for (position_id, entry_mode, approval_mode) in policies {
+            let entry_policy_opt = parse_entry_policy_config(&entry_mode, &approval_mode);
+            let entry_policy = match entry_policy_opt {
+                Some(p) => p,
+                None => {
+                    warn!(
+                        %position_id,
+                        entry_mode = %entry_mode,
+                        approval_mode = %approval_mode,
+                        "Unknown entry/approval mode; skipping detector restore"
+                    );
+                    continue;
+                },
+            };
+
+            let position = match self.store.positions().find_by_id(position_id).await {
+                Ok(Some(p)) => p,
+                Ok(None) => {
+                    warn!(%position_id, "Armed position not found in store after restore; skipping");
+                    continue;
+                },
+                Err(e) => {
+                    warn!(%position_id, error = %e, "Failed to load position from store; skipping detector restore");
+                    continue;
+                },
+            };
+
+            let pm = self.position_manager.read().await;
+            if let Err(e) = pm.restore_armed_position(&position, entry_policy).await {
+                warn!(%position_id, error = %e, "Failed to restore detector for Armed position");
+            }
+        }
     }
 
     /// Start the API server.

--- a/robsond/src/daemon.rs
+++ b/robsond/src/daemon.rs
@@ -24,9 +24,9 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use chrono::{DateTime, Datelike, Utc};
 use robson_connectors::BinanceRestClient;
-use robson_domain::{Position, PositionId, PositionState, Symbol, TradingPolicy};
 #[cfg(feature = "postgres")]
 use robson_domain::{ApprovalPolicy, EntryPolicy, EntryPolicyConfig};
+use robson_domain::{Position, PositionId, PositionState, Symbol, TradingPolicy};
 use robson_engine::Engine;
 use robson_exec::{ExchangePort, Executor, IntentJournal, StubExchange};
 #[cfg(feature = "postgres")]

--- a/robsond/src/position_manager.rs
+++ b/robsond/src/position_manager.rs
@@ -1504,6 +1504,42 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
         Ok(position)
     }
 
+    /// Re-attach entry policy and spawn a detector for an Armed position
+    /// recovered from the projection on daemon startup.
+    ///
+    /// Called after `restore_positions()` has already loaded the position into
+    /// the in-memory store. This method only restores the in-memory
+    /// `entry_policies` map and spawns the detector — it does not re-emit any
+    /// events.
+    pub async fn restore_armed_position(
+        &self,
+        position: &Position,
+        entry_policy: EntryPolicyConfig,
+    ) -> DaemonResult<()> {
+        let position_id = position.id;
+
+        {
+            let mut policies = self.entry_policies.write().await;
+            policies.insert(position_id, entry_policy);
+        }
+
+        let cancel_token = self.child_cancel_token();
+        let detector = DetectorTask::from_position_with_policy(
+            position,
+            entry_policy,
+            Arc::clone(&self.event_bus),
+            Arc::clone(&self.ohlcv_port),
+            cancel_token,
+        )?;
+        let handle = detector.spawn();
+
+        let mut detectors = self.detectors.write().await;
+        detectors.insert(position_id, handle);
+
+        info!(%position_id, "Armed position restored: detector re-spawned");
+        Ok(())
+    }
+
     /// Returns an `Arc` to the circuit breaker so API handlers can read/write
     /// it.
     pub fn circuit_breaker(&self) -> Arc<CircuitBreaker> {


### PR DESCRIPTION
## Summary

- **Root cause**: `entry_policies` was a pure in-memory `HashMap` inside `PositionManager`. On daemon restart (crash or rolling deploy), all Armed positions were recovered from the PostgreSQL projection but their entry policy and detector tasks were never restored — so immediate-mode positions never triggered entry.
- **Migration** (`migrations/20240101000013`): adds `entry_mode` / `approval_mode` columns to `positions_current`.
- **Projector** (`apply.rs`, `handlers/positions.rs`, `types.rs`): `entry_policy_resolved` was previously routed to an audit-only no-op. Now it calls a real handler that `UPDATE`s the two new columns idempotently (guarded by `last_seq`).
- **Store** (`postgres.rs`, `lib.rs`): new `find_armed_entry_policies()` function returns `(position_id, entry_mode, approval_mode)` for all Armed rows that have persisted policy data.
- **PositionManager** (`position_manager.rs`): new `restore_armed_position()` method re-inserts into `entry_policies` and spawns a fresh `DetectorTask` without re-emitting events.
- **Daemon** (`daemon.rs`): new `restore_armed_detectors()` step runs immediately after `restore_positions()` at startup; parses the persisted policy strings and calls `restore_armed_position` for each Armed position.

## Test plan

- [ ] Deploy to production (ArgoCD auto-sync after merge)
- [ ] Run DB migration: `sqlx migrate run` (or ArgoCD init-container if configured)
- [ ] Arm a new position with `Immediate` + `Automatic`; confirm detector fires and order executes without restarting daemon
- [ ] Restart daemon with an existing Armed position; confirm logs show "Armed position restored: detector re-spawned" and entry executes normally
- [ ] Arm a position with `ConfirmedTrend`; confirm it still awaits signal after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)