### PR TITLE
fix(frontend): render funding Decimal strings + persistent Treasury link

### DIFF
--- a/frontend/src/lib/api/robson.ts
+++ b/frontend/src/lib/api/robson.ts
@@ -154,17 +154,20 @@ export type FundingState =
   | "REFRESHED"
   | "FAILED";
 
+// Monetary fields are rust_decimal::Decimal, serialized by the backend as JSON
+// strings (e.g. "198.79328929...") to preserve precision. Keep them as strings
+// and format for display only — never compute money in the browser.
 export type FundingItem = {
   asset: string;
-  qty: number;
-  est_usdt: number;
+  qty: string;
+  est_usdt: string;
 };
 
 export type FundingQuote = {
   quote_id: string;
   items: FundingItem[];
-  estimated_usdt: number;
-  fees: number;
+  estimated_usdt: string;
+  fees: string;
   slippage_bps: number;
   expires_at: string;
 };
@@ -186,7 +189,7 @@ export type FundingSaga = {
 export type FundingSagaSummary = {
   saga_id: string;
   state: FundingState;
-  estimated_usdt: number;
+  estimated_usdt: string;
   created_at: string;
 };
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -41,7 +41,8 @@
     "connectionError": "CONNECTION ERROR",
     "retry": "Retry",
     "insufficientCapitalBanner": "Insufficient capital to operate",
-    "addFunds": "Add funds"
+    "addFunds": "Add funds",
+    "treasuryNav": "Treasury"
   },
   "operation": {
     "position": "Position",

--- a/frontend/src/lib/i18n/pt-BR.json
+++ b/frontend/src/lib/i18n/pt-BR.json
@@ -41,7 +41,8 @@
     "connectionError": "ERRO DE CONEXÃO",
     "retry": "Tentar novamente",
     "insufficientCapitalBanner": "Capital insuficiente para operar",
-    "addFunds": "Adicionar fundos"
+    "addFunds": "Adicionar fundos",
+    "treasuryNav": "Tesouraria"
   },
   "operation": {
     "position": "Posição",

--- a/frontend/src/routes/(authed)/dashboard/+page.svelte
+++ b/frontend/src/routes/(authed)/dashboard/+page.svelte
@@ -366,6 +366,7 @@
             {topBarLabel()} · SLOT {occupied}/{displayedSlots}
           {/if}
         </div>
+        <a href="/funding" class="nav-link">{$_("dashboard.treasuryNav")}</a>
         {#if isHistoricalMonth}
           <button class="btn-entry" onclick={returnToCurrentMonth}>NOW</button>
         {:else if haltState === "monthly_halt"}
@@ -907,6 +908,20 @@
     border-color: var(--err);
     cursor: not-allowed;
     opacity: 0.8;
+  }
+  /* Sober, always-present treasury link (Zurich): quieter than the primary
+     action button — no border, dim until hover. */
+  .nav-link {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--track-label);
+    color: var(--fg-2);
+    text-decoration: none;
+    transition: color var(--dur) var(--ease);
+  }
+  .nav-link:hover {
+    color: var(--cyan-brand);
   }
   .btn-approve {
     font-family: var(--font-mono);

--- a/frontend/src/routes/(authed)/funding/+page.svelte
+++ b/frontend/src/routes/(authed)/funding/+page.svelte
@@ -11,6 +11,10 @@
   } from '$api/robson';
   import { _ } from 'svelte-i18n';
 
+  // Monetary fields arrive as Decimal strings from the backend; format for
+  // display only (no money math in the browser).
+  const fmtUsdt = (v: string | number): string => Number(v).toFixed(2);
+
   type WizardPhase = 'quote' | 'preview' | 'confirm' | 'executing';
 
   let phase = $state<WizardPhase>('quote');
@@ -174,7 +178,7 @@
                   <Row gap={4} justify="between" align="baseline">
                     <span class="mono">{item.asset}</span>
                     <span class="mono">{item.qty}</span>
-                    <span class="mono dim">{item.est_usdt.toFixed(2)} USDT</span
+                    <span class="mono dim">{fmtUsdt(item.est_usdt)} USDT</span
                     >
                   </Row>
                 {/each}
@@ -183,12 +187,12 @@
                 <Row gap={4} justify="between" align="baseline">
                   <span class="eyebrow">{$_('funding.totalEstimated')}</span>
                   <span class="mono"
-                    >{quote.estimated_usdt.toFixed(2)} USDT</span
+                    >{fmtUsdt(quote.estimated_usdt)} USDT</span
                   >
                 </Row>
                 <Row gap={4} justify="between" align="baseline">
                   <span class="eyebrow">{$_('funding.fees')}</span>
-                  <span class="mono">{quote.fees.toFixed(2)} USDT</span>
+                  <span class="mono">{fmtUsdt(quote.fees)} USDT</span>
                 </Row>
                 <Row gap={4} justify="between" align="baseline">
                   <span class="eyebrow">{$_('funding.slippageBps')}</span>
@@ -294,7 +298,7 @@
                   >
                 </Stack>
                 <span class="state-pill">{stateLabel(saga.state)}</span>
-                <span class="mono">{saga.estimated_usdt.toFixed(2)} USDT</span>
+                <span class="mono">{fmtUsdt(saga.estimated_usdt)} USDT</span>
               </Row>
             </Card>
           </a>

--- a/frontend/src/routes/(authed)/funding/[id]/+page.svelte
+++ b/frontend/src/routes/(authed)/funding/[id]/+page.svelte
@@ -7,6 +7,9 @@
   import { robsonApi, type FundingSaga, type FundingEvent } from '$api/robson';
   import { _ } from 'svelte-i18n';
 
+  // Decimal strings from the backend; format for display only.
+  const fmtUsdt = (v: string | number): string => Number(v).toFixed(2);
+
   const POLL_INTERVAL_MS = 2_000;
   const TERMINAL_STATES = new Set(['REFRESHED', 'FAILED']);
 
@@ -115,7 +118,7 @@
               <Row gap={4} justify="between" align="baseline">
                 <span class="mono">{item.asset}</span>
                 <span class="mono">{item.qty}</span>
-                <span class="mono dim">{item.est_usdt.toFixed(2)} USDT</span>
+                <span class="mono dim">{fmtUsdt(item.est_usdt)} USDT</span>
               </Row>
             {/each}
           </Stack>


### PR DESCRIPTION
## What

Two frontend changes for the funding surface:

### 1. Bugfix — `/funding` was broken (Quote button stuck on "Loading")
The backend serializes `rust_decimal::Decimal` money fields as JSON **strings** (`"198.79328929..."`), but the FE typed `estimated_usdt`/`est_usdt`/`fees`/`qty` as `number` and called `.toFixed()` → `Uncaught TypeError: ....estimated_usdt.toFixed is not a function`, which threw during render so the wizard never left the loading state (the `POST /funding/quote` itself returned 200 correctly).

Fix: type those fields as `string` and format for display via a small `fmtUsdt(v) = Number(v).toFixed(2)` helper (display only — no money math in the browser). Applied in `funding/+page.svelte` and `funding/[id]/+page.svelte`.

### 2. Persistent Treasury link (Zurich + Zug)
The only path to `/funding` was a *conditional* banner (`{#if insufficientCapital}`) — so when capital is sufficient the link disappears (inconsistent discovery). Added a sober, always-present **"Tesouraria"** link in the dashboard header (the logged-in home), next to the status strip. The contextual "Adicionar fundos" banner stays for the insufficient-capital nudge.
- Zurich: predictable, always-available navigation near the capital context.
- Zug: treasury (funding the trading capital) as a first-class, permanent surface.

## Verification
- `npm run check` (svelte-check): **0 errors** (4 pre-existing warnings in design components, untouched).
- `npm run build`: ✓.
- New i18n key `dashboard.treasuryNav` (pt-BR "Tesouraria" / en "Treasury").

> Note: `npm run lint` (eslint) remains red on `main` (no eslint config) — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
