### PR TITLE
[codex] harden Robson entry execution policy

### DIFF
--- a/frontend/src/lib/design/components/NavBar.svelte
+++ b/frontend/src/lib/design/components/NavBar.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { robsonApi } from '$api/robson';
+  import { status, startStatusPolling, stopStatusPolling } from '$stores/status';
   import Row from './Row.svelte';
 
-  let capital = $state<number | null>(null);
-
   $effect(() => {
-    robsonApi
-      .getStatus()
-      .then((s) => (capital = s.wallet_balance))
-      .catch(() => {});
+    startStatusPolling();
+    return () => stopStatusPolling();
   });
 
   let currentPath = $derived($page.url.pathname);
@@ -35,10 +31,10 @@
       </div>
     </Row>
     <Row gap={4} align="center">
-      {#if capital !== null}
+      {#if $status !== null}
         <span class="capital" title="USDT-M futures wallet">
           <span class="capital-label">FUTURES</span>
-          <span class="capital-value">{capital.toFixed(2)}</span>
+          <span class="capital-value">{($status.wallet_balance).toFixed(2)}</span>
           <span class="capital-unit">USDT</span>
         </span>
       {/if}

--- a/frontend/src/lib/stores/status.ts
+++ b/frontend/src/lib/stores/status.ts
@@ -1,0 +1,38 @@
+import { writable } from 'svelte/store';
+import { robsonApi, type StatusResponse } from '$api/robson';
+
+export const status = writable<StatusResponse | null>(null);
+
+let refreshInFlight: Promise<StatusResponse | null> | null = null;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+export async function refreshStatus(): Promise<StatusResponse | null> {
+  if (refreshInFlight) return refreshInFlight;
+
+  refreshInFlight = robsonApi
+    .getStatus()
+    .then((next) => {
+      status.set(next);
+      return next;
+    })
+    .finally(() => {
+      refreshInFlight = null;
+    });
+
+  return refreshInFlight;
+}
+
+export function startStatusPolling(intervalMs = 10_000): void {
+  if (pollTimer) return;
+
+  void refreshStatus().catch(() => {});
+  pollTimer = setInterval(() => {
+    void refreshStatus().catch(() => {});
+  }, intervalMs);
+}
+
+export function stopStatusPolling(): void {
+  if (!pollTimer) return;
+  clearInterval(pollTimer);
+  pollTimer = null;
+}

--- a/frontend/src/routes/(authed)/dashboard/+page.svelte
+++ b/frontend/src/routes/(authed)/dashboard/+page.svelte
@@ -12,12 +12,12 @@
     type Position,
     type SseEvent,
     type PendingApproval,
-    type StatusResponse,
   } from "$api/robson";
   import { activePositions } from "$stores/operations";
   import { haltStatus } from "$stores/slots";
   import { recentEvents, pushEvent } from "$stores/events";
   import { toasts, showToast } from "$stores/toast";
+  import { status as sharedStatus, refreshStatus } from "$stores/status";
   import {
     deriveMonthSlots,
     sortPositionsOldestFirst,
@@ -35,19 +35,16 @@
   } from "$lib/presentation/labels";
   import { _ } from "svelte-i18n";
 
-  const POLL_INTERVAL_MS = 10_000;
-
   let error = $state<string | null>(null);
   let connected = $state(false);
   let closeSse: (() => void) | null = null;
-  let pollTimer: ReturnType<typeof setInterval> | null = null;
   let showArmModal = $state(false);
   let pendingApprovals = $state<PendingApproval[]>([]);
   let historyError = $state<string | null>(null);
   let selectedMonth = $state(currentMonthKey());
   let monthlyPositions = $state<Position[]>([]);
   let monthlySlotCellsTotal = $state<number | null>(null);
-  let currentStatus = $state<StatusResponse | null>(null);
+  let currentStatus = $derived($sharedStatus);
   let approvalTick = $state(Date.now());
   let approvalTickTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -195,13 +192,14 @@
     error = null;
     try {
       const [status, halt] = await Promise.all([
-        robsonApi.getStatus(),
+        refreshStatus(),
         robsonApi.getHaltStatus(),
       ]);
-      currentStatus = status;
-      activePositions.set(status.positions.filter((op) => isRenderableLivePosition(op)));
+      if (status) {
+        activePositions.set(status.positions.filter((op) => isRenderableLivePosition(op)));
+        pendingApprovals = status.pending_approvals;
+      }
       haltStatus.set(halt);
-      pendingApprovals = status.pending_approvals;
       connected = true;
     } catch (e) {
       error =
@@ -239,13 +237,7 @@
         const posId = payload.position_id as string | undefined;
         if (posId && event.event_type === "position.changed") {
           void Promise.all([
-            robsonApi
-              .getStatus()
-              .then((s) => {
-                currentStatus = s;
-                activePositions.set(s.positions);
-              })
-              .catch(() => {}),
+            refreshStatus().catch(() => {}),
             loadHistory().catch(() => {}),
           ]);
         }
@@ -263,40 +255,9 @@
     }
   }
 
-  function startPolling() {
-    stopPolling();
-    pollTimer = setInterval(() => {
-      void (async () => {
-        try {
-          const [status, halt] = await Promise.all([
-            robsonApi.getStatus(),
-            robsonApi.getHaltStatus(),
-          ]);
-          currentStatus = status;
-          activePositions.set(status.positions.filter((op) => isRenderableLivePosition(op)));
-          haltStatus.set(halt);
-          pendingApprovals = status.pending_approvals;
-          connected = true;
-          error = null;
-          void loadHistory();
-        } catch {
-          // SSE + polling: silent retry, error shown only if initial load fails
-        }
-      })();
-    }, POLL_INTERVAL_MS);
-  }
-
-  function stopPolling() {
-    if (pollTimer) {
-      clearInterval(pollTimer);
-      pollTimer = null;
-    }
-  }
-
   function retry() {
     void load();
     startSse();
-    startPolling();
   }
 
   function prevMonth() {
@@ -314,14 +275,12 @@
     untrack(() => {
       void load();
       startSse();
-      startPolling();
       approvalTickTimer = setInterval(() => {
         approvalTick = Date.now();
       }, 1000);
     });
     return () => {
       stopSse();
-      stopPolling();
       if (approvalTickTimer) {
         clearInterval(approvalTickTimer);
         approvalTickTimer = null;

--- a/robson-exec/src/executor.rs
+++ b/robson-exec/src/executor.rs
@@ -614,7 +614,10 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         match &results[0] {
-            ActionResult::OrderFailed { event: Event::EntryOrderFailed { cycle_id: actual, .. }, error } => {
+            ActionResult::OrderFailed {
+                event: Event::EntryOrderFailed { cycle_id: actual, .. },
+                error,
+            } => {
                 assert_eq!(*actual, cycle_id);
                 assert!(error.contains("Simulated exchange failure"));
             },

--- a/robson-exec/src/executor.rs
+++ b/robson-exec/src/executor.rs
@@ -24,9 +24,6 @@ use crate::{
     ports::{ExchangePort, OrderResult},
 };
 
-const ENTRY_ORDER_MAX_ATTEMPTS: u32 = 3;
-const ENTRY_ORDER_RETRY_BACKOFF_MS: u64 = 25;
-
 // =============================================================================
 // Execution Result
 // =============================================================================
@@ -294,27 +291,13 @@ impl<E: ExchangePort, S: Store> Executor<E, S> {
             "Placing entry order"
         );
 
-        // 5. Execute on exchange. Transient exchange failures retry with a
-        // short bounded backoff; a final failure is persisted as EntryOrderFailed.
-        let mut result = self
+        // 5. Execute on exchange exactly once. A timeout/transport failure after
+        // order acceptance is ambiguous for MARKET orders; automatic retry can
+        // create duplicate real positions. Reconciliation must resolve drift.
+        let result = self
             .exchange
             .place_market_order(&symbol, side, quantity, &client_order_id, false)
             .await;
-        for attempt in 1..ENTRY_ORDER_MAX_ATTEMPTS {
-            match &result {
-                Err(error) if is_transient_exchange_error(error) => {
-                    tokio::time::sleep(std::time::Duration::from_millis(
-                        ENTRY_ORDER_RETRY_BACKOFF_MS * u64::from(attempt),
-                    ))
-                    .await;
-                    result = self
-                        .exchange
-                        .place_market_order(&symbol, side, quantity, &client_order_id, false)
-                        .await;
-                },
-                _ => break,
-            }
-        }
 
         // 6. Record result and emit appropriate domain event
         match &result {
@@ -469,10 +452,6 @@ impl<E: ExchangePort, S: Store> Executor<E, S> {
     }
 }
 
-fn is_transient_exchange_error(error: &ExecError) -> bool {
-    matches!(error, ExecError::Timeout(_) | ExecError::Exchange(_))
-}
-
 // =============================================================================
 // Tests
 // =============================================================================
@@ -605,6 +584,42 @@ mod tests {
             results2[0],
             ActionResult::AlreadyProcessed(id) if id == signal_id
         ));
+    }
+
+    #[tokio::test]
+    async fn test_entry_order_failure_is_not_retried() {
+        let exchange = Arc::new(StubExchange::new(dec!(95000)));
+        exchange.set_order_fail_next(true);
+        let journal = Arc::new(IntentJournal::new());
+        let store = Arc::new(MemoryStore::new());
+        let executor = Executor::new(exchange, journal, store);
+
+        let signal_id = Uuid::now_v7();
+        let position_id = Uuid::now_v7();
+        let cycle_id = Uuid::now_v7();
+
+        let action = EngineAction::PlaceEntryOrder {
+            position_id,
+            cycle_id: Some(cycle_id),
+            symbol: Symbol::from_pair("BTCUSDT").unwrap(),
+            side: robson_domain::OrderSide::Buy,
+            quantity: Quantity::new(dec!(0.1)).unwrap(),
+            order_id: Uuid::now_v7(),
+            client_order_id: signal_id.to_string(),
+            expected_price: robson_domain::Price::new(dec!(95000)).unwrap(),
+            signal_id,
+        };
+
+        let results = executor.execute(vec![action]).await.unwrap();
+
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            ActionResult::OrderFailed { event: Event::EntryOrderFailed { cycle_id: actual, .. }, error } => {
+                assert_eq!(*actual, cycle_id);
+                assert!(error.contains("Simulated exchange failure"));
+            },
+            other => panic!("Expected non-retried OrderFailed, got {:?}", other),
+        }
     }
 
     #[tokio::test]

--- a/robson-exec/src/stub.rs
+++ b/robson-exec/src/stub.rs
@@ -130,7 +130,8 @@ impl StubExchange {
         *fail_next = fail;
     }
 
-    /// Configure the next futures order placement to fail after account validation.
+    /// Configure the next futures order placement to fail after account
+    /// validation.
     pub fn set_order_fail_next(&self, fail: bool) {
         let mut fail_next = self.order_fail_next.write().unwrap();
         *fail_next = fail;

--- a/robson-exec/src/stub.rs
+++ b/robson-exec/src/stub.rs
@@ -42,6 +42,8 @@ pub struct StubExchange {
     order_counter: RwLock<u64>,
     /// Whether to simulate failures
     fail_next: RwLock<bool>,
+    /// Whether to simulate a futures order placement failure only.
+    order_fail_next: RwLock<bool>,
     /// Simulated futures settings (position_mode, leverage)
     futures_settings: RwLock<(String, u8)>,
     /// Simulated open positions returned by reconciliation scans.
@@ -72,6 +74,7 @@ impl StubExchange {
             fee_rate: Decimal::new(1, 3), // 0.001 = 0.1%
             order_counter: RwLock::new(0),
             fail_next: RwLock::new(false),
+            order_fail_next: RwLock::new(false),
             futures_settings: RwLock::new(("One-way".to_string(), 10)),
             open_positions: RwLock::new(HashMap::new()),
             futures_balance: RwLock::new(Decimal::from(10000)),
@@ -121,9 +124,15 @@ impl StubExchange {
         prices.get(symbol).copied().unwrap_or(self.default_price)
     }
 
-    /// Configure the next order to fail.
+    /// Configure the next operation to fail.
     pub fn set_fail_next(&self, fail: bool) {
         let mut fail_next = self.fail_next.write().unwrap();
+        *fail_next = fail;
+    }
+
+    /// Configure the next futures order placement to fail after account validation.
+    pub fn set_order_fail_next(&self, fail: bool) {
+        let mut fail_next = self.order_fail_next.write().unwrap();
         *fail_next = fail;
     }
 
@@ -139,6 +148,13 @@ impl StubExchange {
         let mut fail_next = self.fail_next.write().unwrap();
         let fail = *fail_next;
         *fail_next = false; // Reset after check
+        fail
+    }
+
+    fn should_fail_order(&self) -> bool {
+        let mut fail_next = self.order_fail_next.write().unwrap();
+        let fail = *fail_next;
+        *fail_next = false;
         fail
     }
 
@@ -256,7 +272,7 @@ impl ExchangePort for StubExchange {
         _reduce_only: bool,
     ) -> Result<OrderResult, ExecError> {
         // Check if we should simulate a failure
-        if self.should_fail() {
+        if self.should_fail() || self.should_fail_order() {
             return Err(ExecError::Exchange("Simulated exchange failure".to_string()));
         }
 

--- a/robson-store/src/memory.rs
+++ b/robson-store/src/memory.rs
@@ -436,8 +436,7 @@ impl PositionRepository for MemoryStore {
                     && p.side == side
                     && matches!(
                         p.state,
-                        robson_domain::PositionState::Armed
-                            | robson_domain::PositionState::Entering { .. }
+                        robson_domain::PositionState::Entering { .. }
                             | robson_domain::PositionState::Active { .. }
                             | robson_domain::PositionState::Exiting { .. }
                     )
@@ -610,7 +609,7 @@ impl Store for MemoryStore {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use robson_domain::{OrderSide, PositionState, Price, Quantity, Side, Symbol};
+    use robson_domain::{OrderSide, PositionState, Quantity, Side, Symbol};
     use rust_decimal_macros::dec;
 
     use super::*;
@@ -781,6 +780,21 @@ mod tests {
 
         let result = PositionRepository::find_active(&store).await.unwrap();
         assert!(result.is_empty(), "Error position must not appear in find_active");
+    }
+
+    #[tokio::test]
+    async fn test_position_find_active_by_symbol_and_side_excludes_armed() {
+        let store = MemoryStore::new();
+        let armed = create_test_position();
+        let symbol = armed.symbol.clone();
+        let side = armed.side;
+
+        PositionRepository::save(&store, &armed).await.unwrap();
+
+        let found = PositionRepository::find_active_by_symbol_and_side(&store, &symbol, side)
+            .await
+            .unwrap();
+        assert!(found.is_none(), "Armed position must not mark exchange exposure as tracked");
     }
 
     #[tokio::test]

--- a/robsond/src/chaos_tests.rs
+++ b/robsond/src/chaos_tests.rs
@@ -241,14 +241,14 @@ async fn chaos_risk_engine_slow_denies_by_timeout_safe_default() {
 }
 
 #[tokio::test]
-async fn chaos_exchange_timeout_retries_then_records_entry_failure() {
+async fn chaos_exchange_timeout_does_not_retry_ambiguous_entry_order() {
     let exchange = Arc::new(TimeoutExchange::new());
     let store = Arc::new(MemoryStore::new());
     let executor = Executor::new(exchange.clone(), Arc::new(Default::default()), store);
 
     let results = executor.execute(vec![entry_order_action(Uuid::now_v7())]).await.unwrap();
 
-    assert_eq!(exchange.attempts(), 3);
+    assert_eq!(exchange.attempts(), 1);
     assert!(matches!(results.as_slice(), [robson_exec::ActionResult::OrderFailed { .. }]));
 }
 

--- a/robsond/src/daemon.rs
+++ b/robsond/src/daemon.rs
@@ -2243,13 +2243,10 @@ mod tests {
         let stored_auto =
             daemon_auto.store.positions().find_by_id(pid_auto).await.unwrap().unwrap();
         assert!(
-            matches!(
-                stored_auto.state,
-                PositionState::Closed {
-                    exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
-                    ..
-                }
-            ),
+            matches!(stored_auto.state, PositionState::Closed {
+                exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+                ..
+            }),
             "AutoReconcile policy must close stale-active with real evidence"
         );
     }
@@ -2301,13 +2298,10 @@ mod tests {
         daemon.run_startup_auto_reconcile().await.unwrap();
 
         let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
-        assert!(matches!(
-            stored.state,
-            PositionState::Closed {
-                exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
-                ..
-            }
-        ));
+        assert!(matches!(stored.state, PositionState::Closed {
+            exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+            ..
+        }));
     }
 
     #[tokio::test]
@@ -2321,27 +2315,21 @@ mod tests {
         daemon.store.positions().save(&position).await.unwrap();
 
         let now = chrono::Utc::now();
-        daemon.exchange.set_user_trades(
-            &symbol.as_pair(),
-            vec![user_trade(
-                "TRADE-1",
-                "EX-ORDER-2",
-                dec!(90),
-                dec!(0.010),
-                now,
-            )],
-        );
+        daemon.exchange.set_user_trades(&symbol.as_pair(), vec![user_trade(
+            "TRADE-1",
+            "EX-ORDER-2",
+            dec!(90),
+            dec!(0.010),
+            now,
+        )]);
 
         daemon.run_startup_auto_reconcile().await.unwrap();
 
         let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
-        assert!(matches!(
-            stored.state,
-            PositionState::Closed {
-                exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
-                ..
-            }
-        ));
+        assert!(matches!(stored.state, PositionState::Closed {
+            exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+            ..
+        }));
     }
 
     #[tokio::test]
@@ -2456,16 +2444,13 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(
-                vec![input],
-                vec![StartupStaleActiveInfo {
-                    position_id: pid,
-                    symbol: symbol.as_pair(),
-                    side: "Long".to_string(),
-                    quantity: dec!(0.010),
-                    entry_price: Some(dec!(100)),
-                }],
-            )
+            .apply_startup_auto_reconcile_batch(vec![input], vec![StartupStaleActiveInfo {
+                position_id: pid,
+                symbol: symbol.as_pair(),
+                side: "Long".to_string(),
+                quantity: dec!(0.010),
+                entry_price: Some(dec!(100)),
+            }])
             .await
             .unwrap_err();
 
@@ -2519,16 +2504,13 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(
-                vec![input],
-                vec![StartupStaleActiveInfo {
-                    position_id: pid,
-                    symbol: symbol.as_pair(),
-                    side: "Long".to_string(),
-                    quantity: dec!(0.010),
-                    entry_price: Some(dec!(100)),
-                }],
-            )
+            .apply_startup_auto_reconcile_batch(vec![input], vec![StartupStaleActiveInfo {
+                position_id: pid,
+                symbol: symbol.as_pair(),
+                side: "Long".to_string(),
+                quantity: dec!(0.010),
+                entry_price: Some(dec!(100)),
+            }])
             .await
             .unwrap_err();
 
@@ -2568,16 +2550,13 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(
-                vec![input],
-                vec![StartupStaleActiveInfo {
-                    position_id: pid,
-                    symbol: symbol.as_pair(),
-                    side: "Long".to_string(),
-                    quantity: dec!(0.010),
-                    entry_price: Some(dec!(100)),
-                }],
-            )
+            .apply_startup_auto_reconcile_batch(vec![input], vec![StartupStaleActiveInfo {
+                position_id: pid,
+                symbol: symbol.as_pair(),
+                side: "Long".to_string(),
+                quantity: dec!(0.010),
+                entry_price: Some(dec!(100)),
+            }])
             .await
             .unwrap_err();
 
@@ -2648,25 +2627,22 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(
-                vec![input_a, input_b],
-                vec![
-                    StartupStaleActiveInfo {
-                        position_id: pid_a,
-                        symbol: symbol_a.as_pair(),
-                        side: "Long".to_string(),
-                        quantity: dec!(0.010),
-                        entry_price: Some(dec!(100)),
-                    },
-                    StartupStaleActiveInfo {
-                        position_id: pid_b,
-                        symbol: symbol_b.as_pair(),
-                        side: "Long".to_string(),
-                        quantity: dec!(0.010),
-                        entry_price: Some(dec!(100)),
-                    },
-                ],
-            )
+            .apply_startup_auto_reconcile_batch(vec![input_a, input_b], vec![
+                StartupStaleActiveInfo {
+                    position_id: pid_a,
+                    symbol: symbol_a.as_pair(),
+                    side: "Long".to_string(),
+                    quantity: dec!(0.010),
+                    entry_price: Some(dec!(100)),
+                },
+                StartupStaleActiveInfo {
+                    position_id: pid_b,
+                    symbol: symbol_b.as_pair(),
+                    side: "Long".to_string(),
+                    quantity: dec!(0.010),
+                    entry_price: Some(dec!(100)),
+                },
+            ])
             .await
             .unwrap_err();
 

--- a/robsond/src/daemon.rs
+++ b/robsond/src/daemon.rs
@@ -1105,29 +1105,43 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
         let mut stale: Vec<StartupStaleActiveInfo> = Vec::new();
 
         for position in &local_positions {
-            if !matches!(position.state, PositionState::Active { .. }) {
-                continue;
-            }
-
             let present_on_exchange = exchange_positions
                 .iter()
                 .any(|ep| ep.symbol == position.symbol && ep.side == position.side);
 
-            if !present_on_exchange {
-                error!(
-                    position_id = %position.id,
-                    symbol = %position.symbol.as_pair(),
-                    side = ?position.side,
-                    quantity = %position.quantity,
-                    "CRITICAL: Startup gate: Robson-Active position absent from exchange"
-                );
-                stale.push(StartupStaleActiveInfo {
-                    position_id: position.id,
-                    symbol: position.symbol.as_pair(),
-                    side: format!("{:?}", position.side),
-                    quantity: position.quantity.as_decimal(),
-                    entry_price: position.entry_price.map(|p| p.as_decimal()),
-                });
+            match &position.state {
+                PositionState::Active { .. } if !present_on_exchange => {
+                    error!(
+                        position_id = %position.id,
+                        symbol = %position.symbol.as_pair(),
+                        side = ?position.side,
+                        quantity = %position.quantity,
+                        "CRITICAL: Startup gate: Robson-Active position absent from exchange"
+                    );
+                    stale.push(StartupStaleActiveInfo {
+                        position_id: position.id,
+                        symbol: position.symbol.as_pair(),
+                        side: format!("{:?}", position.side),
+                        quantity: position.quantity.as_decimal(),
+                        entry_price: position.entry_price.map(|p| p.as_decimal()),
+                    });
+                },
+                PositionState::Armed if present_on_exchange => {
+                    error!(
+                        position_id = %position.id,
+                        symbol = %position.symbol.as_pair(),
+                        side = ?position.side,
+                        "CRITICAL: Startup gate: Armed position already appears on exchange"
+                    );
+                    stale.push(StartupStaleActiveInfo {
+                        position_id: position.id,
+                        symbol: position.symbol.as_pair(),
+                        side: format!("{:?}", position.side),
+                        quantity: position.quantity.as_decimal(),
+                        entry_price: position.entry_price.map(|p| p.as_decimal()),
+                    });
+                },
+                _ => {},
             }
         }
 
@@ -2051,6 +2065,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_startup_gate_armed_on_exchange_returns_typed_error() {
+        use robson_domain::Symbol;
+        let daemon = Daemon::new_stub(Config::test());
+        let symbol = Symbol::from_pair("BTCUSDT").unwrap();
+
+        let mut position = active_position(symbol.clone(), Side::Long);
+        let pid = position.id;
+        position.state = PositionState::Armed;
+        daemon.store.positions().save(&position).await.unwrap();
+        daemon.exchange.set_open_position(
+            symbol,
+            Side::Long,
+            position.quantity,
+            position.entry_price.unwrap(),
+        );
+
+        let err = daemon.abort_if_stale_active().await.unwrap_err();
+        assert!(
+            matches!(err, DaemonError::StartupStaleActiveDetected { count: 1, .. }),
+            "expected StartupStaleActiveDetected with count 1, got: {err:?}"
+        );
+
+        let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
+        assert!(matches!(stored.state, PositionState::Armed));
+    }
+
+    #[tokio::test]
     async fn test_startup_gate_entering_does_not_abort() {
         use robson_domain::Symbol;
         let daemon = Daemon::new_stub(Config::test());
@@ -2202,10 +2243,13 @@ mod tests {
         let stored_auto =
             daemon_auto.store.positions().find_by_id(pid_auto).await.unwrap().unwrap();
         assert!(
-            matches!(stored_auto.state, PositionState::Closed {
-                exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
-                ..
-            }),
+            matches!(
+                stored_auto.state,
+                PositionState::Closed {
+                    exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+                    ..
+                }
+            ),
             "AutoReconcile policy must close stale-active with real evidence"
         );
     }
@@ -2257,10 +2301,13 @@ mod tests {
         daemon.run_startup_auto_reconcile().await.unwrap();
 
         let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
-        assert!(matches!(stored.state, PositionState::Closed {
-            exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
-            ..
-        }));
+        assert!(matches!(
+            stored.state,
+            PositionState::Closed {
+                exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]
@@ -2274,21 +2321,27 @@ mod tests {
         daemon.store.positions().save(&position).await.unwrap();
 
         let now = chrono::Utc::now();
-        daemon.exchange.set_user_trades(&symbol.as_pair(), vec![user_trade(
-            "TRADE-1",
-            "EX-ORDER-2",
-            dec!(90),
-            dec!(0.010),
-            now,
-        )]);
+        daemon.exchange.set_user_trades(
+            &symbol.as_pair(),
+            vec![user_trade(
+                "TRADE-1",
+                "EX-ORDER-2",
+                dec!(90),
+                dec!(0.010),
+                now,
+            )],
+        );
 
         daemon.run_startup_auto_reconcile().await.unwrap();
 
         let stored = daemon.store.positions().find_by_id(pid).await.unwrap().unwrap();
-        assert!(matches!(stored.state, PositionState::Closed {
-            exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
-            ..
-        }));
+        assert!(matches!(
+            stored.state,
+            PositionState::Closed {
+                exit_reason: robson_domain::ExitReason::ReconciledMissingOnExchange,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]
@@ -2403,13 +2456,16 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(vec![input], vec![StartupStaleActiveInfo {
-                position_id: pid,
-                symbol: symbol.as_pair(),
-                side: "Long".to_string(),
-                quantity: dec!(0.010),
-                entry_price: Some(dec!(100)),
-            }])
+            .apply_startup_auto_reconcile_batch(
+                vec![input],
+                vec![StartupStaleActiveInfo {
+                    position_id: pid,
+                    symbol: symbol.as_pair(),
+                    side: "Long".to_string(),
+                    quantity: dec!(0.010),
+                    entry_price: Some(dec!(100)),
+                }],
+            )
             .await
             .unwrap_err();
 
@@ -2463,13 +2519,16 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(vec![input], vec![StartupStaleActiveInfo {
-                position_id: pid,
-                symbol: symbol.as_pair(),
-                side: "Long".to_string(),
-                quantity: dec!(0.010),
-                entry_price: Some(dec!(100)),
-            }])
+            .apply_startup_auto_reconcile_batch(
+                vec![input],
+                vec![StartupStaleActiveInfo {
+                    position_id: pid,
+                    symbol: symbol.as_pair(),
+                    side: "Long".to_string(),
+                    quantity: dec!(0.010),
+                    entry_price: Some(dec!(100)),
+                }],
+            )
             .await
             .unwrap_err();
 
@@ -2509,13 +2568,16 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(vec![input], vec![StartupStaleActiveInfo {
-                position_id: pid,
-                symbol: symbol.as_pair(),
-                side: "Long".to_string(),
-                quantity: dec!(0.010),
-                entry_price: Some(dec!(100)),
-            }])
+            .apply_startup_auto_reconcile_batch(
+                vec![input],
+                vec![StartupStaleActiveInfo {
+                    position_id: pid,
+                    symbol: symbol.as_pair(),
+                    side: "Long".to_string(),
+                    quantity: dec!(0.010),
+                    entry_price: Some(dec!(100)),
+                }],
+            )
             .await
             .unwrap_err();
 
@@ -2586,22 +2648,25 @@ mod tests {
         };
 
         let err = daemon
-            .apply_startup_auto_reconcile_batch(vec![input_a, input_b], vec![
-                StartupStaleActiveInfo {
-                    position_id: pid_a,
-                    symbol: symbol_a.as_pair(),
-                    side: "Long".to_string(),
-                    quantity: dec!(0.010),
-                    entry_price: Some(dec!(100)),
-                },
-                StartupStaleActiveInfo {
-                    position_id: pid_b,
-                    symbol: symbol_b.as_pair(),
-                    side: "Long".to_string(),
-                    quantity: dec!(0.010),
-                    entry_price: Some(dec!(100)),
-                },
-            ])
+            .apply_startup_auto_reconcile_batch(
+                vec![input_a, input_b],
+                vec![
+                    StartupStaleActiveInfo {
+                        position_id: pid_a,
+                        symbol: symbol_a.as_pair(),
+                        side: "Long".to_string(),
+                        quantity: dec!(0.010),
+                        entry_price: Some(dec!(100)),
+                    },
+                    StartupStaleActiveInfo {
+                        position_id: pid_b,
+                        symbol: symbol_b.as_pair(),
+                        side: "Long".to_string(),
+                        quantity: dec!(0.010),
+                        entry_price: Some(dec!(100)),
+                    },
+                ],
+            )
             .await
             .unwrap_err();
 

--- a/robsond/src/detector.rs
+++ b/robsond/src/detector.rs
@@ -409,7 +409,7 @@ impl DetectorTask {
     /// loop. Fetches candles from the OHLCV port, takes the last close as
     /// the reference price, and delegates to `create_signal` (which
     /// computes the technical stop).
-    async fn try_proactive_immediate_signal(&self) -> DaemonResult<DetectorSignal> {
+    pub(crate) async fn try_proactive_immediate_signal(&self) -> DaemonResult<DetectorSignal> {
         let candles = self
             .ohlcv_port
             .fetch_candles(&self.config.symbol, CandleInterval::FifteenMinutes, 100)

--- a/robsond/src/position_manager.rs
+++ b/robsond/src/position_manager.rs
@@ -23,9 +23,9 @@ use std::{collections::HashMap, sync::Arc};
 
 use chrono::Datelike;
 use robson_domain::{
-    ClosureEvidence, DetectorSignal, EntryPolicyConfig, Event, Position, PositionId, PositionState,
-    Price, Quantity, ReconciliationEvidence, RiskConfig, Side, Symbol, TechnicalStopDistance,
-    TradingPolicy,
+    ClosureEvidence, DetectorSignal, EntryPolicy, EntryPolicyConfig, Event, Position, PositionId,
+    PositionState, Price, Quantity, ReconciliationEvidence, RiskConfig, Side, Symbol,
+    TechnicalStopDistance, TradingPolicy,
 };
 use robson_engine::{
     Engine, EngineAction, EngineDecision, PositionSummary, ProposedTrade, RiskContext, RiskGate,
@@ -1213,16 +1213,9 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
                     query.fail(error.clone(), "acting".to_string());
                     self.record_query_failure(query).await?;
 
-                    // Rearm detector so the Armed position can receive future signals
-                    let position = self.store.positions().find_by_id(position_id).await?;
-                    if let Some(pos) = position {
-                        self.rearm_detector_after_governed_block(
-                            position_id,
-                            &pos,
-                            "exchange entry failed",
-                        )
-                        .await;
-                    }
+                    // Do not rearm after exchange placement failure. Timeout/transport
+                    // failures are ambiguous for MARKET orders and may have been accepted
+                    // by the exchange; reconciliation must resolve exchange/local drift.
                     return Err(DaemonError::Exec(ExecError::Exchange(error)));
                 },
                 ActionResult::EntryExecutionRejected { event, error } => {
@@ -1561,6 +1554,29 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
                 return Err(e);
             },
         };
+        if entry_policy.mode == EntryPolicy::Immediate {
+            let signal = detector.try_proactive_immediate_signal().await.map_err(|e| {
+                DaemonError::Detector(format!("immediate entry failed before execution: {}", e))
+            })?;
+            debug!(%position_id, "Immediate position armed; processing entry synchronously");
+
+            // Complete the ARM query before entering the PROCESS_SIGNAL query path.
+            if let Err(e) = query.complete(QueryOutcome::ActionsExecuted { actions_count }) {
+                query.fail(format!("{}", e), "acting".to_string());
+                self.record_query_failure(&query).await?;
+                return Err(DaemonError::Config(format!("Query completion error: {}", e)));
+            }
+            self.record_query_transition(&query, "completed").await?;
+
+            self.handle_signal(signal).await?;
+            return self
+                .store
+                .positions()
+                .find_by_id(position_id)
+                .await?
+                .ok_or(DaemonError::PositionNotFound(position_id));
+        }
+
         let handle = detector.spawn();
 
         // Store detector handle for cancellation
@@ -4636,6 +4652,35 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn test_arm_immediate_automatic_processes_entry_without_market_tick() {
+        use robson_domain::{ApprovalPolicy as DomainApprovalPolicy, EntryPolicy};
+
+        let manager = create_test_manager().await;
+        let symbol = Symbol::from_pair("BTCUSDT").unwrap();
+        let policy =
+            EntryPolicyConfig::new(EntryPolicy::Immediate, DomainApprovalPolicy::Automatic);
+
+        let position = manager
+            .arm_position_with_policy(
+                symbol,
+                Side::Long,
+                create_test_risk_config(),
+                None,
+                Uuid::now_v7(),
+                policy,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !matches!(position.state, PositionState::Armed),
+            "Immediate automatic arm must not remain waiting for a strategy signal"
+        );
+        let events = manager.store.events().find_by_position(position.id).await.unwrap();
+        assert!(events.iter().any(|event| matches!(event, Event::EntrySignalReceived { .. })));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn test_restore_armed_immediate_automatic_processes_first_market_tick() {
         use robson_domain::{ApprovalPolicy as DomainApprovalPolicy, EntryPolicy};
 
@@ -4650,15 +4695,27 @@ mod tests {
         let policy =
             EntryPolicyConfig::new(EntryPolicy::Immediate, DomainApprovalPolicy::Automatic);
 
-        let position = original_manager
-            .arm_position_with_policy(
-                symbol.clone(),
-                Side::Long,
-                create_test_risk_config(),
-                None,
-                Uuid::now_v7(),
-                policy,
-            )
+        let position_id = Uuid::now_v7();
+        let account_id = Uuid::now_v7();
+        let now = chrono::Utc::now();
+        original_manager
+            .execute_and_persist(vec![
+                EngineAction::EmitEvent(Event::PositionArmed {
+                    position_id,
+                    account_id,
+                    symbol: symbol.clone(),
+                    side: Side::Long,
+                    tech_stop_distance: None,
+                    timestamp: now,
+                }),
+                EngineAction::EmitEvent(Event::EntryPolicyResolved {
+                    position_id,
+                    entry_policy: policy.mode,
+                    approval_policy: policy.approval,
+                    strategy_id: StrategyRegistry::strategy_id_for_policy(policy.mode),
+                    timestamp: now,
+                }),
+            ])
             .await
             .unwrap();
 
@@ -4676,7 +4733,7 @@ mod tests {
 
         let restored_position = store
             .positions()
-            .find_by_id(position.id)
+            .find_by_id(position_id)
             .await
             .unwrap()
             .expect("armed position must survive restart");
@@ -4696,9 +4753,9 @@ mod tests {
 
         tokio::time::timeout(std::time::Duration::from_secs(1), async {
             loop {
-                let events = store.events().find_by_position(position.id).await.unwrap();
+                let events = store.events().find_by_position(position_id).await.unwrap();
                 if events.iter().any(|event| {
-                    matches!(event, Event::EntrySignalReceived { position_id, .. } if *position_id == position.id)
+                    matches!(event, Event::EntrySignalReceived { position_id: event_position_id, .. } if *event_position_id == position_id)
                 }) {
                     break;
                 }


### PR DESCRIPTION
## Summary
- Execute `EntryPolicy::Immediate` synchronously during arm after technical-stop analysis, so automatic immediate entries do not wait for a strategy/tick.
- Remove automatic retry/rearm behavior around ambiguous MARKET entry placement failures.
- Tighten exchange-authorship reconciliation so `Armed` does not mask real exchange exposure, and harden startup gate for `Armed` positions present on exchange.
- Share frontend status polling for near-realtime futures wallet/status.

## Root Cause
`Immediate` correctly mapped to no strategy, but the arm flow still spawned an async detector and returned `Armed` before the synthetic immediate signal was processed. A detector/market-data delay or stop-analysis failure could leave the FE appearing to wait. Separately, entry MARKET retries and detector rearm after exchange placement failure were unsafe because transport failures are ambiguous after order acceptance.

## Validation
- `npm run check` in `frontend`
- `cargo test -p robsond immediate -- --nocapture`
- `cargo test -p robsond startup_gate -- --nocapture`
- `cargo test -p robson-exec entry_order_failure_is_not_retried -- --nocapture`
- `cargo test -p robson-store find_active_by_symbol_and_side_excludes_armed -- --nocapture`
- `cargo test -p robson-exec -- --nocapture`
- `cargo test -p robson-store -- --nocapture`

## Notes
- No deploy performed by this PR creation step.
- Existing warning noise remains in unrelated crates.
