### PR TITLE
fix(detector): subscribe to EventBus before spawn to prevent first-tick loss

### DIFF
--- a/robsond/src/detector.rs
+++ b/robsond/src/detector.rs
@@ -67,7 +67,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::{
-    event_bus::{DaemonEvent, EventBus, MarketData},
+    event_bus::{DaemonEvent, EventBus, EventReceiver, MarketData},
     DaemonError, DaemonResult,
 };
 
@@ -271,6 +271,9 @@ impl DetectorTask {
         let position_id = self.config.position_id;
         let symbol = self.config.symbol.clone();
         let cancel_token = self.cancel_token.clone();
+        // Subscribe before spawning so ticks published immediately after spawn
+        // are buffered for this detector instead of being lost to scheduling.
+        let receiver = self.event_bus.subscribe();
 
         tokio::spawn(async move {
             info!(
@@ -279,7 +282,7 @@ impl DetectorTask {
                 "Detector task started"
             );
 
-            let result = self.run(cancel_token).await;
+            let result = self.run(cancel_token, receiver).await;
 
             match &result {
                 Some(signal) => {
@@ -305,14 +308,15 @@ impl DetectorTask {
     /// Run the detector loop.
     ///
     /// This is the main async loop that:
-    /// 1. Subscribes to EventBus
-    /// 2. Waits for events OR cancellation (cooperative)
-    /// 3. Filters MarketData for our symbol
-    /// 4. Applies MA crossover detection logic
-    /// 5. Returns signal or None
-    async fn run(mut self, cancel_token: CancellationToken) -> Option<DetectorSignal> {
-        let mut receiver = self.event_bus.subscribe();
-
+    /// 1. Waits for events OR cancellation (cooperative)
+    /// 2. Filters MarketData for our symbol
+    /// 3. Applies signal detection logic
+    /// 4. Returns signal or None
+    async fn run(
+        mut self,
+        cancel_token: CancellationToken,
+        mut receiver: EventReceiver,
+    ) -> Option<DetectorSignal> {
         loop {
             // Cooperatively check for cancellation
             tokio::select! {

--- a/robsond/src/position_manager.rs
+++ b/robsond/src/position_manager.rs
@@ -3181,16 +3181,14 @@ mod tests {
     use super::*;
     use crate::query_engine::TracingQueryRecorder;
 
-    /// Create a test manager without starting the signal listener.
-    /// Use this for unit tests that call handle_signal() directly.
-    async fn create_test_manager_with_approval_policy(
+    async fn create_test_manager_with_store_and_event_bus(
+        store: Arc<MemoryStore>,
+        event_bus: Arc<EventBus>,
         approval_policy: ApprovalPolicy,
     ) -> Arc<PositionManager<StubExchange, MemoryStore>> {
         let exchange = Arc::new(StubExchange::new(dec!(95000)));
         let journal = Arc::new(IntentJournal::new());
-        let store = Arc::new(MemoryStore::new());
         let executor = Arc::new(Executor::new(exchange, journal, store.clone()));
-        let event_bus = Arc::new(EventBus::new(100));
         let risk_config = RiskConfig::new(dec!(10000)).unwrap(); // 1% risk
         let engine = Engine::new(risk_config);
 
@@ -3206,6 +3204,19 @@ mod tests {
             )
             .with_ohlcv_port(Arc::new(StubOhlcv::new(create_test_candles()))),
         )
+    }
+
+    /// Create a test manager without starting the signal listener.
+    /// Use this for unit tests that call handle_signal() directly.
+    async fn create_test_manager_with_approval_policy(
+        approval_policy: ApprovalPolicy,
+    ) -> Arc<PositionManager<StubExchange, MemoryStore>> {
+        create_test_manager_with_store_and_event_bus(
+            Arc::new(MemoryStore::new()),
+            Arc::new(EventBus::new(100)),
+            approval_policy,
+        )
+        .await
     }
 
     async fn create_test_manager() -> Arc<PositionManager<StubExchange, MemoryStore>> {
@@ -4540,6 +4551,82 @@ mod tests {
         // Verify detector was cleaned up (single-shot)
         // Detector should be removed after signaling (checked via detector count)
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_restore_armed_immediate_automatic_processes_first_market_tick() {
+        use robson_domain::{ApprovalPolicy as DomainApprovalPolicy, EntryPolicy};
+
+        let store = Arc::new(MemoryStore::new());
+        let original_manager = create_test_manager_with_store_and_event_bus(
+            Arc::clone(&store),
+            Arc::new(EventBus::new(100)),
+            ApprovalPolicy::new(Decimal::from(100u32), 300),
+        )
+        .await;
+        let symbol = Symbol::from_pair("BTCUSDT").unwrap();
+        let policy =
+            EntryPolicyConfig::new(EntryPolicy::Immediate, DomainApprovalPolicy::Automatic);
+
+        let position = original_manager
+            .arm_position_with_policy(
+                symbol.clone(),
+                Side::Long,
+                create_test_risk_config(),
+                None,
+                Uuid::now_v7(),
+                policy,
+            )
+            .await
+            .unwrap();
+
+        original_manager.shutdown().await;
+
+        let restored_event_bus = Arc::new(EventBus::new(100));
+        let restored_manager = create_test_manager_with_store_and_event_bus(
+            Arc::clone(&store),
+            Arc::clone(&restored_event_bus),
+            ApprovalPolicy::new(Decimal::from(100u32), 300),
+        )
+        .await;
+        PositionManager::start(Arc::clone(&restored_manager));
+        tokio::task::yield_now().await;
+
+        let restored_position = store
+            .positions()
+            .find_by_id(position.id)
+            .await
+            .unwrap()
+            .expect("armed position must survive restart");
+
+        restored_manager
+            .restore_armed_position(&restored_position, policy)
+            .await
+            .unwrap();
+
+        // Regression coverage: this first tick is sent immediately after restore,
+        // before the spawned detector task has a chance to poll on current_thread.
+        restored_event_bus.send(DaemonEvent::MarketData(MarketData {
+            symbol: symbol.clone(),
+            price: Price::new(dec!(100)).unwrap(),
+            timestamp: chrono::Utc::now(),
+        }));
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let events = store.events().find_by_position(position.id).await.unwrap();
+                if events.iter().any(|event| {
+                    matches!(event, Event::EntrySignalReceived { position_id, .. } if *position_id == position.id)
+                }) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("restored immediate detector must process the first market tick");
+
+        restored_manager.shutdown().await;
     }
 
     // =========================================================================


### PR DESCRIPTION
## Root Cause

`DetectorTask::spawn()` called `self.event_bus.subscribe()` **inside** the spawned async future (in `run()`). After `restore_armed_position()` returned, the spawned task had not yet been scheduled by tokio. A `MarketData` tick published in that window was sent to zero detector subscribers and permanently lost.

`tokio::sync::broadcast` only delivers events to receivers that existed at the time of `send()`. For `Immediate` mode the detector fires on the **first** tick — so missing it meant the position stayed `Armed` indefinitely.

This race did not affect freshly armed positions (where the WebSocket had been running for a long time and ticks arrive continuously), but hit reliably on daemon restarts where the WebSocket reconnects and sends the first tick within milliseconds of the detector being spawned.

## Fix

Move `self.event_bus.subscribe()` to execute **synchronously before** `tokio::spawn()` in `DetectorTask::spawn()`. The receiver now exists from the moment `spawn()` returns, buffering any ticks sent before the async task runs.

## Regression test

`test_restore_armed_immediate_automatic_processes_first_market_tick` in `position_manager.rs`:
- Arms a position with `Immediate + Automatic`
- Shuts down the original manager (simulates restart)
- Rebuilds manager with the same store
- Calls `restore_armed_position()`
- Sends a `MarketData` tick **immediately** (before the spawned task is scheduled)
- Asserts `EntrySignalReceived` is persisted within 1 second

The test fails before the fix, passes after.

## Verification

- `cargo test --all --no-fail-fast`: 588 passed, 23 ignored
- `cargo test --all --all-features --no-fail-fast`: 592 passed, 39 ignored
- `cargo +nightly fmt --all --check`: clean
- `cargo clippy --all-targets --all-features`: 0 errors

🤖 Co-authored with Codex (GPT-5.5 xhigh) + Claude Sonnet 4.6