### PR TITLE
fix: mark stale active positions in dashboard

### DIFF
--- a/frontend/src/lib/api/robson.ts
+++ b/frontend/src/lib/api/robson.ts
@@ -16,6 +16,7 @@ export type Position = {
   symbol: string;
   side: "Long" | "Short" | string;
   state: PositionState;
+  exchange_sync_state?: string | null;
   entry_mode?: string | null;
   approval_mode?: string | null;
   entry_price: number | null;
@@ -278,6 +279,8 @@ function normalizePosition(raw: unknown): Position {
     symbol: String(p.symbol ?? ""),
     side: String(p.side ?? ""),
     state: (p.state ?? "Error") as PositionState,
+    exchange_sync_state:
+      p.exchange_sync_state == null ? null : String(p.exchange_sync_state),
     entry_mode: p.entry_mode == null ? null : String(p.entry_mode),
     approval_mode: p.approval_mode == null ? null : String(p.approval_mode),
     entry_price: toNumber(p.entry_price),

--- a/frontend/src/lib/presentation/labels.ts
+++ b/frontend/src/lib/presentation/labels.ts
@@ -9,7 +9,23 @@ export function sideLabel(side: string): string {
   return map[side] ?? side;
 }
 
-export function positionStateLabel(state: PositionState): string {
+const STALE_SYNC_STATE = 'stale_missing_on_exchange';
+
+export function positionStateLabel(positionOrState: Position | PositionState): string {
+  if (
+    typeof positionOrState !== 'string' &&
+    'exchange_sync_state' in positionOrState &&
+    positionOrState.exchange_sync_state === STALE_SYNC_STATE
+  ) {
+    return 'Stale';
+  }
+
+  const state =
+    typeof positionOrState === 'string'
+      ? positionOrState
+      : 'state' in positionOrState
+        ? positionOrState.state
+        : positionOrState;
   if (typeof state === 'string') return state;
   const key = Object.keys(state)[0];
   return key;
@@ -28,6 +44,7 @@ export function entryModeLabel(mode?: string | null): string {
 export function positionSummaryLines(p: Position): string[] {
   const lines: string[] = [];
   const state = p.state;
+  const isStale = p.exchange_sync_state === STALE_SYNC_STATE;
   const label = (tag: string, detail: string) => `${tag.padEnd(10)}${detail}`;
 
   if (typeof state === 'string') {
@@ -37,18 +54,22 @@ export function positionSummaryLines(p: Position): string[] {
       lines.push(label('ARMED', `${modeLabel}${approvalLabel}`));
       lines.push(label('LEVERAGE', '10x (fixed)'));
     } else if (state === 'Active') {
-      const details: string[] = [];
-      if (p.entry_price != null) details.push(`entry ${fmtNum(p.entry_price)}`);
-      if (p.trailing_stop != null) details.push(`stop ${fmtNum(p.trailing_stop)}`);
-      lines.push(label('ACTIVE', details.join(' · ') || 'position open'));
-      const target = trailingStopMoveTarget(p);
-      if (target) {
-        lines.push(
-          label(
-            'TARGET',
-            `${fmtNum(target.trigger_price)} -> stop ${fmtNum(target.next_stop)}`,
-          ),
-        );
+      if (isStale) {
+        lines.push(label('STALE', 'not present on exchange'));
+      } else {
+        const details: string[] = [];
+        if (p.entry_price != null) details.push(`entry ${fmtNum(p.entry_price)}`);
+        if (p.trailing_stop != null) details.push(`stop ${fmtNum(p.trailing_stop)}`);
+        lines.push(label('ACTIVE', details.join(' · ') || 'position open'));
+        const target = trailingStopMoveTarget(p);
+        if (target) {
+          lines.push(
+            label(
+              'TARGET',
+              `${fmtNum(target.trigger_price)} -> stop ${fmtNum(target.next_stop)}`,
+            ),
+          );
+        }
       }
     }
   } else {
@@ -58,17 +79,21 @@ export function positionSummaryLines(p: Position): string[] {
     if (key === 'Entering' && val) {
       lines.push(label('ENTERING', `expected entry ${fmtNum(val.expected_entry as number)}`));
     } else if (key === 'Active' && val) {
-      lines.push(label('ACTIVE', `price ${fmtNum(val.current_price as number)} · stop ${fmtNum(val.trailing_stop as number)}`));
-      const target = trailingStopMoveTarget(p);
-      if (target) {
-        lines.push(
-          label(
-            'TARGET',
-            `${fmtNum(target.trigger_price)} -> stop ${fmtNum(target.next_stop)}`,
-          ),
-        );
+      if (isStale) {
+        lines.push(label('STALE', 'not present on exchange'));
+      } else {
+        lines.push(label('ACTIVE', `price ${fmtNum(val.current_price as number)} · stop ${fmtNum(val.trailing_stop as number)}`));
+        const target = trailingStopMoveTarget(p);
+        if (target) {
+          lines.push(
+            label(
+              'TARGET',
+              `${fmtNum(target.trigger_price)} -> stop ${fmtNum(target.next_stop)}`,
+            ),
+          );
+        }
+        if (val.favorable_extreme) lines.push(label('EXTREME', fmtNum(val.favorable_extreme as number)));
       }
-      if (val.favorable_extreme) lines.push(label('EXTREME', fmtNum(val.favorable_extreme as number)));
     } else if (key === 'Exiting' && val) {
       lines.push(label('EXITING', `${val.exit_reason}`));
     } else if (key === 'Closed' && val) {
@@ -133,7 +158,7 @@ function activeTrailingStop(p: Position): number | null {
 }
 
 export function positionMetaLine(p: Position): string {
-  const state = positionStateLabel(p.state);
+  const state = positionStateLabel(p);
   const parts = [`State ${state}`];
   if (p.created_at) parts.push(`Created ${formatDateUtc(p.created_at)}`);
   if (p.closed_at) parts.push(`Closed ${formatDateUtc(p.closed_at)}`);

--- a/frontend/src/routes/(authed)/dashboard/+page.svelte
+++ b/frontend/src/routes/(authed)/dashboard/+page.svelte
@@ -523,7 +523,7 @@
                         </span>
                       </Row>
                       <Row justify="between">
-                        <span class="meta">{positionStateLabel(op.state)}</span>
+                        <span class="meta">{positionStateLabel(op)}</span>
                       </Row>
                       <div class="meta dim">{positionMetaLine(op)}</div>
                       <pre class="history-summary">{positionSummaryLines(
@@ -554,7 +554,7 @@
                         </span>
                       </Row>
                       <Row justify="between">
-                        <span class="meta">{positionStateLabel(op.state)}</span>
+                        <span class="meta">{positionStateLabel(op)}</span>
                         {#if variationFor(op) !== null}
                           <span
                             class="mono"

--- a/frontend/src/routes/(authed)/kill-switch/+page.svelte
+++ b/frontend/src/routes/(authed)/kill-switch/+page.svelte
@@ -123,7 +123,7 @@
               {#each affectedPositions as pos}
                 <div class="pos-row">
                   <span class="pos-label">{positionLabel(pos)}</span>
-                  <span class="pos-state">{positionStateLabel(pos.state)}</span>
+                  <span class="pos-state">{positionStateLabel(pos)}</span>
                 </div>
               {/each}
             </div>

--- a/robson-exec/src/executor.rs
+++ b/robson-exec/src/executor.rs
@@ -93,6 +93,11 @@ impl<E: ExchangePort, S: Store> Executor<E, S> {
         self.exchange.get_price(symbol).await
     }
 
+    /// Expose the exchange port for read-only inspection.
+    pub fn exchange(&self) -> Arc<E> {
+        Arc::clone(&self.exchange)
+    }
+
     /// Execute a list of engine actions.
     ///
     /// Actions are executed in order. If one fails, subsequent actions

--- a/robsond/src/api.rs
+++ b/robsond/src/api.rs
@@ -28,7 +28,7 @@ use robson_domain::{
     ApprovalPolicy as DomainApprovalPolicy, DetectorSignal, EntryPolicy, EntryPolicyConfig,
     Position, PositionState, Price, RiskConfig, Side, Symbol, TradingPolicy,
 };
-use robson_exec::{ExchangePort, UniversalTransferType};
+use robson_exec::{ExchangePort, ExchangePosition, UniversalTransferType};
 #[cfg(feature = "postgres")]
 use robson_store::find_positions_overlapping_month;
 use robson_store::Store;
@@ -139,6 +139,8 @@ pub struct PositionSummary {
     pub symbol: String,
     pub side: String,
     pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exchange_sync_state: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entry_mode: Option<String>,
@@ -1126,6 +1128,13 @@ where
         manager.compute_slots_available().await.map_err(|e| to_error_response(e))?;
     let occupied_slots = positions.len();
     let slot_cells_total = occupied_slots.saturating_add(new_slots_available as usize);
+    let exchange_positions = match manager.exchange_open_positions().await {
+        Ok(positions) => Some(positions),
+        Err(error) => {
+            warn!(error = %error, "failed to query exchange open positions for sync check");
+            None
+        },
+    };
     let monthly_realized_loss_pct = if monthly.capital_base > Decimal::ZERO {
         monthly.realized_loss / monthly.capital_base * Decimal::from(100u32)
     } else {
@@ -1134,7 +1143,7 @@ where
 
     let mut summaries: Vec<PositionSummary> = Vec::with_capacity(positions.len());
     for position in &positions {
-        summaries.push(position_to_summary_with_live_price(&manager, position).await);
+        summaries.push(position_to_summary_with_live_price_and_sync(&manager, position, exchange_positions.as_deref()).await);
     }
 
     // Update active positions gauge
@@ -1222,8 +1231,19 @@ where
                     }),
                 )
             })?;
+    let exchange_positions = match manager.exchange_open_positions().await {
+        Ok(positions) => Some(positions),
+        Err(error) => {
+            warn!(error = %error, "failed to query exchange open positions for sync check");
+            None
+        },
+    };
 
-    Ok(Json(position_to_summary_with_live_price(&manager, &position).await))
+    Ok(Json(position_to_summary_with_live_price_and_sync(
+        &manager,
+        &position,
+        exchange_positions.as_deref(),
+    ).await))
 }
 
 /// Arm a new position.
@@ -1881,6 +1901,40 @@ where
     position_to_summary(position, live_price, entry_mode, approval_mode)
 }
 
+async fn position_to_summary_with_live_price_and_sync<E, S>(
+    manager: &PositionManager<E, S>,
+    position: &Position,
+    exchange_positions: Option<&[ExchangePosition]>,
+) -> PositionSummary
+where
+    E: ExchangePort + 'static,
+    S: Store + 'static,
+{
+    let mut summary = position_to_summary_with_live_price(manager, position).await;
+    summary.exchange_sync_state = exchange_sync_state(position, exchange_positions);
+    summary
+}
+
+fn exchange_sync_state(
+    position: &Position,
+    exchange_positions: Option<&[ExchangePosition]>,
+) -> Option<String> {
+    let exchange_positions = exchange_positions?;
+    if !matches!(&position.state, PositionState::Active { .. }) {
+        return None;
+    }
+
+    let found = exchange_positions.iter().any(|exchange_position| {
+        &exchange_position.symbol == &position.symbol && &exchange_position.side == &position.side
+    });
+
+    if found {
+        None
+    } else {
+        Some("stale_missing_on_exchange".to_string())
+    }
+}
+
 fn position_to_summary(
     position: &Position,
     live_price: Option<Price>,
@@ -1959,6 +2013,7 @@ fn position_to_summary(
         symbol: position.symbol.as_pair(),
         side: format!("{:?}", position.side),
         state: state_str,
+        exchange_sync_state: None,
         created_at: position.created_at,
         entry_mode,
         approval_mode,
@@ -2136,7 +2191,7 @@ mod tests {
     use http_body_util::BodyExt;
     use robson_domain::{Quantity, RiskConfig, TechnicalStopDistance, TradingPolicy};
     use robson_engine::Engine;
-    use robson_exec::{Executor, IntentJournal, StubExchange};
+    use robson_exec::{ExchangePosition, Executor, IntentJournal, StubExchange};
     use robson_store::MemoryStore;
     use rust_decimal_macros::dec;
     use tokio::time::timeout;
@@ -2208,6 +2263,33 @@ mod tests {
         assert_eq!(summary.current_price, Some(dec!(90)));
         assert_eq!(summary.pnl, Some(dec!(20)));
         assert_eq!(summary.variation_pct, Some(dec!(10.0)));
+    }
+
+
+    #[test]
+    fn exchange_sync_state_marks_missing_active_position_as_stale() {
+        let mut position =
+            Position::new(Uuid::now_v7(), Symbol::from_pair("BTCUSDT").unwrap(), Side::Long);
+        position.state = PositionState::Active {
+            current_price: Price::new(dec!(100)).unwrap(),
+            trailing_stop: Price::new(dec!(95)).unwrap(),
+            favorable_extreme: Price::new(dec!(105)).unwrap(),
+            extreme_at: chrono::Utc::now(),
+            insurance_stop_id: None,
+            last_emitted_stop: None,
+        };
+
+        let stale = exchange_sync_state(&position, Some(&[]));
+        assert_eq!(stale, Some("stale_missing_on_exchange".to_string()));
+
+        let exchange_positions = vec![ExchangePosition {
+            symbol: Symbol::from_pair("BTCUSDT").unwrap(),
+            side: Side::Long,
+            quantity: robson_domain::Quantity::new(dec!(1)).unwrap(),
+            entry_price: Price::new(dec!(100)).unwrap(),
+        }];
+        let present = exchange_sync_state(&position, Some(&exchange_positions));
+        assert_eq!(present, None);
     }
 
     #[test]

--- a/robsond/src/position_manager.rs
+++ b/robsond/src/position_manager.rs
@@ -33,7 +33,7 @@ use robson_engine::{
 };
 #[cfg(feature = "postgres")]
 use robson_eventlog::{append_event, ActorType as EventlogActorType, Event as EventlogEvent};
-use robson_exec::{ActionResult, ExchangePort, ExecError, Executor, OhlcvPort, StubOhlcv};
+use robson_exec::{ActionResult, ExchangePort, ExchangePosition, ExecError, Executor, OhlcvPort, StubOhlcv};
 #[cfg(feature = "postgres")]
 use robson_projector::apply_event_to_projections;
 use robson_store::Store;
@@ -151,6 +151,11 @@ pub(crate) struct MonthlyRiskState {
 impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
     pub(crate) fn configured_capital(&self) -> Decimal {
         self.engine.lock().unwrap().risk_config().capital()
+    }
+
+    /// Snapshot of open positions observed directly on the exchange.
+    pub(crate) async fn exchange_open_positions(&self) -> DaemonResult<Vec<ExchangePosition>> {
+        self.executor.exchange().get_all_open_positions().await.map_err(Into::into)
     }
 
     /// Update the engine's capital from an external source (exchange balance).


### PR DESCRIPTION
Marks local Active positions as stale when they are missing from the exchange snapshot, so the dashboard no longer shows a closed/orphaned position as live. Includes backend sync metadata, frontend rendering change, and focused tests.