### PR TITLE
feat(funding): Spot→USDT→USDT-M funding saga + capital refresh (flag OFF)

### DIFF
--- a/migrations/20240101000014_create_funding_sagas.sql
+++ b/migrations/20240101000014_create_funding_sagas.sql
@@ -1,0 +1,19 @@
+-- Funding treasury saga projection.
+--
+-- Events remain authoritative in event_log streams keyed as funding:<saga_id>.
+-- This table stores the current state needed by REST GET/list handlers and
+-- worker recovery scans.
+
+CREATE TABLE IF NOT EXISTS funding_sagas (
+    tenant_id      UUID        NOT NULL,
+    saga_id        UUID        NOT NULL,
+    state          TEXT        NOT NULL,
+    quote          JSONB       NOT NULL,
+    estimated_usdt NUMERIC     NOT NULL DEFAULT 0,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, saga_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_funding_sagas_state
+    ON funding_sagas (tenant_id, state, updated_at);

--- a/robson-connectors/src/binance_rest.rs
+++ b/robson-connectors/src/binance_rest.rs
@@ -35,6 +35,9 @@ const BINANCE_FUTURES_API_URL: &str = "https://fapi.binance.com";
 /// Binance USD-M futures testnet REST API base URL.
 const BINANCE_FUTURES_TESTNET_API_URL: &str = "https://testnet.binancefuture.com";
 
+const BINANCE_SPOT_API_URL: &str = "https://api.binance.com";
+const BINANCE_SPOT_TESTNET_API_URL: &str = "https://testnet.binance.vision";
+
 /// Request timeout in seconds
 const REQUEST_TIMEOUT_SECS: u64 = 10;
 
@@ -120,6 +123,22 @@ impl BinanceRestClient {
         }
     }
 
+    fn spot_base_url(&self) -> &str {
+        if self.testnet {
+            BINANCE_SPOT_TESTNET_API_URL
+        } else {
+            BINANCE_SPOT_API_URL
+        }
+    }
+
+    fn endpoint_base_url(&self, endpoint: &str) -> &str {
+        if endpoint.starts_with("/fapi/") {
+            self.base_url()
+        } else {
+            self.spot_base_url()
+        }
+    }
+
     /// Build query string with signature for signed requests.
     fn build_signed_query(
         &self,
@@ -154,11 +173,11 @@ impl BinanceRestClient {
         params: Vec<(&str, String)>,
     ) -> Result<String, BinanceRestError> {
         let url = if params.is_empty() {
-            format!("{}{}", self.base_url(), endpoint)
+            format!("{}{}", self.endpoint_base_url(endpoint), endpoint)
         } else {
             let query =
                 params.iter().map(|(k, v)| format!("{}={}", k, v)).collect::<Vec<_>>().join("&");
-            format!("{}{}?{}", self.base_url(), endpoint, query)
+            format!("{}{}?{}", self.endpoint_base_url(endpoint), endpoint, query)
         };
 
         let response =
@@ -190,7 +209,7 @@ impl BinanceRestClient {
         params: Vec<(&str, String)>,
     ) -> Result<String, BinanceRestError> {
         let query = self.build_signed_query(params)?;
-        let url = format!("{}{}?{}", self.base_url(), endpoint, query);
+        let url = format!("{}{}?{}", self.endpoint_base_url(endpoint), endpoint, query);
 
         let response = timeout(
             Duration::from_secs(REQUEST_TIMEOUT_SECS),
@@ -223,7 +242,7 @@ impl BinanceRestClient {
         params: Vec<(&str, String)>,
     ) -> Result<String, BinanceRestError> {
         let query = self.build_signed_query(params)?;
-        let url = format!("{}{}?{}", self.base_url(), endpoint, query);
+        let url = format!("{}{}?{}", self.endpoint_base_url(endpoint), endpoint, query);
 
         let response = timeout(
             Duration::from_secs(REQUEST_TIMEOUT_SECS),
@@ -256,7 +275,7 @@ impl BinanceRestClient {
         params: Vec<(&str, String)>,
     ) -> Result<String, BinanceRestError> {
         let query = self.build_signed_query(params)?;
-        let url = format!("{}{}?{}", self.base_url(), endpoint, query);
+        let url = format!("{}{}?{}", self.endpoint_base_url(endpoint), endpoint, query);
 
         let response = timeout(
             Duration::from_secs(REQUEST_TIMEOUT_SECS),
@@ -581,6 +600,104 @@ impl BinanceRestClient {
             available_balance: usdt.availableBalance,
         })
     }
+
+    pub async fn get_spot_account_balances(
+        &self,
+    ) -> Result<Vec<BinanceSpotBalance>, BinanceRestError> {
+        let body = self.get_signed("/api/v3/account", vec![]).await?;
+        let account: BinanceSpotAccountResponse =
+            serde_json::from_str(&body).map_err(|e| BinanceRestError::ParseError(e.to_string()))?;
+
+        Ok(account
+            .balances
+            .into_iter()
+            .filter(|b| b.free != Decimal::ZERO || b.locked != Decimal::ZERO)
+            .collect())
+    }
+
+    pub async fn get_spot_price(&self, symbol: &str) -> Result<Price, BinanceRestError> {
+        let body = self
+            .get_public("/api/v3/ticker/price", vec![("symbol", symbol.to_string())])
+            .await?;
+        let response: PriceResponse =
+            serde_json::from_str(&body).map_err(|e| BinanceRestError::ParseError(e.to_string()))?;
+
+        Price::new(response.price)
+            .map_err(|e| BinanceRestError::ParseError(format!("Invalid spot price: {}", e)))
+    }
+
+    pub async fn place_spot_market_order(
+        &self,
+        symbol: &str,
+        side: &str,
+        quantity_param: (&str, Decimal),
+        client_order_id: &str,
+    ) -> Result<BinanceSpotOrderResponse, BinanceRestError> {
+        let params = vec![
+            ("symbol", symbol.to_string()),
+            ("side", side.to_string()),
+            ("type", "MARKET".to_string()),
+            (quantity_param.0, quantity_param.1.to_string()),
+            ("newClientOrderId", client_order_id.to_string()),
+            ("newOrderRespType", "FULL".to_string()),
+        ];
+
+        let body = self.post_signed("/api/v3/order", params).await?;
+        serde_json::from_str(&body).map_err(|e| BinanceRestError::ParseError(e.to_string()))
+    }
+
+    pub async fn get_spot_order(
+        &self,
+        symbol: &str,
+        client_order_id: &str,
+    ) -> Result<Option<BinanceSpotOrderResponse>, BinanceRestError> {
+        let params = vec![
+            ("symbol", symbol.to_string()),
+            ("origClientOrderId", client_order_id.to_string()),
+        ];
+
+        match self.get_signed("/api/v3/order", params).await {
+            Ok(body) => serde_json::from_str(&body)
+                .map(Some)
+                .map_err(|e| BinanceRestError::ParseError(e.to_string())),
+            Err(BinanceRestError::ApiError { code: -2013, .. }) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub async fn universal_transfer(
+        &self,
+        asset: &str,
+        amount: Decimal,
+        transfer_type: &str,
+        client_tran_key: &str,
+    ) -> Result<BinanceUniversalTransferResponse, BinanceRestError> {
+        let params = vec![
+            ("type", transfer_type.to_string()),
+            ("asset", asset.to_string()),
+            ("amount", amount.to_string()),
+            ("clientTranId", client_tran_key.to_string()),
+        ];
+
+        let body = self.post_signed("/sapi/v1/asset/transfer", params).await?;
+        serde_json::from_str(&body).map_err(|e| BinanceRestError::ParseError(e.to_string()))
+    }
+
+    pub async fn get_transfer_history(
+        &self,
+        transfer_type: &str,
+        start_time_ms: i64,
+    ) -> Result<Vec<BinanceUniversalTransfer>, BinanceRestError> {
+        let params = vec![
+            ("type", transfer_type.to_string()),
+            ("startTime", start_time_ms.to_string()),
+        ];
+
+        let body = self.get_signed("/sapi/v1/asset/transfer", params).await?;
+        let response: BinanceUniversalTransferHistoryResponse =
+            serde_json::from_str(&body).map_err(|e| BinanceRestError::ParseError(e.to_string()))?;
+        Ok(response.rows)
+    }
 }
 
 // =============================================================================
@@ -751,6 +868,63 @@ pub struct BinanceFuturesBalance {
     pub wallet_balance: Decimal,
     /// Balance available for new positions.
     pub available_balance: Decimal,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BinanceSpotAccountResponse {
+    balances: Vec<BinanceSpotBalance>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BinanceSpotBalance {
+    pub asset: String,
+    pub free: Decimal,
+    pub locked: Decimal,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BinanceSpotOrderResponse {
+    pub symbol: String,
+    pub order_id: u64,
+    pub client_order_id: String,
+    #[serde(default)]
+    pub transact_time: i64,
+    #[serde(default)]
+    pub update_time: i64,
+    pub status: String,
+    pub executed_qty: Decimal,
+    pub cummulative_quote_qty: Decimal,
+    #[serde(default)]
+    pub fills: Vec<BinanceFill>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BinanceUniversalTransferResponse {
+    pub tran_id: u64,
+    #[serde(default)]
+    pub client_tran_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BinanceUniversalTransferHistoryResponse {
+    pub rows: Vec<BinanceUniversalTransfer>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BinanceUniversalTransfer {
+    pub tran_id: u64,
+    #[serde(default)]
+    pub client_tran_id: Option<String>,
+    pub asset: String,
+    pub amount: Decimal,
+    #[serde(rename = "type")]
+    pub transfer_type: String,
+    pub status: String,
+    pub timestamp: i64,
 }
 
 fn parse_futures_klines(body: &str) -> Result<Vec<BinanceKline>, BinanceRestError> {

--- a/robson-connectors/src/lib.rs
+++ b/robson-connectors/src/lib.rs
@@ -12,7 +12,7 @@ pub mod binance_ws;
 // Re-exports
 pub use binance_rest::{
     BinanceFill, BinanceKline, BinanceOrderResponse, BinanceRestClient, BinanceRestError,
-    FuturesPosition,
+    BinanceSpotOrderResponse, FuturesPosition,
 };
 pub use binance_ws::{
     AggTradeEvent, BalanceUpdateEvent, BinanceWebSocketClient, BinanceWsError, BinanceWsStream,

--- a/robson-exec/src/lib.rs
+++ b/robson-exec/src/lib.rs
@@ -48,6 +48,7 @@ pub use executor::{ActionResult, Executor};
 pub use intent::{Intent, IntentAction, IntentJournal, IntentResult, IntentStatus};
 pub use ports::{
     CandleInterval, ExchangePort, ExchangePosition, FuturesBalance, FuturesSettings,
-    MarketDataPort, OhlcvPort, OrderResult, PriceUpdate, UserTradeRecord,
+    MarketDataPort, OhlcvPort, OrderResult, PriceUpdate, SpotBalance, SpotOrder, SpotOrderRequest,
+    Transfer, TransferId, UniversalTransferType, UserTradeRecord,
 };
 pub use stub::{StubExchange, StubMarketData, StubOhlcv};

--- a/robson-exec/src/ports.rs
+++ b/robson-exec/src/ports.rs
@@ -24,6 +24,74 @@ pub struct FuturesBalance {
     pub available_balance: Decimal,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SpotBalance {
+    pub asset: String,
+    pub free: Decimal,
+    pub locked: Decimal,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SpotOrderSide {
+    Buy,
+    Sell,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SpotOrderQuantity {
+    Base,
+    Quote,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SpotOrderRequest {
+    pub symbol: String,
+    pub side: SpotOrderSide,
+    pub quantity_kind: SpotOrderQuantity,
+    pub quantity: Decimal,
+    pub client_order_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SpotOrder {
+    pub symbol: String,
+    pub exchange_order_id: String,
+    pub client_order_id: String,
+    pub status: String,
+    pub executed_qty: Decimal,
+    pub cummulative_quote_qty: Decimal,
+    pub fee: Decimal,
+    pub fee_asset: String,
+    pub transact_time: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum UniversalTransferType {
+    MainUmfuture,
+}
+
+impl UniversalTransferType {
+    pub fn as_binance_str(&self) -> &'static str {
+        match self {
+            Self::MainUmfuture => "MAIN_UMFUTURE",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TransferId(pub String);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Transfer {
+    pub transfer_id: TransferId,
+    pub client_tran_key: Option<String>,
+    pub asset: String,
+    pub amount: Decimal,
+    pub transfer_type: UniversalTransferType,
+    pub status: String,
+    pub timestamp: DateTime<Utc>,
+}
+
 /// Port for exchange operations (placing/canceling orders).
 ///
 /// Implementations:
@@ -104,6 +172,35 @@ pub trait ExchangePort: Send + Sync {
     /// available balance (free for new positions). Used for capital base
     /// derivation per ADR-0024 §6.
     async fn get_futures_balance(&self) -> Result<FuturesBalance, ExecError>;
+
+    async fn get_spot_account_balances(&self) -> Result<Vec<SpotBalance>, ExecError>;
+
+    async fn get_spot_price(&self, symbol: &str) -> Result<Price, ExecError>;
+
+    async fn place_spot_market_order(
+        &self,
+        request: SpotOrderRequest,
+    ) -> Result<SpotOrder, ExecError>;
+
+    async fn get_spot_order(
+        &self,
+        symbol: &str,
+        client_order_id: &str,
+    ) -> Result<Option<SpotOrder>, ExecError>;
+
+    async fn universal_transfer(
+        &self,
+        asset: &str,
+        amount: Decimal,
+        transfer_type: UniversalTransferType,
+        client_tran_key: &str,
+    ) -> Result<TransferId, ExecError>;
+
+    async fn get_transfer_history(
+        &self,
+        transfer_type: UniversalTransferType,
+        start_time: DateTime<Utc>,
+    ) -> Result<Vec<Transfer>, ExecError>;
 
     /// Query every currently open exchange position.
     ///

--- a/robson-exec/src/stub.rs
+++ b/robson-exec/src/stub.rs
@@ -14,7 +14,9 @@ use crate::{
     error::ExecError,
     ports::{
         CandleInterval, ExchangePort, ExchangePosition, FuturesBalance, FuturesSettings,
-        MarketDataPort, OhlcvPort, OrderResult, PriceUpdate, UserTradeRecord,
+        MarketDataPort, OhlcvPort, OrderResult, PriceUpdate, SpotBalance, SpotOrder,
+        SpotOrderQuantity, SpotOrderRequest, SpotOrderSide, Transfer, TransferId,
+        UniversalTransferType, UserTradeRecord,
     },
 };
 
@@ -47,6 +49,11 @@ pub struct StubExchange {
     orders: RwLock<HashMap<String, OrderResult>>,
     /// Simulated user trades retrievable by `get_user_trades_since`.
     user_trades: RwLock<HashMap<String, Vec<UserTradeRecord>>>,
+    spot_balances: RwLock<HashMap<String, SpotBalance>>,
+    spot_orders: RwLock<HashMap<String, SpotOrder>>,
+    transfers: RwLock<Vec<Transfer>>,
+    spot_order_calls: RwLock<u64>,
+    transfer_calls: RwLock<u64>,
 }
 
 impl StubExchange {
@@ -66,6 +73,11 @@ impl StubExchange {
             futures_balance: RwLock::new(Decimal::from(10000)),
             orders: RwLock::new(HashMap::new()),
             user_trades: RwLock::new(HashMap::new()),
+            spot_balances: RwLock::new(HashMap::new()),
+            spot_orders: RwLock::new(HashMap::new()),
+            transfers: RwLock::new(Vec::new()),
+            spot_order_calls: RwLock::new(0),
+            transfer_calls: RwLock::new(0),
         }
     }
 
@@ -157,6 +169,30 @@ impl StubExchange {
     pub fn set_user_trades(&self, symbol: &str, trades: Vec<UserTradeRecord>) {
         let mut user_trades = self.user_trades.write().unwrap();
         user_trades.insert(symbol.to_string(), trades);
+    }
+
+    pub fn set_spot_balance(&self, asset: &str, free: Decimal, locked: Decimal) {
+        self.spot_balances.write().unwrap().insert(asset.to_string(), SpotBalance {
+            asset: asset.to_string(),
+            free,
+            locked,
+        });
+    }
+
+    pub fn set_spot_order(&self, order: SpotOrder) {
+        self.spot_orders.write().unwrap().insert(order.client_order_id.clone(), order);
+    }
+
+    pub fn set_transfer(&self, transfer: Transfer) {
+        self.transfers.write().unwrap().push(transfer);
+    }
+
+    pub fn spot_order_call_count(&self) -> u64 {
+        *self.spot_order_calls.read().unwrap()
+    }
+
+    pub fn transfer_call_count(&self) -> u64 {
+        *self.transfer_calls.read().unwrap()
     }
 }
 
@@ -270,6 +306,133 @@ impl ExchangePort for StubExchange {
             wallet_balance: balance,
             available_balance: balance,
         })
+    }
+
+    async fn get_spot_account_balances(&self) -> Result<Vec<SpotBalance>, ExecError> {
+        if self.should_fail() {
+            return Err(ExecError::Exchange("Simulated spot balance fetch failure".to_string()));
+        }
+        Ok(self.spot_balances.read().unwrap().values().cloned().collect())
+    }
+
+    async fn get_spot_price(&self, symbol: &str) -> Result<Price, ExecError> {
+        if self.should_fail() {
+            return Err(ExecError::Exchange("Simulated spot price fetch failure".to_string()));
+        }
+        Ok(Price::new(self.get_price_decimal(symbol)).unwrap())
+    }
+
+    async fn place_spot_market_order(
+        &self,
+        request: SpotOrderRequest,
+    ) -> Result<SpotOrder, ExecError> {
+        if self.should_fail() {
+            return Err(ExecError::Exchange("Simulated spot order failure".to_string()));
+        }
+        *self.spot_order_calls.write().unwrap() += 1;
+
+        let price = self.get_price_decimal(&request.symbol);
+        let base_qty = match request.quantity_kind {
+            SpotOrderQuantity::Base => request.quantity,
+            SpotOrderQuantity::Quote => request.quantity / price,
+        };
+        let quote_qty = match request.side {
+            SpotOrderSide::Sell => base_qty * price,
+            SpotOrderSide::Buy => request.quantity,
+        };
+        let fee = quote_qty * self.fee_rate;
+        let asset = request.symbol.trim_end_matches("USDT");
+
+        if request.side == SpotOrderSide::Sell {
+            let mut balances = self.spot_balances.write().unwrap();
+            let balance = balances.entry(asset.to_string()).or_insert_with(|| SpotBalance {
+                asset: asset.to_string(),
+                free: Decimal::ZERO,
+                locked: Decimal::ZERO,
+            });
+            balance.free = (balance.free - base_qty).max(Decimal::ZERO);
+            let usdt = balances.entry("USDT".to_string()).or_insert_with(|| SpotBalance {
+                asset: "USDT".to_string(),
+                free: Decimal::ZERO,
+                locked: Decimal::ZERO,
+            });
+            usdt.free += quote_qty - fee;
+        }
+
+        let order = SpotOrder {
+            symbol: request.symbol,
+            exchange_order_id: self.next_order_id(),
+            client_order_id: request.client_order_id.clone(),
+            status: "FILLED".to_string(),
+            executed_qty: base_qty,
+            cummulative_quote_qty: quote_qty,
+            fee,
+            fee_asset: "USDT".to_string(),
+            transact_time: Utc::now(),
+        };
+        self.spot_orders.write().unwrap().insert(request.client_order_id, order.clone());
+        Ok(order)
+    }
+
+    async fn get_spot_order(
+        &self,
+        _symbol: &str,
+        client_order_id: &str,
+    ) -> Result<Option<SpotOrder>, ExecError> {
+        if self.should_fail() {
+            return Err(ExecError::Exchange("Simulated spot order query failure".to_string()));
+        }
+        Ok(self.spot_orders.read().unwrap().get(client_order_id).cloned())
+    }
+
+    async fn universal_transfer(
+        &self,
+        asset: &str,
+        amount: Decimal,
+        transfer_type: UniversalTransferType,
+        client_tran_key: &str,
+    ) -> Result<TransferId, ExecError> {
+        if self.should_fail() {
+            return Err(ExecError::Exchange("Simulated universal transfer failure".to_string()));
+        }
+        *self.transfer_calls.write().unwrap() += 1;
+        let transfer_id = TransferId(self.next_order_id());
+        let transfer = Transfer {
+            transfer_id: transfer_id.clone(),
+            client_tran_key: Some(client_tran_key.to_string()),
+            asset: asset.to_string(),
+            amount,
+            transfer_type,
+            status: "CONFIRMED".to_string(),
+            timestamp: Utc::now(),
+        };
+        self.transfers.write().unwrap().push(transfer);
+        if asset == "USDT" {
+            let mut balances = self.spot_balances.write().unwrap();
+            if let Some(usdt) = balances.get_mut("USDT") {
+                usdt.free = (usdt.free - amount).max(Decimal::ZERO);
+            }
+            *self.futures_balance.write().unwrap() += amount;
+        }
+        Ok(transfer_id)
+    }
+
+    async fn get_transfer_history(
+        &self,
+        transfer_type: UniversalTransferType,
+        start_time: DateTime<Utc>,
+    ) -> Result<Vec<Transfer>, ExecError> {
+        if self.should_fail() {
+            return Err(ExecError::Exchange("Simulated transfer history failure".to_string()));
+        }
+        Ok(self
+            .transfers
+            .read()
+            .unwrap()
+            .iter()
+            .filter(|t| t.transfer_type == transfer_type && t.timestamp >= start_time)
+            .cloned()
+            .collect())
     }
 
     async fn get_all_open_positions(&self) -> Result<Vec<ExchangePosition>, ExecError> {
@@ -761,5 +924,44 @@ mod tests {
 
         let trades = exchange.get_user_trades_since(&symbol, Utc::now(), 100).await.unwrap();
         assert!(trades.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_stub_spot_order_and_transfer_are_queryable_for_idempotency() {
+        let exchange = StubExchange::new(dec!(100));
+        exchange.set_price("ABCUSDT", dec!(10));
+        exchange.set_spot_balance("ABC", dec!(5), Decimal::ZERO);
+        exchange.set_spot_balance("USDT", dec!(1), Decimal::ZERO);
+
+        let request = SpotOrderRequest {
+            symbol: "ABCUSDT".to_string(),
+            side: SpotOrderSide::Sell,
+            quantity_kind: SpotOrderQuantity::Base,
+            quantity: dec!(5),
+            client_order_id: "spot-1".to_string(),
+        };
+        let order = exchange.place_spot_market_order(request).await.unwrap();
+        assert_eq!(order.status, "FILLED");
+        assert_eq!(exchange.spot_order_call_count(), 1);
+
+        let found = exchange.get_spot_order("ABCUSDT", "spot-1").await.unwrap();
+        assert!(found.is_some());
+
+        let transfer_id = exchange
+            .universal_transfer("USDT", dec!(10), UniversalTransferType::MainUmfuture, "transfer-1")
+            .await
+            .unwrap();
+        assert!(!transfer_id.0.is_empty());
+        assert_eq!(exchange.transfer_call_count(), 1);
+
+        let history = exchange
+            .get_transfer_history(
+                UniversalTransferType::MainUmfuture,
+                Utc::now() - chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].client_tran_key.as_deref(), Some("transfer-1"));
     }
 }

--- a/robsond/src/api.rs
+++ b/robsond/src/api.rs
@@ -14,7 +14,7 @@ use std::{convert::Infallible, sync::Arc, time::Duration};
 use async_stream::stream;
 use axum::{
     extract::{Path, Query, Request, State},
-    http::{header, HeaderValue, Method, StatusCode},
+    http::{header, HeaderMap, HeaderValue, Method, StatusCode},
     middleware::Next,
     response::{
         sse::{KeepAlive, Sse},
@@ -41,8 +41,10 @@ use uuid::Uuid;
 
 use crate::{
     circuit_breaker::{CircuitBreaker, HaltState, MonthlyHaltSnapshot},
+    config::FundingConfig,
     error::DaemonError,
     event_bus::EventBus,
+    funding::{CapitalRefreshResponse, ExecuteFundingRequest},
     position_manager::PositionManager,
     position_monitor::PositionMonitor,
     sse::{map_daemon_event, resync_required_event},
@@ -54,6 +56,7 @@ use crate::{
 
 /// Shared state for API handlers.
 pub struct ApiState<E: ExchangePort + 'static, S: Store + 'static> {
+    pub exchange: Arc<E>,
     pub position_manager: Arc<RwLock<PositionManager<E, S>>>,
     pub event_bus: Arc<EventBus>,
     pub circuit_breaker: Arc<CircuitBreaker>,
@@ -67,6 +70,7 @@ pub struct ApiState<E: ExchangePort + 'static, S: Store + 'static> {
     /// Bearer token for authenticating mutating routes. `None` means auth is
     /// disabled (non-production environments only).
     pub api_token: Option<String>,
+    pub funding: FundingConfig,
 }
 
 // =============================================================================
@@ -476,6 +480,11 @@ where
         .route("/monthly-halt", post(monthly_halt_trigger_handler))
         // Manual reconciliation close (Slice 5B1)
         .route("/reconcile-close", post(reconcile_close_handler))
+        .route("/funding/quote", post(funding_quote_handler::<E, S>))
+        .route("/funding/execute", post(funding_execute_handler::<E, S>))
+        .route("/funding/:id", get(funding_get_handler::<E, S>))
+        .route("/funding", get(funding_list_handler::<E, S>))
+        .route("/capital/refresh", post(capital_refresh_handler::<E, S>))
         .layer(auth_layer)
         .with_state(state);
 
@@ -517,6 +526,241 @@ async fn metrics_handler() -> impl IntoResponse {
         [(header::CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8")],
         body,
     )
+}
+
+#[cfg(feature = "postgres")]
+fn funding_service<E, S>(
+    state: &ApiState<E, S>,
+) -> Result<crate::funding::FundingService<E, S>, (StatusCode, Json<ErrorResponse>)>
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    let (Some(pool), Some(tenant_id)) = (&state.pg_pool, state.tenant_id) else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: "funding_store_unavailable".to_string(),
+            }),
+        ));
+    };
+    Ok(crate::funding::FundingService::new(
+        pool.clone(),
+        tenant_id,
+        state.exchange.clone(),
+        state.position_manager.clone(),
+        state.funding.clone(),
+    ))
+}
+
+#[cfg(feature = "postgres")]
+async fn funding_quote_handler<E, S>(State(state): State<Arc<ApiState<E, S>>>) -> impl IntoResponse
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    match funding_service(&state) {
+        Ok(service) => match service.quote().await {
+            Ok(quote) => (StatusCode::OK, Json(quote)).into_response(),
+            Err(error) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse { error: error.to_string() }),
+            )
+                .into_response(),
+        },
+        Err(response) => response.into_response(),
+    }
+}
+
+#[cfg(not(feature = "postgres"))]
+async fn funding_quote_handler<E, S>(State(_state): State<Arc<ApiState<E, S>>>) -> impl IntoResponse
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(ErrorResponse {
+            error: "funding_store_unavailable".to_string(),
+        }),
+    )
+}
+
+#[cfg(feature = "postgres")]
+async fn funding_execute_handler<E, S>(
+    State(state): State<Arc<ApiState<E, S>>>,
+    headers: HeaderMap,
+    Json(request): Json<ExecuteFundingRequest>,
+) -> impl IntoResponse
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    if !state.funding.enabled {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "error": "funding_disabled" })),
+        )
+            .into_response();
+    }
+    let Some(idempotency_key) =
+        headers.get("Idempotency-Key").and_then(|value| value.to_str().ok())
+    else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "missing_idempotency_key".to_string(),
+            }),
+        )
+            .into_response();
+    };
+
+    match funding_service(&state) {
+        Ok(service) => match service.execute(request.quote_id, idempotency_key).await {
+            Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+            Err(error) if error.to_string().contains("quote_expired") => (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse { error: "quote_expired".to_string() }),
+            )
+                .into_response(),
+            Err(error) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse { error: error.to_string() }),
+            )
+                .into_response(),
+        },
+        Err(response) => response.into_response(),
+    }
+}
+
+#[cfg(not(feature = "postgres"))]
+async fn funding_execute_handler<E, S>(
+    State(state): State<Arc<ApiState<E, S>>>,
+    _headers: HeaderMap,
+    Json(_request): Json<ExecuteFundingRequest>,
+) -> impl IntoResponse
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    if !state.funding.enabled {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "error": "funding_disabled" })),
+        )
+            .into_response();
+    }
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({ "error": "funding_store_unavailable" })),
+    )
+        .into_response()
+}
+
+#[cfg(feature = "postgres")]
+async fn funding_get_handler<E, S>(
+    State(state): State<Arc<ApiState<E, S>>>,
+    Path(id): Path<Uuid>,
+) -> impl IntoResponse
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    match funding_service(&state) {
+        Ok(service) => match service.get(id).await {
+            Ok(view) => (StatusCode::OK, Json(view)).into_response(),
+            Err(error) => (StatusCode::NOT_FOUND, Json(ErrorResponse { error: error.to_string() }))
+                .into_response(),
+        },
+        Err(response) => response.into_response(),
+    }
+}
+
+#[cfg(not(feature = "postgres"))]
+async fn funding_get_handler<E, S>(
+    State(_state): State<Arc<ApiState<E, S>>>,
+    Path(_id): Path<Uuid>,
+) -> impl IntoResponse
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(ErrorResponse {
+            error: "funding_store_unavailable".to_string(),
+        }),
+    )
+}
+
+#[cfg(feature = "postgres")]
+async fn funding_list_handler<E, S>(State(state): State<Arc<ApiState<E, S>>>) -> impl IntoResponse
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    match funding_service(&state) {
+        Ok(service) => match service.list().await {
+            Ok(rows) => (StatusCode::OK, Json(rows)).into_response(),
+            Err(error) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse { error: error.to_string() }),
+            )
+                .into_response(),
+        },
+        Err(response) => response.into_response(),
+    }
+}
+
+#[cfg(not(feature = "postgres"))]
+async fn funding_list_handler<E, S>(State(_state): State<Arc<ApiState<E, S>>>) -> impl IntoResponse
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(ErrorResponse {
+            error: "funding_store_unavailable".to_string(),
+        }),
+    )
+}
+
+async fn capital_refresh_handler<E, S>(
+    State(state): State<Arc<ApiState<E, S>>>,
+) -> impl IntoResponse
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    match refresh_capital_from_exchange(&state.exchange, &state.position_manager).await {
+        Ok(capital) => (StatusCode::OK, Json(CapitalRefreshResponse { capital })).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse { error: error.to_string() }),
+        )
+            .into_response(),
+    }
+}
+
+pub(crate) async fn refresh_capital_from_exchange<E, S>(
+    exchange: &Arc<E>,
+    position_manager: &Arc<RwLock<PositionManager<E, S>>>,
+) -> Result<Decimal, DaemonError>
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    let balance = exchange.get_futures_balance().await?;
+    let capital = balance.wallet_balance;
+    if capital <= Decimal::ZERO {
+        return Err(DaemonError::Config(format!(
+            "Exchange reports zero or negative wallet balance: {capital}"
+        )));
+    }
+    let manager = position_manager.read().await;
+    manager.update_engine_capital(capital);
+    Ok(capital)
 }
 
 /// Liveness probe for Kubernetes - checks if the process is alive.
@@ -1943,7 +2187,7 @@ mod tests {
         let exchange = Arc::new(StubExchange::new(dec!(95000)));
         let journal = Arc::new(IntentJournal::new());
         let store = Arc::new(MemoryStore::new());
-        let executor = Arc::new(Executor::new(exchange, journal, store.clone()));
+        let executor = Arc::new(Executor::new(Arc::clone(&exchange), journal, store.clone()));
         let event_bus = Arc::new(crate::event_bus::EventBus::new(capacity));
         let risk_config = RiskConfig::new(dec!(10000)).unwrap();
         let engine = Engine::new(risk_config);
@@ -1961,6 +2205,7 @@ mod tests {
         let circuit_breaker = position_manager.read().await.circuit_breaker();
 
         let state = Arc::new(ApiState {
+            exchange,
             position_manager: Arc::clone(&position_manager),
             event_bus: Arc::clone(&event_bus),
             circuit_breaker,
@@ -1970,9 +2215,34 @@ mod tests {
             #[cfg(feature = "postgres")]
             tenant_id: None,
             api_token: None,
+            funding: FundingConfig::default(),
         });
 
         (create_router(state), event_bus, position_manager)
+    }
+
+    #[tokio::test]
+    async fn funding_execute_returns_503_when_disabled() {
+        let (app, _, _) = create_test_app_with_event_bus(100).await;
+        let body = serde_json::json!({ "quote_id": Uuid::now_v7() });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/funding/execute")
+                    .header(CONTENT_TYPE, "application/json")
+                    .header("Idempotency-Key", "test-key")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json, serde_json::json!({ "error": "funding_disabled" }));
     }
 
     // #[tokio::test]
@@ -2619,7 +2889,7 @@ mod tests {
             let exchange = Arc::new(StubExchange::new(dec!(95000)));
             let journal = Arc::new(IntentJournal::new());
             let store = Arc::new(MemoryStore::new());
-            let executor = Arc::new(Executor::new(exchange, journal, store.clone()));
+            let executor = Arc::new(Executor::new(Arc::clone(&exchange), journal, store.clone()));
             let event_bus = Arc::new(crate::event_bus::EventBus::new(100));
             let risk_config = RiskConfig::new(dec!(10000)).unwrap();
             let engine = Engine::new(risk_config);
@@ -2635,6 +2905,7 @@ mod tests {
             let circuit_breaker = position_manager.read().await.circuit_breaker();
 
             let state = Arc::new(ApiState {
+                exchange,
                 position_manager: Arc::clone(&position_manager),
                 event_bus: Arc::clone(&event_bus),
                 circuit_breaker,
@@ -2644,6 +2915,7 @@ mod tests {
                 #[cfg(feature = "postgres")]
                 tenant_id: None,
                 api_token: Some("secret-token-123".to_string()),
+                funding: FundingConfig::default(),
             });
 
             (create_router(state), event_bus, position_manager)

--- a/robsond/src/binance_exchange.rs
+++ b/robsond/src/binance_exchange.rs
@@ -17,7 +17,11 @@ use chrono::{DateTime, Utc};
 use robson_connectors::{BinanceRestClient, BinanceRestError};
 use robson_domain::{OrderSide, Price, Quantity, Side, Symbol};
 use robson_exec::{
-    ports::{ExchangePosition, FuturesBalance, FuturesSettings, UserTradeRecord},
+    ports::{
+        ExchangePosition, FuturesBalance, FuturesSettings, SpotBalance, SpotOrder,
+        SpotOrderQuantity, SpotOrderRequest, SpotOrderSide, Transfer, TransferId,
+        UniversalTransferType, UserTradeRecord,
+    },
     ExchangePort, ExecError, OrderResult,
 };
 use rust_decimal::Decimal;
@@ -63,6 +67,35 @@ pub(crate) fn normalize_market_quantity(
 }
 
 // =============================================================================
+fn spot_order_from_response(
+    response: robson_connectors::BinanceSpotOrderResponse,
+) -> Result<SpotOrder, ExecError> {
+    let fee: Decimal = response.fills.iter().map(|f| f.commission).sum();
+    let fee_asset = response
+        .fills
+        .first()
+        .map(|f| f.commission_asset.clone())
+        .unwrap_or_else(|| "USDT".to_string());
+    let millis = if response.transact_time > 0 {
+        response.transact_time
+    } else {
+        response.update_time
+    };
+    let transact_time = DateTime::from_timestamp_millis(millis).unwrap_or_else(Utc::now);
+
+    Ok(SpotOrder {
+        symbol: response.symbol,
+        exchange_order_id: response.order_id.to_string(),
+        client_order_id: response.client_order_id,
+        status: response.status,
+        executed_qty: response.executed_qty,
+        cummulative_quote_qty: response.cummulative_quote_qty,
+        fee,
+        fee_asset,
+        transact_time,
+    })
+}
+
 // Adapter
 // =============================================================================
 
@@ -286,6 +319,105 @@ impl ExchangePort for BinanceExchangeAdapter {
             wallet_balance: balance.wallet_balance,
             available_balance: balance.available_balance,
         })
+    }
+
+    async fn get_spot_account_balances(&self) -> Result<Vec<SpotBalance>, ExecError> {
+        let balances = self.client.get_spot_account_balances().await.map_err(Self::map_error)?;
+        Ok(balances
+            .into_iter()
+            .map(|b| SpotBalance {
+                asset: b.asset,
+                free: b.free,
+                locked: b.locked,
+            })
+            .collect())
+    }
+
+    async fn get_spot_price(&self, symbol: &str) -> Result<Price, ExecError> {
+        self.client.get_spot_price(symbol).await.map_err(Self::map_error)
+    }
+
+    async fn place_spot_market_order(
+        &self,
+        request: SpotOrderRequest,
+    ) -> Result<SpotOrder, ExecError> {
+        let side = match request.side {
+            SpotOrderSide::Buy => "BUY",
+            SpotOrderSide::Sell => "SELL",
+        };
+        let quantity_key = match request.quantity_kind {
+            SpotOrderQuantity::Base => "quantity",
+            SpotOrderQuantity::Quote => "quoteOrderQty",
+        };
+
+        let response = self
+            .client
+            .place_spot_market_order(
+                &request.symbol,
+                side,
+                (quantity_key, request.quantity),
+                &request.client_order_id,
+            )
+            .await
+            .map_err(Self::map_error)?;
+
+        spot_order_from_response(response)
+    }
+
+    async fn get_spot_order(
+        &self,
+        symbol: &str,
+        client_order_id: &str,
+    ) -> Result<Option<SpotOrder>, ExecError> {
+        match self.client.get_spot_order(symbol, client_order_id).await {
+            Ok(Some(response)) => spot_order_from_response(response).map(Some),
+            Ok(None) => Ok(None),
+            Err(error) => Err(Self::map_error(error)),
+        }
+    }
+
+    async fn universal_transfer(
+        &self,
+        asset: &str,
+        amount: Decimal,
+        transfer_type: UniversalTransferType,
+        client_tran_key: &str,
+    ) -> Result<TransferId, ExecError> {
+        let response = self
+            .client
+            .universal_transfer(asset, amount, transfer_type.as_binance_str(), client_tran_key)
+            .await
+            .map_err(Self::map_error)?;
+        Ok(TransferId(response.tran_id.to_string()))
+    }
+
+    async fn get_transfer_history(
+        &self,
+        transfer_type: UniversalTransferType,
+        start_time: DateTime<Utc>,
+    ) -> Result<Vec<Transfer>, ExecError> {
+        let transfers = self
+            .client
+            .get_transfer_history(transfer_type.as_binance_str(), start_time.timestamp_millis())
+            .await
+            .map_err(Self::map_error)?;
+
+        transfers
+            .into_iter()
+            .map(|t| {
+                let timestamp =
+                    DateTime::from_timestamp_millis(t.timestamp).unwrap_or_else(Utc::now);
+                Ok(Transfer {
+                    transfer_id: TransferId(t.tran_id.to_string()),
+                    client_tran_key: t.client_tran_id,
+                    asset: t.asset,
+                    amount: t.amount,
+                    transfer_type,
+                    status: t.status,
+                    timestamp,
+                })
+            })
+            .collect()
     }
 
     async fn get_all_open_positions(&self) -> Result<Vec<ExchangePosition>, ExecError> {

--- a/robsond/src/chaos_tests.rs
+++ b/robsond/src/chaos_tests.rs
@@ -9,10 +9,14 @@ use std::{
 use async_trait::async_trait;
 use robson_domain::{Event, OrderSide, PositionId, Price, Quantity, Side, Symbol};
 use robson_engine::{EngineAction, RiskCheck, RiskVerdict};
-use robson_exec::{ExchangePort, ExecError, Executor, FuturesBalance, FuturesSettings};
+use robson_exec::{
+    ExchangePort, ExecError, Executor, FuturesBalance, FuturesSettings, SpotBalance, SpotOrder,
+    SpotOrderRequest, Transfer, TransferId, UniversalTransferType,
+};
 use robson_store::{
     EventRepository, MemoryStore, OrderRepository, PositionRepository, Store, StoreError,
 };
+use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use uuid::Uuid;
 
@@ -79,6 +83,47 @@ impl ExchangePort for TimeoutExchange {
             wallet_balance: dec!(10000),
             available_balance: dec!(10000),
         })
+    }
+
+    async fn get_spot_account_balances(&self) -> Result<Vec<SpotBalance>, ExecError> {
+        Ok(vec![])
+    }
+
+    async fn get_spot_price(&self, _symbol: &str) -> Result<Price, ExecError> {
+        Price::new(dec!(100)).map_err(ExecError::Domain)
+    }
+
+    async fn place_spot_market_order(
+        &self,
+        _request: SpotOrderRequest,
+    ) -> Result<SpotOrder, ExecError> {
+        Err(ExecError::Timeout("simulated exchange timeout".to_string()))
+    }
+
+    async fn get_spot_order(
+        &self,
+        _symbol: &str,
+        _client_order_id: &str,
+    ) -> Result<Option<SpotOrder>, ExecError> {
+        Ok(None)
+    }
+
+    async fn universal_transfer(
+        &self,
+        _asset: &str,
+        _amount: Decimal,
+        _transfer_type: UniversalTransferType,
+        _client_tran_key: &str,
+    ) -> Result<TransferId, ExecError> {
+        Err(ExecError::Timeout("simulated exchange timeout".to_string()))
+    }
+
+    async fn get_transfer_history(
+        &self,
+        _transfer_type: UniversalTransferType,
+        _start_time: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<Transfer>, ExecError> {
+        Ok(vec![])
     }
 
     async fn get_all_open_positions(

--- a/robsond/src/config.rs
+++ b/robsond/src/config.rs
@@ -37,6 +37,9 @@ pub struct Config {
     /// Reconciliation worker configuration.
     pub reconciliation: ReconciliationConfig,
 
+    /// Funding treasury capability configuration.
+    pub funding: FundingConfig,
+
     /// Environment (test, development, production)
     pub environment: Environment,
 }
@@ -54,6 +57,25 @@ pub struct ApiConfig {
     /// Bearer token for authenticating mutating API routes.
     /// Required when ROBSON_ENV=production; optional otherwise.
     pub api_token: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FundingConfig {
+    pub enabled: bool,
+    pub dust_usdt: Decimal,
+    pub quote_ttl_secs: u64,
+    pub slippage_bps: u32,
+}
+
+impl Default for FundingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            dust_usdt: Decimal::ONE,
+            quote_ttl_secs: 60,
+            slippage_bps: 20,
+        }
+    }
 }
 
 /// Projection configuration.
@@ -239,6 +261,7 @@ impl Config {
         let market_data = Self::load_market_data_config()?;
         let position_monitor = Self::load_position_monitor_config()?;
         let reconciliation = Self::load_reconciliation_config()?;
+        let funding = Self::load_funding_config()?;
 
         // Fail-fast: API token is mandatory in production
         if environment == Environment::Production && api.api_token.is_none() {
@@ -255,6 +278,7 @@ impl Config {
             market_data,
             position_monitor,
             reconciliation,
+            funding,
             environment,
         })
     }
@@ -296,6 +320,7 @@ impl Config {
                 missing_grace_secs: 60,
                 on_startup_stale_active: StartupStaleActivePolicy::Abort,
             },
+            funding: FundingConfig::default(),
             environment: Environment::Test,
         }
     }
@@ -396,6 +421,29 @@ impl Config {
                 .map_err(|_| DaemonError::Config(format!("Invalid {} value: {}", key, val))),
             Err(_) => Ok(default),
         }
+    }
+
+    fn load_funding_config() -> DaemonResult<FundingConfig> {
+        let enabled = env::var("FUNDING_ENABLED")
+            .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+        let dust_usdt = Self::load_decimal_env("DUST_USDT", Decimal::ONE)?;
+        let quote_ttl_secs = env::var("FUNDING_QUOTE_TTL_SECS")
+            .ok()
+            .map(|v| {
+                v.parse::<u64>().map_err(|_| {
+                    DaemonError::Config(format!("Invalid FUNDING_QUOTE_TTL_SECS: {v}"))
+                })
+            })
+            .transpose()?
+            .unwrap_or(60);
+
+        Ok(FundingConfig {
+            enabled,
+            dust_usdt,
+            quote_ttl_secs,
+            slippage_bps: 20,
+        })
     }
 
     fn load_projection_config() -> DaemonResult<ProjectionConfig> {
@@ -564,6 +612,7 @@ impl Default for Config {
             market_data: MarketDataConfig::default(),
             position_monitor: PositionMonitorConfig::default(),
             reconciliation: ReconciliationConfig::default(),
+            funding: FundingConfig::default(),
             environment: Environment::Development,
         }
     }

--- a/robsond/src/daemon.rs
+++ b/robsond/src/daemon.rs
@@ -48,6 +48,8 @@ use tokio::{net::TcpListener, sync::RwLock};
 use tracing::{error, info, warn};
 
 #[cfg(feature = "postgres")]
+use crate::funding::{worker::FundingWorker, FundingService};
+#[cfg(feature = "postgres")]
 use crate::projection_worker::ProjectionWorker;
 #[cfg(feature = "postgres")]
 use crate::query::ExecutionQuery;
@@ -448,18 +450,10 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
     /// Best-effort: logs a warning on failure and continues with the
     /// placeholder so the daemon can still start during exchange outages.
     async fn initialize_capital(&self) {
-        match self.exchange.get_futures_balance().await {
-            Ok(balance) => {
-                let capital = balance.wallet_balance;
-                if capital <= rust_decimal::Decimal::ZERO {
-                    warn!(
-                        %capital,
-                        "Exchange reports zero or negative wallet balance — keeping placeholder capital"
-                    );
-                    return;
-                }
-                let manager = self.position_manager.read().await;
-                manager.update_engine_capital(capital);
+        match crate::api::refresh_capital_from_exchange(&self.exchange, &self.position_manager)
+            .await
+        {
+            Ok(capital) => {
                 info!(%capital, "Engine capital initialized from exchange balance");
             },
             Err(e) => {
@@ -623,6 +617,31 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
         #[cfg(not(feature = "postgres"))]
         let projection_handle: Option<tokio::task::JoinHandle<()>> = None;
 
+        #[cfg(feature = "postgres")]
+        let funding_handle = if let (Some(pool), Some(tenant_id)) =
+            (&self.pg_pool, self.config.projection.tenant_id)
+        {
+            let service = FundingService::new(
+                pool.clone(),
+                tenant_id,
+                Arc::clone(&self.exchange),
+                Arc::clone(&self.position_manager),
+                self.config.funding.clone(),
+            );
+            let worker = FundingWorker::new(service);
+            let worker_shutdown = shutdown.clone();
+            Some(tokio::spawn(async move {
+                if let Err(e) = worker.run(worker_shutdown).await {
+                    error!(error = %e, "Funding worker failed");
+                }
+            }))
+        } else {
+            None
+        };
+
+        #[cfg(not(feature = "postgres"))]
+        let funding_handle: Option<tokio::task::JoinHandle<()>> = None;
+
         // 9. Subscribe to event bus
         let mut event_receiver = self.event_bus.subscribe();
 
@@ -687,6 +706,11 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
         if let Some(handle) = projection_handle {
             info!("Waiting for projection worker to finish...");
             let _ = tokio::time::timeout(tokio::time::Duration::from_secs(30), handle).await;
+        }
+
+        if let Some(handle) = funding_handle {
+            info!("Waiting for funding worker to finish...");
+            let _ = tokio::time::timeout(tokio::time::Duration::from_secs(10), handle).await;
         }
 
         if let Some(monitor) = position_monitor {
@@ -1382,6 +1406,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
             pm.circuit_breaker()
         };
         let state = Arc::new(ApiState {
+            exchange: self.exchange.clone(),
             position_manager: self.position_manager.clone(),
             event_bus: self.event_bus.clone(),
             circuit_breaker,
@@ -1391,6 +1416,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
             #[cfg(feature = "postgres")]
             tenant_id: self.config.projection.tenant_id,
             api_token: self.config.api.api_token.clone(),
+            funding: self.config.funding.clone(),
         });
 
         let router = create_router(state);

--- a/robsond/src/funding/mod.rs
+++ b/robsond/src/funding/mod.rs
@@ -1,0 +1,8 @@
+pub mod saga;
+pub mod types;
+#[cfg(feature = "postgres")]
+pub mod worker;
+
+#[cfg(feature = "postgres")]
+pub use saga::FundingService;
+pub use types::*;

--- a/robsond/src/funding/saga.rs
+++ b/robsond/src/funding/saga.rs
@@ -1,0 +1,482 @@
+#[cfg(feature = "postgres")]
+use std::sync::Arc;
+
+#[cfg(feature = "postgres")]
+use chrono::{Duration, Utc};
+#[cfg(feature = "postgres")]
+use robson_eventlog::{append_event, ActorType, Event, QueryOptions};
+#[cfg(feature = "postgres")]
+use robson_exec::{
+    ports::{SpotOrderQuantity, SpotOrderRequest, SpotOrderSide, UniversalTransferType},
+    ExchangePort,
+};
+#[cfg(feature = "postgres")]
+use robson_store::Store;
+#[cfg(feature = "postgres")]
+use rust_decimal::Decimal;
+#[cfg(feature = "postgres")]
+use rust_decimal_macros::dec;
+#[cfg(feature = "postgres")]
+use serde_json::json;
+#[cfg(feature = "postgres")]
+use sqlx::{PgPool, Row};
+#[cfg(feature = "postgres")]
+use tokio::sync::RwLock;
+#[cfg(feature = "postgres")]
+use uuid::Uuid;
+
+#[cfg(feature = "postgres")]
+use super::types::{
+    ExecuteFundingResponse, FundingEventView, FundingQuote, FundingQuoteItem, FundingSagaSummary,
+    FundingSagaView, FundingState,
+};
+#[cfg(feature = "postgres")]
+use crate::{
+    config::FundingConfig,
+    error::{DaemonError, DaemonResult},
+    position_manager::PositionManager,
+};
+
+#[cfg(feature = "postgres")]
+const SPOT_FEE_RATE: Decimal = dec!(0.001);
+
+#[cfg(feature = "postgres")]
+pub struct FundingService<E: ExchangePort + 'static, S: Store + 'static> {
+    pool: Arc<PgPool>,
+    tenant_id: Uuid,
+    exchange: Arc<E>,
+    position_manager: Arc<RwLock<PositionManager<E, S>>>,
+    config: FundingConfig,
+}
+
+#[cfg(feature = "postgres")]
+impl<E: ExchangePort + 'static, S: Store + 'static> FundingService<E, S> {
+    pub fn new(
+        pool: Arc<PgPool>,
+        tenant_id: Uuid,
+        exchange: Arc<E>,
+        position_manager: Arc<RwLock<PositionManager<E, S>>>,
+        config: FundingConfig,
+    ) -> Self {
+        Self {
+            pool,
+            tenant_id,
+            exchange,
+            position_manager,
+            config,
+        }
+    }
+
+    pub async fn quote(&self) -> DaemonResult<FundingQuote> {
+        let quote_id = Uuid::new_v4();
+        let balances = self.exchange.get_spot_account_balances().await?;
+        let expires_at = Utc::now() + Duration::seconds(self.config.quote_ttl_secs as i64);
+        let mut items = Vec::new();
+        let mut estimated_usdt = Decimal::ZERO;
+        let mut fees = Decimal::ZERO;
+        let buffer = Decimal::from(self.config.slippage_bps) / Decimal::from(10_000u32);
+
+        for balance in balances {
+            if balance.asset == "USDT" || balance.free <= Decimal::ZERO {
+                continue;
+            }
+            let symbol = format!("{}USDT", balance.asset);
+            let price = self.exchange.get_spot_price(&symbol).await?;
+            let gross = balance.free * price.as_decimal();
+            if gross < self.config.dust_usdt {
+                continue;
+            }
+            let fee = gross * SPOT_FEE_RATE;
+            let est_usdt = gross * (Decimal::ONE - buffer) - fee;
+            if est_usdt < self.config.dust_usdt {
+                continue;
+            }
+            fees += fee;
+            estimated_usdt += est_usdt;
+            items.push(FundingQuoteItem {
+                asset: balance.asset,
+                qty: balance.free,
+                est_usdt,
+                symbol,
+            });
+        }
+
+        let quote = FundingQuote {
+            quote_id,
+            items,
+            estimated_usdt,
+            fees,
+            slippage_bps: self.config.slippage_bps,
+            expires_at,
+        };
+        self.append_and_project(
+            quote_id,
+            FundingState::Quoted,
+            "FundingQuoted",
+            json!({ "quote": quote }),
+        )
+        .await?;
+        Ok(quote)
+    }
+
+    pub async fn execute(
+        &self,
+        quote_id: Uuid,
+        idempotency_key: &str,
+    ) -> DaemonResult<ExecuteFundingResponse> {
+        let mut view = self.load_saga(quote_id).await?;
+        if view.state == FundingState::Refreshed.as_str() {
+            return Ok(ExecuteFundingResponse { saga_id: quote_id, state: view.state });
+        }
+        if view.state == FundingState::Failed.as_str() {
+            return Ok(ExecuteFundingResponse { saga_id: quote_id, state: view.state });
+        }
+
+        let quote = self.load_quote(quote_id).await?;
+        if Utc::now() > quote.expires_at && view.state == FundingState::Quoted.as_str() {
+            self.fail(quote_id, "quote_expired").await?;
+            return Err(DaemonError::Config("quote_expired".to_string()));
+        }
+
+        if view.state == FundingState::Quoted.as_str() {
+            self.append_and_project(
+                quote_id,
+                FundingState::Converting,
+                "FundingStarted",
+                json!({ "idempotency_key": idempotency_key }),
+            )
+            .await?;
+            view.state = FundingState::Converting.as_str().to_string();
+        }
+
+        if view.state == FundingState::Converting.as_str() {
+            for item in &quote.items {
+                let client_order_id = spot_client_order_id(quote_id, &item.asset);
+                let order =
+                    match self.exchange.get_spot_order(&item.symbol, &client_order_id).await? {
+                        Some(order) if order.status == "FILLED" => order,
+                        _ => {
+                            self.exchange
+                                .place_spot_market_order(SpotOrderRequest {
+                                    symbol: item.symbol.clone(),
+                                    side: SpotOrderSide::Sell,
+                                    quantity_kind: SpotOrderQuantity::Base,
+                                    quantity: item.qty,
+                                    client_order_id: client_order_id.clone(),
+                                })
+                                .await?
+                        },
+                    };
+                if order.status != "FILLED" {
+                    self.fail(quote_id, &format!("spot_order_not_filled:{}", item.asset)).await?;
+                    return Err(DaemonError::Config(format!(
+                        "spot_order_not_filled:{}",
+                        item.asset
+                    )));
+                }
+                self.append_and_project(
+                    quote_id,
+                    FundingState::Converting,
+                    "ConversionExecuted",
+                    json!({
+                        "asset": item.asset,
+                        "qty": order.executed_qty,
+                        "usdt_out": order.cummulative_quote_qty,
+                        "client_order_id": client_order_id,
+                    }),
+                )
+                .await?;
+            }
+
+            self.append_and_project(
+                quote_id,
+                FundingState::Converted,
+                "FundingConverted",
+                json!({ "spot_usdt": self.current_spot_usdt().await? }),
+            )
+            .await?;
+            view.state = FundingState::Converted.as_str().to_string();
+        }
+
+        if view.state == FundingState::Converted.as_str()
+            || view.state == FundingState::Transferring.as_str()
+        {
+            let amount = self.current_spot_usdt().await?;
+            if amount > Decimal::ZERO {
+                let client_tran_key = transfer_client_key(quote_id);
+                self.append_and_project(
+                    quote_id,
+                    FundingState::Transferring,
+                    "TransferPrepared",
+                    json!({ "client_tran_key": client_tran_key, "amount": amount }),
+                )
+                .await?;
+                let existing = self
+                    .exchange
+                    .get_transfer_history(
+                        UniversalTransferType::MainUmfuture,
+                        Utc::now() - Duration::hours(24),
+                    )
+                    .await?
+                    .into_iter()
+                    .find(|t| t.client_tran_key.as_deref() == Some(&client_tran_key));
+                let transfer_id = match existing {
+                    Some(t) => t.transfer_id,
+                    None => {
+                        self.exchange
+                            .universal_transfer(
+                                "USDT",
+                                amount,
+                                UniversalTransferType::MainUmfuture,
+                                &client_tran_key,
+                            )
+                            .await?
+                    },
+                };
+                self.append_and_project(
+                    quote_id,
+                    FundingState::Transferring,
+                    "TransferExecuted",
+                    json!({ "transfer_id": transfer_id.0, "amount": amount }),
+                )
+                .await?;
+            }
+            self.append_and_project(quote_id, FundingState::Settled, "FundingSettled", json!({}))
+                .await?;
+            view.state = FundingState::Settled.as_str().to_string();
+        }
+
+        if view.state == FundingState::Settled.as_str() {
+            let capital = self.refresh_capital().await?;
+            self.append_and_project(
+                quote_id,
+                FundingState::Refreshed,
+                "CapitalRefreshed",
+                json!({ "capital": capital }),
+            )
+            .await?;
+            view.state = FundingState::Refreshed.as_str().to_string();
+        }
+
+        Ok(ExecuteFundingResponse { saga_id: quote_id, state: view.state })
+    }
+
+    pub async fn refresh_capital(&self) -> DaemonResult<Decimal> {
+        let balance = self.exchange.get_futures_balance().await?;
+        let capital = balance.wallet_balance;
+        if capital <= Decimal::ZERO {
+            return Err(DaemonError::Config(format!(
+                "Exchange reports zero or negative wallet balance: {capital}"
+            )));
+        }
+        let manager = self.position_manager.read().await;
+        manager.update_engine_capital(capital);
+        Ok(capital)
+    }
+
+    pub async fn get(&self, saga_id: Uuid) -> DaemonResult<FundingSagaView> {
+        self.load_saga(saga_id).await
+    }
+
+    pub async fn list(&self) -> DaemonResult<Vec<FundingSagaSummary>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT saga_id, state, estimated_usdt, created_at
+            FROM funding_sagas
+            WHERE tenant_id = $1
+            ORDER BY created_at DESC
+            LIMIT 100
+            "#,
+        )
+        .bind(self.tenant_id)
+        .fetch_all(&*self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| FundingSagaSummary {
+                saga_id: row.get("saga_id"),
+                state: row.get("state"),
+                estimated_usdt: row.get("estimated_usdt"),
+                created_at: row.get("created_at"),
+            })
+            .collect())
+    }
+
+    pub async fn resume_non_terminal(&self) -> DaemonResult<usize> {
+        let rows = sqlx::query(
+            r#"
+            SELECT saga_id
+            FROM funding_sagas
+            WHERE tenant_id = $1
+              AND state NOT IN ('REFRESHED', 'FAILED')
+            ORDER BY updated_at ASC
+            LIMIT 20
+            "#,
+        )
+        .bind(self.tenant_id)
+        .fetch_all(&*self.pool)
+        .await?;
+
+        let mut resumed = 0;
+        for row in rows {
+            let saga_id: Uuid = row.get("saga_id");
+            let _ = self.execute(saga_id, "funding-worker-resume").await;
+            resumed += 1;
+        }
+        Ok(resumed)
+    }
+
+    async fn current_spot_usdt(&self) -> DaemonResult<Decimal> {
+        Ok(self
+            .exchange
+            .get_spot_account_balances()
+            .await?
+            .into_iter()
+            .find(|b| b.asset == "USDT")
+            .map(|b| b.free)
+            .unwrap_or(Decimal::ZERO))
+    }
+
+    async fn fail(&self, saga_id: Uuid, reason: &str) -> DaemonResult<()> {
+        self.append_and_project(
+            saga_id,
+            FundingState::Failed,
+            "FundingFailed",
+            json!({ "reason": reason }),
+        )
+        .await
+    }
+
+    async fn load_quote(&self, saga_id: Uuid) -> DaemonResult<FundingQuote> {
+        let snapshot: serde_json::Value = sqlx::query_scalar(
+            "SELECT quote FROM funding_sagas WHERE tenant_id = $1 AND saga_id = $2",
+        )
+        .bind(self.tenant_id)
+        .bind(saga_id)
+        .fetch_optional(&*self.pool)
+        .await?
+        .ok_or_else(|| DaemonError::Config("funding_saga_not_found".to_string()))?;
+
+        serde_json::from_value(snapshot)
+            .map_err(|e| DaemonError::Config(format!("invalid funding quote snapshot: {e}")))
+    }
+
+    async fn load_saga(&self, saga_id: Uuid) -> DaemonResult<FundingSagaView> {
+        let row = sqlx::query(
+            r#"
+            SELECT state, quote, updated_at
+            FROM funding_sagas
+            WHERE tenant_id = $1 AND saga_id = $2
+            "#,
+        )
+        .bind(self.tenant_id)
+        .bind(saga_id)
+        .fetch_optional(&*self.pool)
+        .await?
+        .ok_or_else(|| DaemonError::Config("funding_saga_not_found".to_string()))?;
+
+        let quote: FundingQuote = serde_json::from_value(row.get("quote"))
+            .map_err(|e| DaemonError::Config(format!("invalid funding quote snapshot: {e}")))?;
+        let events = robson_eventlog::query_events(
+            &self.pool,
+            QueryOptions::new(self.tenant_id).stream(stream_key(saga_id)),
+        )
+        .await
+        .map_err(|e| DaemonError::EventLog(e.to_string()))?
+        .into_iter()
+        .map(|event| FundingEventView {
+            event_type: event.event_type,
+            at: event.occurred_at,
+            payload: event.payload,
+        })
+        .collect();
+
+        Ok(FundingSagaView {
+            saga_id,
+            state: row.get("state"),
+            items: quote.items,
+            events,
+            updated_at: row.get("updated_at"),
+        })
+    }
+
+    async fn append_and_project(
+        &self,
+        saga_id: Uuid,
+        state: FundingState,
+        event_type: &str,
+        payload: serde_json::Value,
+    ) -> DaemonResult<()> {
+        let mut event =
+            Event::new(self.tenant_id, stream_key(saga_id), event_type, payload.clone())
+                .with_actor(ActorType::Daemon, Some("funding-saga".to_string()));
+        event.workflow_id = Some(saga_id);
+        event.command_id = Some(Uuid::new_v4());
+        append_event(&self.pool, &stream_key(saga_id), None, event)
+            .await
+            .map_err(|e| DaemonError::EventLog(e.to_string()))?;
+
+        let quote = if let Some(quote) = payload.get("quote").cloned() {
+            quote
+        } else {
+            sqlx::query_scalar::<_, serde_json::Value>(
+                "SELECT quote FROM funding_sagas WHERE tenant_id = $1 AND saga_id = $2",
+            )
+            .bind(self.tenant_id)
+            .bind(saga_id)
+            .fetch_optional(&*self.pool)
+            .await?
+            .unwrap_or_else(|| {
+                json!({
+                    "quote_id": saga_id,
+                    "items": [],
+                    "estimated_usdt": "0",
+                    "fees": "0",
+                    "slippage_bps": self.config.slippage_bps,
+                    "expires_at": Utc::now()
+                })
+            })
+        };
+        let estimated_usdt = serde_json::from_value::<FundingQuote>(quote.clone())
+            .map(|q| q.estimated_usdt)
+            .unwrap_or(Decimal::ZERO);
+
+        sqlx::query(
+            r#"
+            INSERT INTO funding_sagas (
+                tenant_id, saga_id, state, quote, estimated_usdt, created_at, updated_at
+            ) VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+            ON CONFLICT (tenant_id, saga_id) DO UPDATE SET
+                state = EXCLUDED.state,
+                quote = COALESCE(funding_sagas.quote, EXCLUDED.quote),
+                estimated_usdt = COALESCE(funding_sagas.estimated_usdt, EXCLUDED.estimated_usdt),
+                updated_at = NOW()
+            "#,
+        )
+        .bind(self.tenant_id)
+        .bind(saga_id)
+        .bind(state.as_str())
+        .bind(quote)
+        .bind(estimated_usdt)
+        .execute(&*self.pool)
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn stream_key(saga_id: Uuid) -> String {
+    format!("funding:{saga_id}")
+}
+
+#[cfg(feature = "postgres")]
+fn spot_client_order_id(saga_id: Uuid, asset: &str) -> String {
+    format!("rbx-fund-{}-{}", saga_id.simple(), asset)
+}
+
+#[cfg(feature = "postgres")]
+fn transfer_client_key(saga_id: Uuid) -> String {
+    format!("rbx-fund-transfer-{}", saga_id.simple())
+}

--- a/robsond/src/funding/types.rs
+++ b/robsond/src/funding/types.rs
@@ -1,0 +1,107 @@
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum FundingState {
+    Quoted,
+    Converting,
+    Converted,
+    Transferring,
+    Settled,
+    Refreshed,
+    Failed,
+}
+
+impl FundingState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Quoted => "QUOTED",
+            Self::Converting => "CONVERTING",
+            Self::Converted => "CONVERTED",
+            Self::Transferring => "TRANSFERRING",
+            Self::Settled => "SETTLED",
+            Self::Refreshed => "REFRESHED",
+            Self::Failed => "FAILED",
+        }
+    }
+}
+
+impl std::str::FromStr for FundingState {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "QUOTED" => Ok(Self::Quoted),
+            "CONVERTING" => Ok(Self::Converting),
+            "CONVERTED" => Ok(Self::Converted),
+            "TRANSFERRING" => Ok(Self::Transferring),
+            "SETTLED" => Ok(Self::Settled),
+            "REFRESHED" => Ok(Self::Refreshed),
+            "FAILED" => Ok(Self::Failed),
+            other => Err(format!("unknown funding state {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FundingQuoteItem {
+    pub asset: String,
+    pub qty: Decimal,
+    pub est_usdt: Decimal,
+    pub symbol: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FundingQuote {
+    pub quote_id: Uuid,
+    pub items: Vec<FundingQuoteItem>,
+    pub estimated_usdt: Decimal,
+    pub fees: Decimal,
+    pub slippage_bps: u32,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FundingEventView {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub at: DateTime<Utc>,
+    #[serde(flatten)]
+    pub payload: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FundingSagaView {
+    pub saga_id: Uuid,
+    pub state: String,
+    pub items: Vec<FundingQuoteItem>,
+    pub events: Vec<FundingEventView>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FundingSagaSummary {
+    pub saga_id: Uuid,
+    pub state: String,
+    pub estimated_usdt: Decimal,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExecuteFundingRequest {
+    pub quote_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecuteFundingResponse {
+    pub saga_id: Uuid,
+    pub state: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapitalRefreshResponse {
+    pub capital: Decimal,
+}

--- a/robsond/src/funding/worker.rs
+++ b/robsond/src/funding/worker.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+
+use robson_exec::ExchangePort;
+use robson_store::Store;
+use tokio::time::interval;
+use tracing::{debug, error, info};
+
+use super::saga::FundingService;
+use crate::error::DaemonResult;
+
+pub struct FundingWorker<E: ExchangePort + 'static, S: Store + 'static> {
+    service: FundingService<E, S>,
+    poll_interval: Duration,
+}
+
+impl<E: ExchangePort + 'static, S: Store + 'static> FundingWorker<E, S> {
+    pub fn new(service: FundingService<E, S>) -> Self {
+        Self {
+            service,
+            poll_interval: Duration::from_secs(5),
+        }
+    }
+
+    pub async fn run(self, shutdown: tokio_util::sync::CancellationToken) -> DaemonResult<()> {
+        info!("Funding worker started");
+        let mut ticker = interval(self.poll_interval);
+        ticker.tick().await;
+
+        loop {
+            tokio::select! {
+                _ = shutdown.cancelled() => {
+                    info!("Funding worker shutdown requested");
+                    break;
+                }
+                _ = ticker.tick() => {
+                    match self.service.resume_non_terminal().await {
+                        Ok(count) if count > 0 => debug!(count, "Funding worker resumed sagas"),
+                        Ok(_) => {},
+                        Err(error) => error!(%error, "Funding worker poll failed"),
+                    }
+                }
+            }
+        }
+
+        info!("Funding worker stopped");
+        Ok(())
+    }
+}

--- a/robsond/src/lib.rs
+++ b/robsond/src/lib.rs
@@ -48,6 +48,7 @@ pub mod daemon;
 pub mod detector;
 pub mod error;
 pub mod event_bus;
+pub mod funding;
 pub mod market_data;
 pub mod metrics;
 pub mod position_manager;
@@ -69,8 +70,8 @@ pub use binance_exchange::BinanceExchangeAdapter;
 pub use binance_ohlcv::BinanceOhlcvAdapter;
 pub use circuit_breaker::{CircuitBreaker, HaltState, MonthlyHaltSnapshot};
 pub use config::{
-    ApiConfig, Config, EngineConfig, Environment, MarketDataConfig, PositionMonitorConfig,
-    ProjectionConfig, ReconciliationConfig, StartupStaleActivePolicy,
+    ApiConfig, Config, EngineConfig, Environment, FundingConfig, MarketDataConfig,
+    PositionMonitorConfig, ProjectionConfig, ReconciliationConfig, StartupStaleActivePolicy,
 };
 pub use daemon::Daemon;
 pub use detector::{DetectorConfig, DetectorTask};


### PR DESCRIPTION
## What

Adds a **Funding** treasury capability: convert non-USDT Spot balances to USDT and Universal-Transfer the result into the USDT-M futures wallet, modelled as an **idempotent, event-sourced saga** (exchange = source of truth, forward-only). Also adds a live **capital refresh** that removes the "capital is only read at daemon startup" limitation.

Context: the daemon today reads capital once at startup (`initialize_capital`) and only the USDT asset of the futures wallet. There is no Spot/Convert/Transfer path, so funding the bot required manual exchange actions + a pod restart.

## Saga

`QUOTED → CONVERTING → CONVERTED → TRANSFERRING → SETTLED → REFRESHED` (`FAILED` terminal).
Re-entrant: each `execute()` resumes from the persisted state. Idempotency:
- spot conversions use a deterministic `clientOrderId` and check `get_spot_order` for `FILLED` before placing;
- the transfer uses a deterministic client key and checks `get_transfer_history` before re-sending.
Events on stream `funding:<saga_id>` + `funding_sagas` projection (new migration). `FundingWorker` resumes non-terminal sagas on startup.

## Endpoints (Bearer)
- `POST /funding/quote` → quote (no money moved)
- `POST /funding/execute` (`Idempotency-Key`) → `{saga_id, state}`
- `GET /funding`, `GET /funding/:id`
- `POST /capital/refresh` → `{capital}`

Gated by **`FUNDING_ENABLED` (default false)**; disabled → `execute` returns `503 funding_disabled`. New config: `DUST_USDT`, `FUNDING_QUOTE_TTL_SECS`, `slippage_bps`.

## Money safety
All amounts use `rust_decimal::Decimal`. Forward-only (no auto-reversal). Deploy posture is **prod with the flag OFF**; first real run is gated behind the operator enabling the API key Spot+Transfer scope and flipping the flag with type-to-confirm in the UI.

## Verification
- `cargo build` + `cargo clippy --all-targets` clean; **318 tests pass**.
- Diff was de-churned: Codex's stable-`cargo fmt` reformatted ~10 unrelated files; re-running nightly `rustfmt` (the repo's `rustfmt.toml` uses unstable options) collapsed all pure-formatting churn back to `main`, leaving only funding logic.
- Fixed a missing re-export (`SpotBalance/SpotOrder/SpotOrderRequest/Transfer/TransferId/UniversalTransferType`) in `robson-exec` that broke the test/clippy build.

## ⚠️ Known gap (blocks flipping the flag, not this flag-OFF merge)
Saga idempotency/retry/resume behavior is **not yet unit-tested** (only the flag-disabled path is). The pg-gated `FundingService` needs a test harness wiring `StubExchange` + a test pool. **Must be covered before `FUNDING_ENABLED` is turned on.** Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
