### PR TITLE
docs: align leverage policy with 1x operation

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -56,7 +56,7 @@ robson status --watch
 
 ```bash
 robson arm BTCUSDT --strategy all-in
-robson arm ETHUSDT --strategy all-in --capital 1000 --leverage 2
+robson arm ETHUSDT --capital 1000
 ```
 
 ### Emergency Close

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -74,12 +74,12 @@ Options:
   --strategy NAME     Strategy name (required)
                       Options: all-in, custom
   --capital AMOUNT    Capital to allocate (default: from config)
-  --leverage N        Leverage multiplier (1-10, default: 3)
+                      Leverage: fixed at 1x (not configurable; ADR-0024)
   --dry-run           Simulate without real orders
 
 Examples:
   robson arm BTCUSDT --strategy all-in
-  robson arm ETHUSDT --strategy all-in --capital 1000 --leverage 2
+  robson arm ETHUSDT --strategy all-in --capital 1000
   robson arm BTCUSDT --strategy all-in --dry-run
 ```
 
@@ -155,9 +155,9 @@ POSITIONS
 
 ID               Symbol    Side   State    Entry      SL         SG         PnL       Leverage
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-pos_01HQZXY123   BTCUSDT   Long   Active   $95,000    $93,500    $98,500    +$156.23  3x
-pos_01HQZXY456   ETHUSDT   Long   Armed    -          -          -          -         2x
-pos_01HQZXY789   BTCUSDT   Long   Closed   $94,000    $92,500    -          -$100.00  3x
+pos_01HQZXY123   BTCUSDT   Long   Active   $95,000    $93,500    $98,500    +$156.23  1x
+pos_01HQZXY456   ETHUSDT   Long   Armed    -          -          -          -         1x
+pos_01HQZXY789   BTCUSDT   Long   Closed   $94,000    $92,500    -          -$100.00  1x
 
 SUMMARY
   Active: 1
@@ -179,7 +179,7 @@ SUMMARY
       "stop_loss": 93500.0,
       "stop_gain": 98500.0,
       "quantity": 0.2001,
-      "leverage": 3,
+      "leverage": 1,
       "unrealized_pnl": 156.23,
       "palma": {
         "distance": 1500.0,
@@ -197,6 +197,8 @@ SUMMARY
   }
 }
 ```
+
+> **Note**: `leverage` is informational only — fixed at 1x, not a configurable parameter (ADR-0024).
 
 ---
 
@@ -519,7 +521,7 @@ color = true
 
 [risk]
 default_capital = 10000.0
-default_leverage = 3
+# Leverage is fixed at 1x (not configurable); margin availability is the physical bound (ADR-0024).
 # Position count is governed by ADR-0024 dynamic slots in robsond.
 # Legacy max_open_positions is not enforced by RiskGate.
 

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -136,7 +136,7 @@ impl Position {
 ```
 
 **Key Design Notes**:
-- No `leverage` field (fixed 10x for Binance isolated margin)
+- No `leverage` field (fixed 1x; margin availability is the physical bound)
 - No `stop_gain` field (trailing stop handles exits)
 - `tech_stop_distance` captures the risk distance
 
@@ -269,7 +269,7 @@ impl RiskConfig {
 }
 ```
 
-**Design Note**: No `max_leverage` - leverage is fixed at 10x.
+**Design Note**: No `max_leverage` - leverage is fixed at 1x (margin availability is the physical bound).
 
 ### Price
 
@@ -657,7 +657,7 @@ pub struct RiskConfig {
 ```
 
 **Removed from original design**:
-- `max_leverage` - Fixed at 10x (Binance isolated margin)
+- `max_leverage` - Fixed at 1x (margin availability is the physical bound)
 - `insurance_stop_enabled` - No insurance stops in v2
 
 ### Risk Checks (Future: Phase 5)

--- a/docs/EXECUTION-PLAN.md
+++ b/docs/EXECUTION-PLAN.md
@@ -70,7 +70,7 @@ The original design had separate stop_loss and stop_gain. The implementation use
 
 Leverage was removed as a configurable parameter:
 - **Old**: `Leverage(u8)` value object with 1-10x range
-- **New**: Fixed 10x leverage (Binance isolated margin default)
+- **New**: Fixed 1x leverage (margin availability is the physical bound, ADR-0024)
 
 **Rationale**: Simplifies position sizing. Risk is controlled by position size, not leverage.
 
@@ -143,7 +143,7 @@ The original design had a backup stop on exchange. Removed for simplicity:
 | Original | Implemented | Reason |
 |----------|-------------|--------|
 | `PalmaDaMao` | `TechnicalStopDistance` | Clearer naming |
-| `Leverage(u8)` | Removed (fixed 10x) | Simplification |
+| `Leverage(u8)` | Removed (fixed 1x) | Simplification |
 | `stop_gain: Price` | Trailing stop in Active state | Better exit strategy |
 | `Trade` entity | Merged into `Order` | Market orders fill immediately |
 
@@ -854,8 +854,8 @@ cargo test --all               # 92 tests currently
    - `disarm()` → DELETE /positions/:id
    - (status and panic already aligned)
 
-2. **Add isolated margin safety check** in executor/connector:
-   - Assert leverage=10x and isolated mode before order execution
+2. **Add futures settings safety check** in executor/connector:
+   - Assert One-way mode and leverage=1x before order execution
    - Fail-safe if account is not in expected state
 
 3. **Complete signal orchestration** in PositionManager:

--- a/docs/PROMPT-PACK.md
+++ b/docs/PROMPT-PACK.md
@@ -229,12 +229,12 @@ Add position sizing logic to Position in robson-domain/src/entities/position.rs:
    - Input: entry_price, stop_loss
    - Calculate palma distance
    - Use formula: (capital × risk_pct) / palma_distance
-   - Apply leverage multiplier
+   - Leverage is fixed at 1x (no multiplier; notional == initial margin)
    - Return Quantity
 
 2. Add validate_notional() method:
    - Check min notional ($10)
-   - Check max notional (capital × leverage)
+   - Check max notional against available margin (capital at 1x)
 
 3. Add round_to_precision() helper:
    - Round to exchange precision (8 decimals for BTC)
@@ -242,7 +242,7 @@ Add position sizing logic to Position in robson-domain/src/entities/position.rs:
 4. Add tests:
    - Test sizing calculation (capital $10k, risk 1%, palma $1500 → 0.0666... BTC)
    - Test notional validation
-   - Test leverage multiplication
+   - Test margin bound rejection (notional > capital at 1x)
 
 Validation:
 ```bash

--- a/docs/SMOKE-TEST.md
+++ b/docs/SMOKE-TEST.md
@@ -14,7 +14,7 @@ This document provides a **copy/paste operational smoke test** to validate the R
 - CLI ↔ Daemon communication
 - Position state transitions (Armed → Entering → Active → Closed)
 - Signal orchestration (detector → engine → executor)
-- Margin safety validation (isolated + 10x leverage)
+- Futures settings validation (One-way mode + 1x leverage)
 - Golden Rule position sizing
 - Trailing stop behavior
 - Panic mode
@@ -336,36 +336,36 @@ Verify these invariants hold true during smoke test execution.
 
 ### Leverage Invariant
 
-**Invariant**: All positions use fixed 10x leverage (isolated margin).
+**Invariant**: All positions use fixed 1x leverage in One-way mode; margin availability is the physical bound (ADR-0024).
 
 **How to Verify**:
 
 ```bash
-# Check daemon logs for margin validation
-# Look for: "Validating margin settings (isolated + 10x)"
+# Check daemon logs for futures settings validation
+# Look for: "Validating futures settings (One-way + 1x)"
 
 # Or inspect code constant:
-grep -r "FIXED_LEVERAGE" robson-exec/src/executor.rs
-# Output: pub const FIXED_LEVERAGE: u8 = 10;
+grep -n "LEVERAGE" robson-domain/src/value_objects.rs
+# Output: pub const LEVERAGE: u8 = 1;
 ```
 
-**Expected**: Always 10x, never configurable in MVP.
+**Expected**: Always 1x, never configurable.
 
 ---
 
 ### Margin Safety Invariant
 
-**Invariant**: Margin validation occurs BEFORE entry and BEFORE exit.
+**Invariant**: Futures settings validation occurs BEFORE entry and BEFORE exit.
 
 **How to Verify**:
 
 ```bash
 # In daemon logs during entry (T2), look for:
-# "Validating margin settings (isolated + 10x)"
-# "Margin safety check passed"
+# "Validating futures settings (One-way + 1x)"
+# "Futures settings verified: One-way mode confirmed, leverage set"
 
 # During exit (T3), look for:
-# "Validating margin settings for exit (isolated + 10x)"
+# "Validating futures settings for exit (One-way + 1x)"
 ```
 
 **Expected**: Validation runs for every order placement, never bypassed.
@@ -555,7 +555,7 @@ curl http://localhost:8080/status | jq
 |-------|----------|
 | Stop loss above entry (for LONG) | Ensure stop < entry for LONG positions |
 | Stop loss below entry (for SHORT) | Ensure stop > entry for SHORT positions |
-| Insufficient capital for 10x leverage | Increase --capital amount |
+| Insufficient capital for 1x position (margin bound) | Increase --capital amount |
 | StubExchange returns invalid margin | This is a bug, report it |
 
 **Debug Commands**:

--- a/docs/architecture/v3-architectural-decisions.md
+++ b/docs/architecture/v3-architectural-decisions.md
@@ -574,7 +574,7 @@ Robson's PnL model is authoritative for **risk gate decisions only**. It is not 
 
 **Rejected**: Continuing with implicit behavior (current state before this ADR) — implicit assumptions about fees and pricing source make correctness analysis impossible.
 
-**Fees deduction**: `build_risk_context()` sums `realized_pnl - fees_paid` from closed positions. MonthlyHalt triggers on net PnL (gross minus fees). At 1% risk per trade with typical 0.04% commission (entry + exit × 10x leverage ≈ 0.8% per cycle in fees), fees are material and correctly accounted for in the drawdown calculation.
+**Fees deduction**: `build_risk_context()` sums `realized_pnl - fees_paid` from closed positions. MonthlyHalt triggers on net PnL (gross minus fees). At 1% risk per trade with typical 0.04% commission (entry + exit at 1x leverage ≈ 0.08% per cycle in fees), fees are material and correctly accounted for in the drawdown calculation.
 
 **Breaks if wrong**: If fees are material and not deducted, the system may allow more capital loss than the 4% policy intends. Conversely, if fees are double-counted in a future correction, MonthlyHalt could trigger prematurely. Fix must be validated with real exchange data.
 

--- a/robson-domain/src/entities.rs
+++ b/robson-domain/src/entities.rs
@@ -224,7 +224,7 @@ pub fn calculate_notional_value(quantity: &Quantity, entry_price: &Price) -> rus
 
 /// Calculate margin required for position
 ///
-/// Margin = Notional / Leverage = Notional / 10
+/// Margin = Notional / Leverage = Notional / 1 (integral margin at 1x)
 pub fn calculate_margin_required(
     quantity: &Quantity,
     entry_price: &Price,

--- a/robson-exec/src/ports.rs
+++ b/robson-exec/src/ports.rs
@@ -107,7 +107,7 @@ pub trait ExchangePort: Send + Sync {
     /// # Arguments
     ///
     /// * `symbol` - Trading pair to check
-    /// * `expected_leverage` - Expected leverage multiplier (e.g., 10)
+    /// * `expected_leverage` - Expected leverage multiplier (e.g., 1)
     ///
     /// # Returns
     ///


### PR DESCRIPTION
## Summary
- Align active CLI/runbook/domain docs with fixed 1x leverage policy.
- Remove stale operator-facing references to configurable `--leverage`, default leverage, fixed 10x, and obsolete FIXED_LEVERAGE examples.
- Update code comments to describe 1x integral-margin behavior without changing runtime logic.

## Verification
- `cargo +nightly fmt --all --check`
- `cargo test --all --no-fail-fast`
- `cargo clippy --all-targets -- -D clippy::correctness -D clippy::suspicious`
- `git diff --check`

## Notes
- Runtime behavior is unchanged.
- Historical/audit docs retaining old 10x references were intentionally preserved as point-in-time records.
