### PR TITLE
[codex] Recalibrate capital base after manual Futures account drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The system provides a single-operator runtime with a slot-based monthly risk mod
 - **Technical stop**: always from chart analysis (second S/R level, 15m timeframe) — never a percentage of entry price
 - **Slot capacity**: 4 concurrent positions maximum
 
-`capital_base` is set once at month start as a pessimistic snapshot: `wallet_balance − carried_risk(Entering + Active + Armed)`. It is immutable for the duration of the month.
+`capital_base` is set at month start as a pessimistic snapshot: `wallet_balance − carried_risk(Entering + Active + Armed)`. It is immutable during normal operation, but must be recalibrated if reconciliation detects manual account changes outside Robson.
 
 ## Position Lifecycle
 

--- a/docs/ADRs.md
+++ b/docs/ADRs.md
@@ -38,5 +38,6 @@ Index
 | ADR-0022 | Robson-Authored Position Invariant | Decided (Follow-up required) | 2026-04-18 |
 | ADR-0023 | Symbol-Agnostic Policy Invariant | Decided (Follow-up required) | 2026-04-18 |
 | ADR-0036 | Monthly Slot Inheritance and Stop Visibility | Decided | 2026-05-05 |
+| ADR-0038 | Capital Base Recalibration After Manual Account Change | Decided (Implementation required) | 2026-05-28 |
 
 Files located in `docs/adr/`.

--- a/docs/adr/ADR-0022-robson-authored-position-invariant.md
+++ b/docs/adr/ADR-0022-robson-authored-position-invariant.md
@@ -1,7 +1,7 @@
 # ADR-0022 — Robson-Authored Position Invariant
 
 **Date**: 2026-04-18
-**Last Amended**: 2026-05-11 (5B1 live + 5B2A merged; see Amendments)
+**Last Amended**: 2026-05-28 (capital base recalibration after manual account drift; see ADR-0038)
 **Status**: DECIDED — IN PROGRESS (I3 runtime steady-state and startup abort live; manual recovery 5B1 live; startup auto_reconcile 5B2B planned)
 **Deciders**: RBX Systems (operator + architecture)
 
@@ -26,6 +26,12 @@ Every such position silently consumes the account's exposure, margin, and risk
 budget that the Risk Engine assumes is free — with cascading effects under leverage.
 It also has no technical stop, no span, no governance trail, and is invisible to the
 monthly drawdown calculation.
+
+Manual account changes can also corrupt the current month's risk base even after
+position-level reconciliation closes the offending position. If the Futures wallet
+balance has fallen materially below the stored monthly `capital_base`, Robson must
+recalibrate the current month's base before allowing new entries. ADR-0038 defines
+that account-level reconciliation rule.
 
 The existing reconciliation flow (`v3-runtime-spec.md` — Recovery Procedure Scenario
 4) reconciles `RuntimeState` against the exchange and adopts the exchange state
@@ -120,6 +126,8 @@ exception (see [ADR-0023](ADR-0023-symbol-agnostic-policy-invariant.md)).
   due to a bug) results in an auto-close of a legitimate position. Mitigation: the
   exchange-order-id ↔ event-log link must be written atomically with the order
   placement (follow-up required).
+- A manual account loss or withdrawal now forces an additional reconciliation step:
+  current-month `capital_base` must be recalibrated before entries resume.
 
 ### Operational
 
@@ -184,6 +192,7 @@ Follow-up work required (tracked as `MIG-v3#TBD — Reconciliation Worker`):
 - [ADR-0007 — Robson is a Risk Assistant, not an Autotrader](ADR-0007-robson-is-risk-assistant-not-autotrader.md)
 - [ADR-0021 — Opportunity Detection vs Technical Stop Analysis](ADR-0021-opportunity-detection-vs-technical-stop-analysis.md)
 - [ADR-0023 — Symbol-Agnostic Policy Invariant](ADR-0023-symbol-agnostic-policy-invariant.md) (companion)
+- [ADR-0038 — Capital Base Recalibration After Manual Account Change](ADR-0038-capital-base-recalibration-after-manual-account-change.md)
 - [TD-2026-05-05-001 — Core Position Lifecycle Drift](../technical-debt.md) and its
   [Implementation Guide](../implementation/TD-2026-05-05-001-CORE-LIFECYCLE-DRIFT.md)
 - [Runbook td-2026-05-05-001-stale-active-recovery](../runbooks/td-2026-05-05-001-stale-active-recovery.md) — operator recovery when the startup gate aborts under I3

--- a/docs/adr/ADR-0024-trading-policy-layer.md
+++ b/docs/adr/ADR-0024-trading-policy-layer.md
@@ -151,6 +151,27 @@ If a carried position closes in profit during the new month, that gain flows int
 `current_equity` and will feed the capital base of the month after. It does not
 retroactively increase the current month's `capital_base` or budget.
 
+### 6A. Intra-Month Recalibration After Manual Account Change
+
+The month-start `capital_base` is immutable only while the operated Futures
+account remains exclusively controlled by `robsond`. If reconciliation detects a
+manual or otherwise non-Robson account change, the current month's
+`capital_base` MUST be recalibrated before new entries are allowed.
+
+The recalibrated value uses the same pessimistic shape as the month-boundary
+rule:
+
+```text
+capital_base = max(0, current_futures_wallet_balance - carried_risk)
+```
+
+This recalibration is exceptional and auditable. It MUST be represented by a
+dedicated event such as `CapitalBaseRecalibrated`, not by replaying or mutating
+`MonthBoundaryReset`. The projector updates the current `monthly_state` row's
+`capital_base` while preserving accumulated `realized_loss` and `trades_opened`.
+
+See ADR-0038 for the full decision.
+
 **Rationale for the abstraction:**
 
 This design gives the operator a clean, predictable invariant: every month begins with

--- a/docs/adr/ADR-0038-capital-base-recalibration-after-manual-account-change.md
+++ b/docs/adr/ADR-0038-capital-base-recalibration-after-manual-account-change.md
@@ -1,0 +1,166 @@
+# ADR-0038 — Capital Base Recalibration After Manual Account Change
+
+**Date**: 2026-05-28
+**Status**: DECIDED — IMPLEMENTATION REQUIRED
+**Deciders**: RBX Systems (operator + architecture)
+
+---
+
+## Context
+
+`capital_base` is the anchor for Robson's monthly risk model:
+
+- per-trade risk is `capital_base * 1%`;
+- monthly budget is `capital_base * 4%`;
+- slot availability is derived from remaining monthly budget.
+
+ADR-0024 made `capital_base` a month-start snapshot. That is correct while the
+operated Binance Futures account is exclusively controlled by `robsond`.
+
+Manual account changes break that assumption. If an operator trades, closes,
+deposits, withdraws, or otherwise changes the Futures account outside Robson, the
+current wallet balance can become materially lower than the stored monthly
+`capital_base`. Continuing to size new positions from the stale value would
+overstate risk capacity and can cause oversized entries or margin failures.
+
+Manual trading on the Robson-operated account remains prohibited by ADR-0022.
+This ADR defines the required recovery behavior when it nevertheless happens.
+
+---
+
+## Decision
+
+When Robson detects a manual or otherwise non-Robson account change that makes
+the current Futures wallet/equity materially diverge from Robson's risk ledger,
+Robson MUST recalibrate the current month's `capital_base` before allowing any
+new entries.
+
+The recalibrated value is:
+
+```text
+new_capital_base = max(0, current_futures_wallet_balance - carried_risk)
+```
+
+where `carried_risk` is the same pessimistic risk calculation used at a month
+boundary: committed risk from `Entering`/`Active` positions plus reserved risk
+for `Armed` positions.
+
+The recalibration is an audit event, not a silent projection update.
+
+---
+
+## Required Runtime Behavior
+
+1. **Detect manual account drift.**
+   Reconciliation must compare exchange account state with Robson's event-sourced
+   ledger. Triggers include UNTRACKED positions, manual closes, balance changes,
+   deposits/withdrawals, and wallet/equity deltas not explained by Robson events.
+
+2. **Block new entries while unresolved.**
+   Once manual drift is detected, the entry path must fail closed until the
+   drift is reconciled and `capital_base` has been recalibrated.
+
+3. **Close/reconcile positions first.**
+   Position-level reconciliation still follows ADR-0022:
+   UNTRACKED exchange positions are closed; stale Robson `Active` positions are
+   reconciled with real evidence where available.
+
+4. **Recalculate current-month `capital_base`.**
+   After position reconciliation, query the current Futures wallet balance and
+   compute `new_capital_base = max(0, wallet_balance - carried_risk)`.
+
+5. **Emit a dedicated event.**
+   Recalibration must be represented by a new domain event, for example:
+
+   ```text
+   CapitalBaseRecalibrated {
+     previous_capital_base,
+     new_capital_base,
+     wallet_balance,
+     carried_risk,
+     reason,
+     evidence,
+     month,
+     year,
+     timestamp,
+   }
+   ```
+
+   The canonical `reason` for this ADR is `manual_account_change`.
+
+6. **Project into `monthly_state`.**
+   The projector updates the current `(year, month)` row's `capital_base` to
+   `new_capital_base` while preserving already accumulated `realized_loss` and
+   `trades_opened`.
+
+7. **Re-evaluate risk gates.**
+   MonthlyHalt, slots, and position sizing must be recomputed against the new
+   `capital_base` before any new entry can proceed.
+
+---
+
+## Non-Goals
+
+- This does not permit manual trading on the Robson-operated account.
+- This does not adopt manual trades into Robson's governance trail.
+- This does not replace month-boundary recalculation; it adds an intra-month
+  exceptional recalibration path.
+- This does not let manual gains silently increase risk. A recalibration may
+  reduce or increase `capital_base`, but it must always be auditable and tied to
+  detected account drift.
+
+---
+
+## Consequences
+
+### Positive
+
+- Robson no longer sizes positions from a stale monthly base after manual account
+  losses or withdrawals.
+- Exchange state and risk policy become consistent before new entries resume.
+- Manual account interference remains a visible policy violation with an audit
+  trail.
+
+### Negative / Trade-offs
+
+- Reconciliation becomes broader: it must reason about account-level balance
+  drift, not only position lifecycle drift.
+- `monthly_state.capital_base` is no longer strictly immutable for the whole
+  calendar month; it is immutable except for explicit recalibration events.
+- Additional UI/API observability is needed so the operator can see when and why
+  the monthly base changed.
+
+---
+
+## Relationship To ADR-0037
+
+ADR-0037 defines operational states such as `PAUSED`, `DRAINING`, and `STOPPED`.
+This ADR is orthogonal. A future runtime state such as `RECONCILING` or
+`DEGRADED` may be used to enforce the entry block while capital recalibration is
+pending, but the capital accounting rule belongs to ADR-0024/ADR-0022 and this
+ADR.
+
+---
+
+## Implementation Notes
+
+Likely code changes:
+
+- `robson-domain`: add `CapitalBaseRecalibrated` event and typed reason/evidence.
+- `robson-projector`: update `monthly_state.capital_base` on the event without
+  resetting `realized_loss` or `trades_opened`.
+- `robsond`: add account-level drift detection to reconciliation and an entry
+  gate that blocks while drift is unresolved.
+- `robsond`: reuse month-boundary carried-risk calculation for intra-month
+  recalibration.
+- API/frontend: expose current `capital_base`, recalibration status, last
+  recalibration reason, and timestamp.
+
+---
+
+## Related
+
+- ADR-0022 — Robson-Authored Position Invariant
+- ADR-0024 — Trading Policy Layer
+- ADR-0037 — Runtime State Machine for Operational Control
+- `docs/policies/UNTRACKED-POSITION-RECONCILIATION.md`

--- a/docs/policies/UNTRACKED-POSITION-RECONCILIATION.md
+++ b/docs/policies/UNTRACKED-POSITION-RECONCILIATION.md
@@ -22,13 +22,14 @@ No exceptions. No workarounds. No shortcuts.
 
 ---
 
-## The Three Invariants
+## The Four Invariants
 
 The policy is symmetric: the relation between Robson's local lifecycle state
 and the exchange's view of the account must hold in both directions. I1/I2
 protect the exchange-to-Robson direction (foreign positions get closed). I3
 protects the opposite direction (Robson-Active positions whose exchange
-counterpart has disappeared get reconciled).
+counterpart has disappeared get reconciled). I4 protects the account-level
+risk base after manual or otherwise non-Robson balance changes.
 
 ### I1 — Authorship Invariant
 
@@ -204,6 +205,36 @@ visible audit trail and an operator alert:
 The on-wire `Event::PositionClosed.closure_evidence.kind` is `reconciled`
 and the inner `source` is `estimated`; nothing about the JSON shape lets a
 downstream consumer mistake estimated PnL for a real exchange fill.
+
+### I4 — Capital Base Recalibration Invariant (ADR-0038)
+
+> **Manual account drift invalidates the current risk base.** If Robson detects
+> a manual or otherwise non-Robson change to the operated Futures account that
+> makes the exchange wallet/equity diverge materially from Robson's monthly
+> risk ledger, Robson MUST block new entries and recalculate the current
+> month's `capital_base` from the current Futures wallet balance before
+> trading resumes.
+
+I4 is account-level reconciliation. I1/I2/I3 reconcile positions; I4 reconciles
+the monthly risk base used for position sizing and MonthlyHalt.
+
+Required behavior:
+
+1. Detect account-level drift during reconciliation.
+2. Finish position-level reconciliation first: close UNTRACKED positions and
+   reconcile stale Robson `Active` positions according to I2/I3.
+3. Compute `new_capital_base = max(0, current_futures_wallet_balance - carried_risk)`.
+4. Emit a dedicated `CapitalBaseRecalibrated` event with previous base, new
+   base, wallet balance, carried risk, reason, evidence, month, year, and
+   timestamp.
+5. Project the event into `monthly_state.capital_base` without resetting
+   `realized_loss` or `trades_opened`.
+6. Recompute slots, position sizing, and MonthlyHalt using the recalibrated
+   value before any new entry proceeds.
+
+The canonical reason for this path is `manual_account_change`. Recalibration
+does not legitimize manual trading on the operated account and must not create
+synthetic Robson-authored entry history for manual trades.
 
 ---
 
@@ -409,6 +440,7 @@ the reconciliation close is non-overridable.
 ## Related Documentation
 
 - **[ADR-0022 — Robson-Authored Position Invariant](../adr/ADR-0022-robson-authored-position-invariant.md)**
+- **[ADR-0038 — Capital Base Recalibration After Manual Account Change](../adr/ADR-0038-capital-base-recalibration-after-manual-account-change.md)**
 - **[SYMBOL-AGNOSTIC-POLICIES.md](SYMBOL-AGNOSTIC-POLICIES.md)**
 - [v3-runtime-spec.md](../architecture/v3-runtime-spec.md) — Recovery Procedures §Reconciliation
 - [v3-control-loop.md](../architecture/v3-control-loop.md) — Crash Recovery §Reconciliation

--- a/robson-domain/src/events.rs
+++ b/robson-domain/src/events.rs
@@ -333,6 +333,33 @@ pub enum Event {
         timestamp: DateTime<Utc>,
     },
 
+    /// Current-month capital base recalibrated after manual or otherwise
+    /// non-Robson account drift was detected.
+    ///
+    /// This is a system-scoped event. It does not belong to a specific
+    /// position, so helper accessors use `Uuid::nil()` as a synthetic
+    /// sentinel position ID.
+    CapitalBaseRecalibrated {
+        /// Previous monthly capital base from `monthly_state`
+        previous_capital_base: Decimal,
+        /// New monthly capital base after wallet-balance reconciliation
+        new_capital_base: Decimal,
+        /// Current Futures wallet balance observed on the exchange
+        wallet_balance: Decimal,
+        /// Risk reserved for carried positions at recalibration time
+        carried_risk: Decimal,
+        /// Machine-readable reason, e.g. `manual_account_change`
+        reason: String,
+        /// Human-readable or structured evidence reference
+        evidence: String,
+        /// UTC month (1-12)
+        month: u32,
+        /// UTC year
+        year: i32,
+        /// When the recalibration was processed
+        timestamp: DateTime<Utc>,
+    },
+
     /// Entry is awaiting operator approval before the order can be placed.
     ///
     /// Emitted when the entry signal passed risk evaluation but the position's
@@ -430,7 +457,9 @@ impl Event {
             | Event::PositionError { position_id, .. }
             | Event::InsuranceStopPlaced { position_id, .. }
             | Event::InsuranceStopCancelled { position_id, .. } => *position_id,
-            Event::MonthBoundaryReset { .. } => uuid::Uuid::nil(),
+            Event::MonthBoundaryReset { .. } | Event::CapitalBaseRecalibrated { .. } => {
+                uuid::Uuid::nil()
+            },
         }
     }
 
@@ -455,6 +484,7 @@ impl Event {
             | Event::ExitFilled { timestamp, .. }
             | Event::PositionClosed { timestamp, .. }
             | Event::MonthBoundaryReset { timestamp, .. }
+            | Event::CapitalBaseRecalibrated { timestamp, .. }
             | Event::EntryApprovalPending { timestamp, .. }
             | Event::PositionDisarmed { timestamp, .. }
             | Event::PositionError { timestamp, .. }
@@ -484,6 +514,7 @@ impl Event {
             Event::ExitFilled { .. } => "exit_filled",
             Event::PositionClosed { .. } => "position_closed",
             Event::MonthBoundaryReset { .. } => "month_boundary_reset",
+            Event::CapitalBaseRecalibrated { .. } => "capital_base_recalibrated",
             Event::EntryApprovalPending { .. } => "entry_approval_pending",
             Event::PositionDisarmed { .. } => "position_disarmed",
             Event::PositionError { .. } => "position_error",

--- a/robson-projector/src/apply.rs
+++ b/robson-projector/src/apply.rs
@@ -28,6 +28,7 @@ enum ProjectionRoute {
     TechnicalStopAnalyzed,
     EntrySignalReceived,
     MonthBoundaryReset,
+    CapitalBaseRecalibrated,
     TrailingStopUpdated,
     PositionMonitorTick,
     ExitTriggered,
@@ -69,6 +70,7 @@ fn projection_route(event_type: &str) -> Option<ProjectionRoute> {
             Some(ProjectionRoute::EntrySignalReceived)
         },
         "month_boundary_reset" => Some(ProjectionRoute::MonthBoundaryReset),
+        "capital_base_recalibrated" => Some(ProjectionRoute::CapitalBaseRecalibrated),
         "trailing_stop_updated" | "TRAILING_STOP_UPDATED" => {
             Some(ProjectionRoute::TrailingStopUpdated)
         },
@@ -157,6 +159,9 @@ pub async fn apply_event_to_projections(pool: &PgPool, envelope: &EventEnvelope)
         },
         Some(ProjectionRoute::MonthBoundaryReset) => {
             handlers::monthly_state::handle_month_boundary_reset(pool, envelope).await?
+        },
+        Some(ProjectionRoute::CapitalBaseRecalibrated) => {
+            handlers::monthly_state::handle_capital_base_recalibrated(pool, envelope).await?
         },
         Some(ProjectionRoute::TrailingStopUpdated) => {
             handlers::positions::handle_trailing_stop_updated(pool, envelope).await?

--- a/robson-projector/src/handlers/monthly_state.rs
+++ b/robson-projector/src/handlers/monthly_state.rs
@@ -13,7 +13,7 @@ use sqlx::PgPool;
 
 use crate::{
     error::{ProjectionError, Result},
-    types::{EntryFilled, MonthBoundaryReset, PositionClosedDomain},
+    types::{CapitalBaseRecalibrated, EntryFilled, MonthBoundaryReset, PositionClosedDomain},
 };
 
 pub(crate) async fn handle_month_boundary_reset(
@@ -52,6 +52,45 @@ pub(crate) async fn handle_month_boundary_reset(
     .bind(month)
     .bind(payload.capital_base)
     .bind(payload.carried_positions_risk)
+    .bind(payload.timestamp)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub(crate) async fn handle_capital_base_recalibrated(
+    pool: &PgPool,
+    envelope: &EventEnvelope,
+) -> Result<()> {
+    let payload: CapitalBaseRecalibrated = serde_json::from_value(envelope.payload.clone())
+        .map_err(|e| ProjectionError::InvalidPayload {
+            event_type: envelope.event_type.clone(),
+            reason: e.to_string(),
+        })?;
+
+    let year = i16::try_from(payload.year).map_err(|_| ProjectionError::InvalidPayload {
+        event_type: envelope.event_type.clone(),
+        reason: format!("year out of range for SMALLINT: {}", payload.year),
+    })?;
+    let month = i16::try_from(payload.month).map_err(|_| ProjectionError::InvalidPayload {
+        event_type: envelope.event_type.clone(),
+        reason: format!("month out of range for SMALLINT: {}", payload.month),
+    })?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO monthly_state (year, month, capital_base, carried_risk, realized_loss, trades_opened, created_at)
+        VALUES ($1, $2, $3, $4, 0, 0, $5)
+        ON CONFLICT (year, month) DO UPDATE SET
+            capital_base = EXCLUDED.capital_base,
+            carried_risk = EXCLUDED.carried_risk
+        "#,
+    )
+    .bind(year)
+    .bind(month)
+    .bind(payload.new_capital_base)
+    .bind(payload.carried_risk)
     .bind(payload.timestamp)
     .execute(pool)
     .await?;

--- a/robson-projector/src/types.rs
+++ b/robson-projector/src/types.rs
@@ -255,6 +255,20 @@ pub struct MonthBoundaryReset {
     pub timestamp: DateTime<Utc>,
 }
 
+/// CAPITAL_BASE_RECALIBRATED payload
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapitalBaseRecalibrated {
+    pub previous_capital_base: Decimal,
+    pub new_capital_base: Decimal,
+    pub wallet_balance: Decimal,
+    pub carried_risk: Decimal,
+    pub reason: String,
+    pub evidence: String,
+    pub month: u32,
+    pub year: i32,
+    pub timestamp: DateTime<Utc>,
+}
+
 // =============================================================================
 // BALANCE EVENTS
 // =============================================================================

--- a/robson-store/src/memory.rs
+++ b/robson-store/src/memory.rs
@@ -124,9 +124,9 @@ impl MemoryStore {
             // signal is accepted and entry processing begins.
             Event::TechnicalStopAnalyzed { .. } => {},
 
-            // MonthBoundaryReset: system-level audit/projection event. It does
-            // not mutate per-position state in the in-memory projection.
-            Event::MonthBoundaryReset { .. } => {},
+            // System-level audit/projection events. They do not mutate
+            // per-position state in the in-memory projection.
+            Event::MonthBoundaryReset { .. } | Event::CapitalBaseRecalibrated { .. } => {},
 
             // EntryOrderPlaced (LEGACY): audit-only, does NOT transition to Entering.
             // Kept for eventlog replay compatibility.

--- a/robsond/src/position_manager.rs
+++ b/robsond/src/position_manager.rs
@@ -201,7 +201,8 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
     #[cfg(feature = "postgres")]
     fn event_stream_key(event: &Event) -> String {
         match event {
-            Event::MonthBoundaryReset { year, month, .. } => {
+            Event::MonthBoundaryReset { year, month, .. }
+            | Event::CapitalBaseRecalibrated { year, month, .. } => {
                 format!("system:month_boundary:{year:04}-{month:02}")
             },
             _ => format!("position:{}", event.position_id()),

--- a/robsond/src/reconciliation_worker.rs
+++ b/robsond/src/reconciliation_worker.rs
@@ -5,13 +5,14 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Datelike, Utc};
 use robson_domain::{
-    OrderFillEvidence, Position, PositionId, PositionState, Quantity, ReconciliationEvidence, Side,
-    Symbol, UserTradeEvidence,
+    Event, OrderFillEvidence, Position, PositionId, PositionState, Quantity,
+    ReconciliationEvidence, Side, Symbol, UserTradeEvidence,
 };
 use robson_exec::{ExchangePort, ExchangePosition, OrderResult, UserTradeRecord};
 use robson_store::Store;
+use rust_decimal::Decimal;
 use tokio::{
     sync::{Mutex, RwLock},
     time::{Instant, MissedTickBehavior},
@@ -278,6 +279,10 @@ impl<E: ExchangePort + 'static, S: Store + 'static> ReconciliationWorker<E, S> {
         }
 
         reconciled += self.reconcile_local_missing_positions(&exchange_positions).await?;
+
+        if reconciled > 0 {
+            self.recalibrate_capital_base_after_manual_drift(reconciled).await?;
+        }
 
         Ok(reconciled)
     }
@@ -551,6 +556,105 @@ impl<E: ExchangePort + 'static, S: Store + 'static> ReconciliationWorker<E, S> {
                 Err(DaemonError::Exec(error))
             },
         }
+    }
+
+    async fn recalibrate_capital_base_after_manual_drift(
+        &self,
+        reconciled_positions: usize,
+    ) -> DaemonResult<()> {
+        let now = Utc::now();
+        let wallet_balance = self.exchange.get_futures_balance().await?.wallet_balance;
+        let previous_capital_base = {
+            let manager = self.position_manager.read().await;
+            manager.load_monthly_state(now).await?.capital_base
+        };
+
+        let carried_risk_committed =
+            Self::calculate_committed_carried_risk(&self.store.positions().find_risk_open().await?);
+        let armed_count = self
+            .store
+            .positions()
+            .find_active()
+            .await?
+            .iter()
+            .filter(|position| matches!(position.state, PositionState::Armed))
+            .count() as u32;
+        let armed_risk =
+            previous_capital_base * Decimal::new(1, 2) * Decimal::from(armed_count);
+        let carried_risk = carried_risk_committed + armed_risk;
+        let new_capital_base = (wallet_balance - carried_risk).max(Decimal::ZERO);
+
+        if new_capital_base == previous_capital_base {
+            info!(
+                %previous_capital_base,
+                %wallet_balance,
+                %carried_risk,
+                reconciled_positions,
+                "Capital base recalibration skipped: value unchanged after reconciliation"
+            );
+            return Ok(());
+        }
+
+        info!(
+            %previous_capital_base,
+            %new_capital_base,
+            %wallet_balance,
+            %carried_risk,
+            reconciled_positions,
+            "Capital base recalibrated after manual account drift"
+        );
+
+        let event = Event::CapitalBaseRecalibrated {
+            previous_capital_base,
+            new_capital_base,
+            wallet_balance,
+            carried_risk,
+            reason: "manual_account_change".to_string(),
+            evidence: format!("reconciliation_worker:positions_reconciled={reconciled_positions}"),
+            month: now.month(),
+            year: now.year(),
+            timestamp: now,
+        };
+
+        let manager = self.position_manager.read().await;
+        manager.emit_domain_event(event).await?;
+
+        Ok(())
+    }
+
+    fn calculate_committed_carried_risk(positions: &[Position]) -> Decimal {
+        positions
+            .iter()
+            .filter_map(|position| {
+                let qty = position.quantity.as_decimal();
+                if qty == Decimal::ZERO {
+                    return None;
+                }
+
+                let (entry, stop) = match &position.state {
+                    PositionState::Active { trailing_stop, .. } => {
+                        (position.entry_price?.as_decimal(), trailing_stop.as_decimal())
+                    },
+                    PositionState::Entering { expected_entry, .. } => {
+                        let entry = expected_entry.as_decimal();
+                        let stop = position
+                            .tech_stop_distance
+                            .as_ref()
+                            .map(|tech_stop| tech_stop.initial_stop.as_decimal())
+                            .unwrap_or(entry);
+                        (entry, stop)
+                    },
+                    _ => return None,
+                };
+
+                let risk = match position.side {
+                    Side::Long => (entry - stop) * qty,
+                    Side::Short => (stop - entry) * qty,
+                };
+
+                Some(risk.max(Decimal::ZERO))
+            })
+            .sum()
     }
 }
 

--- a/robsond/src/reconciliation_worker.rs
+++ b/robsond/src/reconciliation_worker.rs
@@ -644,8 +644,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> ReconciliationWorker<E, S> {
             .iter()
             .filter(|position| matches!(position.state, PositionState::Armed))
             .count() as u32;
-        let armed_risk =
-            previous_capital_base * Decimal::new(1, 2) * Decimal::from(armed_count);
+        let armed_risk = previous_capital_base * Decimal::new(1, 2) * Decimal::from(armed_count);
         let carried_risk = carried_risk_committed + armed_risk;
         let new_capital_base = (wallet_balance - carried_risk).max(Decimal::ZERO);
 

--- a/robsond/src/reconciliation_worker.rs
+++ b/robsond/src/reconciliation_worker.rs
@@ -282,6 +282,8 @@ impl<E: ExchangePort + 'static, S: Store + 'static> ReconciliationWorker<E, S> {
 
         if reconciled > 0 {
             self.recalibrate_capital_base_after_manual_drift(reconciled).await?;
+        } else {
+            self.recalibrate_capital_base_after_pure_financial_drift().await?;
         }
 
         Ok(reconciled)
@@ -562,6 +564,69 @@ impl<E: ExchangePort + 'static, S: Store + 'static> ReconciliationWorker<E, S> {
         &self,
         reconciled_positions: usize,
     ) -> DaemonResult<()> {
+        self.recalibrate_capital_base(
+            format!("reconciliation_worker:positions_reconciled={reconciled_positions}"),
+            Some(reconciled_positions),
+        )
+        .await
+    }
+
+    async fn recalibrate_capital_base_after_pure_financial_drift(&self) -> DaemonResult<()> {
+        let now = Utc::now();
+        let risk_open = self.store.positions().find_risk_open().await?;
+        let all_open = self.store.positions().find_active().await?;
+        let armed_count = all_open
+            .iter()
+            .filter(|position| matches!(position.state, PositionState::Armed))
+            .count();
+
+        if !risk_open.is_empty() || armed_count > 0 {
+            debug!(
+                risk_open_count = risk_open.len(),
+                armed_count,
+                "Pure financial drift scan skipped while Robson positions are open or armed"
+            );
+            return Ok(());
+        }
+
+        let wallet_balance = self.exchange.get_futures_balance().await?.wallet_balance;
+        let previous_capital_base = {
+            let manager = self.position_manager.read().await;
+            manager.load_monthly_state(now).await?.capital_base
+        };
+        let closed = self.store.positions().find_closed_in_month(now.year(), now.month()).await?;
+        let robson_month_net: Decimal =
+            closed.iter().map(|position| position.realized_pnl - position.fees_paid).sum();
+        let expected_wallet_balance = previous_capital_base + robson_month_net;
+        let unexplained_delta = wallet_balance - expected_wallet_balance;
+
+        if decimal_abs(unexplained_delta) <= financial_drift_tolerance() {
+            return Ok(());
+        }
+
+        warn!(
+            %wallet_balance,
+            %expected_wallet_balance,
+            %previous_capital_base,
+            %robson_month_net,
+            %unexplained_delta,
+            "Pure financial account drift detected; recalibrating capital_base"
+        );
+
+        self.recalibrate_capital_base(
+            format!(
+                "financial_drift:wallet_balance={wallet_balance};expected_wallet_balance={expected_wallet_balance};unexplained_delta={unexplained_delta}"
+            ),
+            None,
+        )
+        .await
+    }
+
+    async fn recalibrate_capital_base(
+        &self,
+        evidence: String,
+        reconciled_positions: Option<usize>,
+    ) -> DaemonResult<()> {
         let now = Utc::now();
         let wallet_balance = self.exchange.get_futures_balance().await?.wallet_balance;
         let previous_capital_base = {
@@ -589,7 +654,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> ReconciliationWorker<E, S> {
                 %previous_capital_base,
                 %wallet_balance,
                 %carried_risk,
-                reconciled_positions,
+                ?reconciled_positions,
                 "Capital base recalibration skipped: value unchanged after reconciliation"
             );
             return Ok(());
@@ -600,7 +665,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> ReconciliationWorker<E, S> {
             %new_capital_base,
             %wallet_balance,
             %carried_risk,
-            reconciled_positions,
+            ?reconciled_positions,
             "Capital base recalibrated after manual account drift"
         );
 
@@ -610,7 +675,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> ReconciliationWorker<E, S> {
             wallet_balance,
             carried_risk,
             reason: "manual_account_change".to_string(),
-            evidence: format!("reconciliation_worker:positions_reconciled={reconciled_positions}"),
+            evidence,
             month: now.month(),
             year: now.year(),
             timestamp: now,
@@ -655,6 +720,18 @@ impl<E: ExchangePort + 'static, S: Store + 'static> ReconciliationWorker<E, S> {
                 Some(risk.max(Decimal::ZERO))
             })
             .sum()
+    }
+}
+
+fn financial_drift_tolerance() -> Decimal {
+    Decimal::new(1, 2)
+}
+
+fn decimal_abs(value: Decimal) -> Decimal {
+    if value < Decimal::ZERO {
+        -value
+    } else {
+        value
     }
 }
 
@@ -802,6 +879,87 @@ mod tests {
             .iter()
             .filter(|event| matches!(event, robson_domain::Event::PositionClosed { .. }))
             .count()
+    }
+
+    async fn capital_base_recalibration_events(
+        store: &Arc<MemoryStore>,
+    ) -> Vec<robson_domain::Event> {
+        store
+            .events()
+            .get_all_events()
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|event| matches!(event, robson_domain::Event::CapitalBaseRecalibrated { .. }))
+            .collect()
+    }
+
+    async fn save_closed_position_with_pnl_and_fees(
+        store: &Arc<MemoryStore>,
+        realized_pnl: Decimal,
+        fees_paid: Decimal,
+    ) {
+        let symbol = Symbol::from_pair("BTCUSDT").unwrap();
+        let now = Utc::now();
+        let exit_price = Price::new(dec!(100) + realized_pnl).unwrap();
+        let mut position = Position::new(Uuid::now_v7(), symbol, Side::Long);
+        position.entry_price = Some(Price::new(dec!(100)).unwrap());
+        position.quantity = Quantity::new(dec!(1)).unwrap();
+        position.realized_pnl = realized_pnl;
+        position.fees_paid = fees_paid;
+        position.closed_at = Some(now);
+        position.updated_at = now;
+        position.state = PositionState::Closed {
+            exit_price,
+            realized_pnl,
+            exit_reason: ExitReason::TrailingStop,
+        };
+        store.positions().save(&position).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_pure_financial_drift_recalibrates_capital_base_without_open_risk() {
+        let exchange = Arc::new(StubExchange::new(dec!(100)));
+        let store = Arc::new(MemoryStore::new());
+        let event_bus = Arc::new(EventBus::new(16));
+        exchange.set_futures_balance(dec!(7500));
+        let worker = create_worker(exchange, store.clone(), event_bus, Duration::from_secs(0));
+
+        assert_eq!(worker.scan_and_reconcile().await.unwrap(), 0);
+
+        let events = capital_base_recalibration_events(&store).await;
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            robson_domain::Event::CapitalBaseRecalibrated {
+                previous_capital_base,
+                new_capital_base,
+                wallet_balance,
+                carried_risk,
+                evidence,
+                ..
+            } => {
+                assert_eq!(*previous_capital_base, dec!(10000));
+                assert_eq!(*new_capital_base, dec!(7500));
+                assert_eq!(*wallet_balance, dec!(7500));
+                assert_eq!(*carried_risk, Decimal::ZERO);
+                assert!(evidence.starts_with("financial_drift:"));
+            },
+            event => panic!("unexpected event: {event:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pure_financial_drift_ignores_robson_closed_pnl() {
+        let exchange = Arc::new(StubExchange::new(dec!(100)));
+        let store = Arc::new(MemoryStore::new());
+        let event_bus = Arc::new(EventBus::new(16));
+        save_closed_position_with_pnl_and_fees(&store, dec!(200), dec!(0.50)).await;
+        exchange.set_futures_balance(dec!(10199.50));
+        let worker = create_worker(exchange, store.clone(), event_bus, Duration::from_secs(0));
+
+        assert_eq!(worker.scan_and_reconcile().await.unwrap(), 0);
+
+        assert!(capital_base_recalibration_events(&store).await.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Implements ADR-0038 for capital base recalibration after manual Futures account changes.

- Adds the `CapitalBaseRecalibrated` domain event and projector handling.
- Recalculates current-month `capital_base` after manual position reconciliation.
- Detects pure financial account drift when there is no Robson open risk or armed entry.
- Keeps Robson-authored closed PnL from being treated as manual financial drift.
- Updates ADR/policy docs to reflect the new invariant.

## Validation

- `cargo check -p robson-domain -p robson-store -p robson-projector -p robsond`
- `cargo check -p robsond`
- `cargo test -p robsond reconciliation_worker`
- `git diff --check`

Note: `cargo fmt --all --check` was not used as a gate because the repo has pre-existing formatting churn outside this slice.