### PR TITLE
[codex] reduce redundant frontend polling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ CI must pass the first two tiers unconditionally. The third tier requires a prov
 
 These are architectural constraints that MUST NOT be violated by any agent or human:
 
-10. **No static exposure hard limits.** `max_open_positions`, `max_total_exposure_pct`, and `max_single_position_pct` were eliminated in MIG-v3#11 (ADR-0024). The only static constraint is `risk_per_trade_pct = 1%` and `max_monthly_drawdown_pct = 4%` of `capital_base`. Slot availability governs entry capacity. There is no daily loss limit. Funding rate does not determine exposure limits in long positions.
+10. **No static exposure hard limits.** `max_open_positions`, `max_total_exposure_pct`, and `max_single_position_pct` were eliminated in MIG-v3#11 (ADR-0024). The only static constraint is `risk_per_trade_pct = 1%` as a maximum-loss cap and `max_monthly_drawdown_pct = 4%` of `capital_base`. Slot availability governs entry capacity. There is no daily loss limit. Funding rate does not determine exposure limits in long positions. Realized risk may be lower when available margin caps the position size.
 11. **`Estimated` evidence is permanently blocked in `reconcile_close`.** Only `OrderFillRecord` and `UserTradeRecord` are accepted for automated reconciled closes. If evidence is unavailable, the daemon aborts startup and requires manual operator intervention via `robson-cli reconcile-close`.
 12. **No LLM, no autonomous trading.** v3 has zero LLM coupling. The operator decides WHEN to trade. Robson decides HOW MUCH and enforces THAT risk rules are never violated. QE-P5 (Context Governance) is deferred to v4.
 

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -538,18 +538,20 @@ Position Size = Max Risk Amount / Tech Stop Distance
 ```rust
 pub fn calculate_position_size(
     risk_config: &RiskConfig,
+    entry_price: &Price,
     tech_stop: &TechnicalStopDistance,
 ) -> Result<Quantity, DomainError> {
     // 1. Validate tech stop
     tech_stop.validate()?;
 
-    // 2. Calculate max risk amount
+    // 2. Calculate max risk amount and 1x margin cap
     let max_risk = risk_config.max_risk_amount();
+    let risk_sized_qty = max_risk / tech_stop.distance();
+    let margin_sized_qty =
+        (risk_config.capital() * Decimal::from(RiskConfig::LEVERAGE)) / entry_price.as_decimal();
+    let size = risk_sized_qty.min(margin_sized_qty);
 
-    // 3. Calculate position size
-    let size = max_risk / tech_stop.distance();
-
-    // 4. Validate minimum
+    // 3. Validate minimum
     if size < Decimal::from_str("0.00001")? {
         return Err(DomainError::PositionSizingError("Size too small"));
     }

--- a/docs/adr/ADR-0007-robson-is-risk-assistant-not-autotrader.md
+++ b/docs/adr/ADR-0007-robson-is-risk-assistant-not-autotrader.md
@@ -37,8 +37,8 @@ This decision fundamentally shapes:
 - Set entry and stop levels
 
 **Robson's responsibilities**:
-- Calculate position size (1% risk rule)
-- Validate risk limits (drawdown, exposure)
+- Calculate position size (1% loss cap)
+- Validate risk limits (drawdown, margin)
 - Monitor stops 24/7
 - Execute stops automatically (safety)
 - Track performance per strategy

--- a/docs/adr/ADR-0024-trading-policy-layer.md
+++ b/docs/adr/ADR-0024-trading-policy-layer.md
@@ -43,7 +43,7 @@ variables, operator API, or any runtime mechanism.
 
 | Policy | Value | Rationale |
 |--------|-------|-----------|
-| risk_per_trade_pct | 1% | Golden Rule anchor: position is sized so that 1 span of loss = 1% of capital |
+| risk_per_trade_pct | 1% max | Golden Rule cap: position is sized so stop loss never exceeds 1% of capital; margin may reduce realized risk below the cap |
 | max_monthly_drawdown_pct | 4% | 4 consecutive losses × 1% = 4%; after 4 errors in a month the user is blocked |
 
 ### 3. Technical Stop Configuration (Configurable)
@@ -66,9 +66,11 @@ eliminated as independent configuration parameters.
 
 The single-position physical bound is margin availability at fixed 1x leverage: the
 stop-derived notional must fit available capital before exchange submission. Position
-sizing via the Golden Rule still targets 1% technical-stop risk, but tight stops may
-produce a notional larger than available capital; those trades are policy-invalid and
-must be rejected or resized by an explicit future policy, never made viable by leverage.
+sizing via the Golden Rule uses 1% as a maximum loss cap; tight stops may produce a
+risk-sized quantity that exceeds available capital, so the final quantity is capped by
+margin and the realized risk may be below 1%. If a trade still cannot fit after capping
+and exchange filters, it is policy-invalid and must be rejected, never made viable by
+leverage.
 
 The duplicate-position guard (no same symbol+side) is preserved as an operational
 constraint, not a risk limit.

--- a/docs/architecture/v3-architectural-decisions.md
+++ b/docs/architecture/v3-architectural-decisions.md
@@ -77,7 +77,7 @@ CREATE TABLE event_log (
 **Rejected**: Advisory mode (log-only), Hybrid (advisory for low-risk, blocking for high-risk)
 
 **Rationale**:
-- A single trade exceeding 1% risk can wipe 1% of capital. This is not a "log and investigate" scenario.
+- A single trade whose stop-derived loss exceeds the 1% cap can wipe 1% of capital. This is not a "log and investigate" scenario.
 - Advisory mode creates a false sense of safety — risk violations are detected but not prevented
 - Hybrid mode (advisory for low-risk) introduces complexity in categorizing risk levels, with the dangerous possibility of miscategorization letting a high-risk action through as "low-risk"
 - The GovernedAction pattern (Rust type that can only be constructed by Runtime after Risk Engine approval) makes bypass impossible at compile time
@@ -472,22 +472,22 @@ See [v3-query-query-engine.md §11](v3-query-query-engine.md) for details.
 
 ---
 
-### ADR-v3-022: Fixed 1% Risk Per Trade — Non-Configurable
+### ADR-v3-022: Max 1% Loss Per Trade — Non-Configurable
 
 **Date**: 2026-04-11
 **Status**: DECIDED — implemented
 
-**Context**: In v2, `risk_per_trade_pct` was a configurable field in `RiskConfig`, settable via the `ArmRequest` API parameter and the `ROBSON_DEFAULT_RISK_PERCENT` environment variable. This created multiple paths to override a critical safety parameter. The operator's trading methodology prescribes exactly 1% risk per trade — no exceptions, no market-condition adjustments, no operator override.
+**Context**: In v2, `risk_per_trade_pct` was a configurable field in `RiskConfig`, settable via the `ArmRequest` API parameter and the `ROBSON_DEFAULT_RISK_PERCENT` environment variable. This created multiple paths to override a critical safety parameter. The operator's trading methodology now treats 1% as a maximum loss cap per trade: the stop-derived risk must not exceed 1% of capital, and realized risk may be lower when available 1x margin caps the position size.
 
-**Decision**: Risk per trade is a compile-time constant (`RiskConfig::RISK_PER_TRADE_PCT = 1`). All configuration paths are removed.
+**Decision**: Risk per trade remains a compile-time constant (`RiskConfig::RISK_PER_TRADE_PCT = 1`) as a maximum-loss cap. All configuration paths are removed.
 
-**Chose**: Hard-coded constant, zero configuration surface
+**Chose**: Hard-coded cap, zero configuration surface
 **Rejected**: Configurable with default (leaves override path open); Environment variable with validation (still overridable); Per-trade parameter (highest risk — ad-hoc decisions under pressure)
 
 **Rationale**:
-- The 1% rule is the foundation of the position sizing Golden Rule: `position_size = (capital × 0.01) / stop_distance`. Making it configurable means every trade is an opportunity to deviate under emotional pressure.
+- The 1% cap is the foundation of the position sizing Golden Rule: `position_size = min((capital × 0.01) / stop_distance, capital / entry_price)`. Making it configurable means every trade is an opportunity to deviate under emotional pressure.
 - Removing the configuration surface eliminates an entire class of operator error. The system cannot be told to risk more.
-- If the operator's methodology changes (e.g., 0.5% per trade), the constant is updated in code, reviewed, tested, and deployed — a deliberate process, not a runtime decision.
+- If the operator's methodology changes (e.g., 0.5% cap per trade), the constant is updated in code, reviewed, tested, and deployed — a deliberate process, not a runtime decision.
 
 **Changes made**:
 - `RiskConfig` constructor: `new(capital, risk_pct)` → `new(capital)` (field removed, constant added)
@@ -574,7 +574,7 @@ Robson's PnL model is authoritative for **risk gate decisions only**. It is not 
 
 **Rejected**: Continuing with implicit behavior (current state before this ADR) — implicit assumptions about fees and pricing source make correctness analysis impossible.
 
-**Fees deduction**: `build_risk_context()` sums `realized_pnl - fees_paid` from closed positions. MonthlyHalt triggers on net PnL (gross minus fees). At 1% risk per trade with typical 0.04% commission (entry + exit at 1x leverage ≈ 0.08% per cycle in fees), fees are material and correctly accounted for in the drawdown calculation.
+**Fees deduction**: `build_risk_context()` sums `realized_pnl - fees_paid` from closed positions. MonthlyHalt triggers on net PnL (gross minus fees). At a 1% loss cap per trade with typical 0.04% commission (entry + exit at 1x leverage ≈ 0.08% per cycle in fees), fees are material and correctly accounted for in the drawdown calculation.
 
 **Breaks if wrong**: If fees are material and not deducted, the system may allow more capital loss than the 4% policy intends. Conversely, if fees are double-counted in a future correction, MonthlyHalt could trigger prematurely. Fix must be validated with real exchange data.
 

--- a/docs/architecture/v3-risk-engine-spec.md
+++ b/docs/architecture/v3-risk-engine-spec.md
@@ -36,12 +36,13 @@ always safe) and is tagged `UNTRACKED_ON_EXCHANGE` in the audit trail.
 
 These decisions are final for v3. No alternatives, no overrides, no flexibility.
 
-### 1. Risk Per Trade: Fixed 1%
+### 1. Risk Per Trade: Max 1% Loss
 
-- Every position risks exactly **1% of total capital**.
-- Position size is derived from the technical stop distance (Golden Rule).
-- Formula: `position_size = (capital × 0.01) / stop_distance`
+- Every position is sized so its stop loss is capped at **1% of total capital**.
+- Position size is derived from the technical stop distance (Golden Rule) and capped by available 1x margin.
+- Formula: `position_size = min((capital × 0.01) / stop_distance, capital / entry_price)`
 - This is not configurable. There is no environment variable, API parameter, or mode selector.
+- Realized loss may be below 1% when margin availability is the binding constraint.
 
 ### 2. Monthly Drawdown: 4% Hard Halt
 

--- a/docs/implementation/AGENTIC-WORKFLOW-FRONTEND-IMPLEMENTATION.md
+++ b/docs/implementation/AGENTIC-WORKFLOW-FRONTEND-IMPLEMENTATION.md
@@ -202,7 +202,7 @@ Authorization: Bearer ${authTokens.access}
 3. **Position size preview appears**
    - Calculates: (10000 × 0.01) / |50000 - 48000| = 0.05 BTC
    - Shows: "Calculated Position Size: 0.05000000 BTC"
-   - Shows: "Based on 1% risk rule: risking $100.00 on this trade"
+   - Shows: "Based on 1% loss cap: risking up to $100.00 on this trade"
 
 4. **User clicks "Create Plan"**
    - Button shows "Creating Plan..." with spinner

--- a/docs/policies/SYMBOL-AGNOSTIC-POLICIES.md
+++ b/docs/policies/SYMBOL-AGNOSTIC-POLICIES.md
@@ -92,9 +92,9 @@ The rules below are symbol-agnostic by construction and must remain so:
 
 | Rule | Statement | Notes |
 |---|---|---|
-| 1% risk per trade | `risk_amount = capital × 0.01` | Capital is in quote-asset-neutral units (USD equivalent) |
+| 1% loss cap per trade | `risk_amount = capital × 0.01` | Capital is in quote-asset-neutral units (USD equivalent); realized risk may be lower when margin caps size |
 | 4% monthly drawdown | `MonthlyPnL ≤ −(capital × 0.04)` | Aggregated across all symbols |
-| Position size (Golden Rule) | `size = risk_amount / abs(entry − tech_stop)` | Works for any symbol |
+| Position size (Golden Rule) | `size = min(risk_amount / abs(entry − tech_stop), capital / entry)` | Works for any symbol |
 | Span (palmo) | `span = abs(entry_price − technical_stop)` | Symbol-neutral; stop is chart-derived |
 | Hand-Span Trailing Stop | Stop advances in integer multiples of `span` | Monotonic, per-position |
 | Technical Stop Distance | Second support (LONG) / resistance (SHORT) on 15m chart | Chart-derived, not percentage |

--- a/docs/requirements/CRITICAL-REQUIREMENTS-DASHBOARD.md
+++ b/docs/requirements/CRITICAL-REQUIREMENTS-DASHBOARD.md
@@ -126,7 +126,7 @@
 ---
 
 ### Rule #2: Position Size from Stop Distance
-**Rule**: Position size MUST be calculated from stop distance (1% risk)
+**Rule**: Position size MUST be calculated from stop distance (1% loss cap)
 
 **Enforcement Points**:
 1. CLI shows calculated size, user confirms

--- a/docs/requirements/POSITION-SIZING-GOLDEN-RULE.md
+++ b/docs/requirements/POSITION-SIZING-GOLDEN-RULE.md
@@ -16,10 +16,10 @@
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                                                                 │
-│    Position Size = Max Risk Amount / Technical Stop Distance    │
+│    Risk-sized qty = Max Risk Amount / Technical Stop Distance   │
 │                                                                 │
 │    Where:                                                       │
-│    • Max Risk Amount = Capital × 1%                             │
+│    • Max Risk Amount = Capital × 1% (maximum loss cap)          │
 │    • Technical Stop Distance = |Entry Price - Technical Stop|   │
 │    • Technical Stop = 2nd Support Level (from chart analysis)   │
 │                                                                 │
@@ -42,6 +42,9 @@ Step 2: CALCULATE STOP DISTANCE
         │
         └── Stop Distance = |Entry - Technical Stop|
         └── This is in PRICE UNITS (e.g., $950)
+        └── qty_by_risk = Max Risk / Stop Distance
+        └── qty_by_margin = Capital / Entry Price
+        └── Final qty = min(qty_by_risk, qty_by_margin)
         │
         ▼
 Step 3: DETERMINE MAX RISK AMOUNT
@@ -53,7 +56,7 @@ Step 3: DETERMINE MAX RISK AMOUNT
 Step 4: DERIVE POSITION SIZE
         │
         └── Position Size = Max Risk / Stop Distance
-        └── This ensures you lose EXACTLY 1% if stopped
+        └── This ensures you lose at most 1% if stopped
         │
         ▼
 Step 5: EXECUTE ORDER
@@ -79,7 +82,7 @@ CALCULATE:
 
 RESULT:
   • You buy 0.0667 BTC for $6,333.33
-  • If stopped at $93,500, you lose $100 (exactly 1%)
+  • If stopped at $93,500, you lose at most $100 (up to 1%)
   • Position is sized FOR the stop, not despite it
 ```
 
@@ -103,18 +106,18 @@ This is correct. The stop drives the position size.
 If the 2nd support is far away:
 - Stop Distance is large
 - Position Size is small
-- Risk is still 1%
+- Risk stays within the cap
 
 ### 2. Tight Stop = Larger Position
 If the 2nd support is close:
 - Stop Distance is small
 - Position Size is larger
-- Risk is still 1%
+- Risk stays within the cap
 
-### 3. Risk is CONSTANT
+### 3. Risk is CAPPED
 No matter the stop distance:
-- You always risk exactly 1% of capital
-- The position size adjusts to match
+- You risk at most 1% of capital
+- The position size adjusts to fit both stop distance and available margin
 
 ---
 
@@ -173,7 +176,7 @@ There is NO way to place a trade in Robson without:
 |---------|--------|
 | Technical Stop | Chart analysis (2nd support) |
 | Stop Distance | Calculated from stop |
-| Max Risk | 1% of capital (constant) |
+| Max Risk | Up to 1% of capital (maximum loss cap) |
 | Position Size | **DERIVED** from stop distance |
 
 **The stop comes FIRST. Everything else follows.**

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -258,7 +258,7 @@ REQ-FUT-XXX-001: Description
 ### Feature Requirements
 - [Isolated Margin Trading](isolated-margin-requirements.md) - Leveraged trading with risk management
 - [Technical Stop Rule](technical-stop-requirements.md) - Stop-loss derived from chart analysis
-- [Position Sizing Golden Rule](POSITION-SIZING-GOLDEN-RULE.md) - 1% risk per trade
+- [Position Sizing Golden Rule](POSITION-SIZING-GOLDEN-RULE.md) - 1% loss cap per trade
 - [Strategy Semantic Clarity](STRATEGY-SEMANTIC-CLARITY.md) - User-driven strategy selection
 - [BALANCE Mode](balance-mode-requirements.md) - Dynamic capital from exchange balance
 

--- a/docs/requirements/STRATEGY-SEMANTIC-CLARITY.md
+++ b/docs/requirements/STRATEGY-SEMANTIC-CLARITY.md
@@ -77,9 +77,9 @@ When user says: *"I want to buy BTC with 2% stop-loss using Mean Reversion strat
 - Strategy context: Mean Reversion
 
 **Robson calculates** (the intelligence):
-- Maximum position size that risks exactly 1% of capital
+- Maximum position size that keeps loss at or below the 1% cap
 - Order quantity with proper precision
-- Validates against total exposure limits
+- Validates against available margin and monthly drawdown
 - Confirms monthly drawdown is within 4% limit
 
 **Example**:
@@ -105,8 +105,8 @@ Robson Calculates:
 
 ### What Robson Does
 
-1. **Calculates** optimal position size (1% risk rule)
-2. **Validates** against risk limits (drawdown, exposure)
+1. **Calculates** optimal position size (1% loss cap)
+2. **Validates** against risk limits (drawdown, margin)
 3. **Monitors** stops automatically (24/7 monitoring)
 4. **Executes** stops when triggered (safety automation)
 5. **Tracks** performance per strategy (analytics)
@@ -283,7 +283,7 @@ strategy.config = {
    - Entry: $90,000 (current price)
    - Stop: $88,200 (technical support level - user's analysis)
 4. **Robson calculates**:
-   - Quantity: 0.00555556 BTC (1% risk)
+   - Quantity: 0.00555556 BTC (1% cap)
    - Position value: $500
    - Risk amount: $10
 5. User reviews calculation, confirms

--- a/docs/requirements/balance-mode-requirements.md
+++ b/docs/requirements/balance-mode-requirements.md
@@ -318,7 +318,7 @@ assert preview_quantity == persisted_quantity
 
 ### Related Documents
 
-- [Position Sizing Golden Rule](POSITION-SIZING-GOLDEN-RULE.md) - 1% risk rule
+- [Position Sizing Golden Rule](POSITION-SIZING-GOLDEN-RULE.md) - 1% loss cap
 - [Strategy Semantic Clarity](STRATEGY-SEMANTIC-CLARITY.md) - User-driven strategy selection
 - [Technical Stop Requirements](technical-stop-requirements.md) - Stop-loss derivation
 

--- a/docs/requirements/isolated-margin-requirements.md
+++ b/docs/requirements/isolated-margin-requirements.md
@@ -253,7 +253,7 @@ Robson monitors price and executes the exit to ensure reliability.
 
 #### REQ-FUT-MARGIN-008: Position Sizing for Margin
 
-**Description**: System must calculate optimal position size for margin trades using the 1% risk rule, accounting for leverage.
+**Description**: System must calculate optimal position size for margin trades using the 1% loss cap, accounting for leverage and available margin.
 
 **Rationale**: Core Robson intelligence - protecting user capital.
 
@@ -266,7 +266,7 @@ Robson monitors price and executes the exit to ensure reliability.
 **Estimated Complexity**: Moderate
 
 **Acceptance Criteria**:
-- [ ] Calculate position size where max loss = 1% of total capital
+- [ ] Calculate position size where max loss is capped at 1% of total capital
 - [ ] Account for leverage in margin calculations
 - [ ] Ensure margin allocated <= available margin
 - [ ] Warn if position would approach liquidation
@@ -275,13 +275,14 @@ Robson monitors price and executes the exit to ensure reliability.
 **Formula**:
 ```
 Capital = Isolated Margin Equity (quote net + base net * price)
-Risk Amount = Capital × 0.01 (1% rule)
+Max Risk Amount = Capital × 0.01 (1% cap)
 Stop Distance = |Entry Price - Stop Price|
-Base Quantity = Risk Amount / Stop Distance
+Risk-Sized Quantity = Max Risk Amount / Stop Distance
+Margin-Sized Quantity = Available Margin × Leverage / Entry Price
+Final Quantity = min(Risk-Sized Quantity, Margin-Sized Quantity)
 
-Margin Required = (Base Quantity × Entry Price) / Leverage
-If Margin Required > Available Margin:
-    Reduce position proportionally
+If Final Quantity would still violate exchange filters:
+    Reject the trade
 ```
 
 ---

--- a/docs/requirements/technical-stop-requirements.md
+++ b/docs/requirements/technical-stop-requirements.md
@@ -88,7 +88,7 @@ Position Value = 0.0667 × $95,000 = $6,333.33
          ▼
 3. ROBSON calculates position size
    - Uses technical stop distance
-   - Applies 1% risk rule
+   - Applies 1% loss cap
    - Returns safe quantity
          │
          ▼

--- a/docs/specs/TECHNICAL-STOP-RULE.md
+++ b/docs/specs/TECHNICAL-STOP-RULE.md
@@ -28,14 +28,14 @@
 5. System calculates stop distance (entry_price - stop_price)
    ↓
 6. System calculates position size:
-   - Max loss = 1% of total capital
-   - Position size = (capital × 0.01) / stop_distance
+   - Max loss = up to 1% of total capital
+   - Position size = min((capital × 0.01) / stop_distance, capital / entry_price)
    ↓
 7. System presents to user:
    - Entry price: $X
    - Technical stop: $Y (distance: Z%)
    - Position size: N units ($M value)
-   - Max loss: $L (1% of capital)
+   - Max loss: $L (1% cap)
    ↓
 8. User confirms or adjusts
    ↓

--- a/docs/specs/features/isolated-margin-spec.md
+++ b/docs/specs/features/isolated-margin-spec.md
@@ -846,7 +846,7 @@ class OpenMarginPositionUseCase:
     Flow:
     1. Validate inputs (symbol, side, stop price)
     2. Get current margin account status
-    3. Calculate position size using 1% risk rule
+    3. Calculate position size using 1% loss cap
     4. Transfer required margin from Spot (if needed)
     5. Place market order
     6. Place stop-loss order

--- a/frontend/src/lib/api/robson.ts
+++ b/frontend/src/lib/api/robson.ts
@@ -371,6 +371,7 @@ export class ApiError extends Error {
 export function connectEventStream(
   onEvent: (event: SseEvent) => void,
   onError?: (err: Event) => void,
+  onReconnect?: () => void,
 ): () => void {
   if (!browser) return () => {};
 
@@ -384,7 +385,7 @@ export function connectEventStream(
     }
   ).__RBX_EVENT_SOURCE_FACTORY__;
 
-  const source = factory ? factory(url) : new FetchEventSource(url, token);
+  const source = factory ? factory(url) : new FetchEventSource(url, token, onReconnect);
 
   source.onmessage = (msg) => {
     try {
@@ -400,20 +401,38 @@ export function connectEventStream(
   return () => source.close();
 }
 
-/** Fetch-based SSE client — sends Bearer token via header, not query param. */
-class FetchEventSource implements EventSourceLike {
+/** Fetch-based SSE client — sends Bearer token via header, not query param.
+ *  Reconnects automatically with exponential backoff on any disconnect. */
+export class FetchEventSource implements EventSourceLike {
   onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null;
   onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
 
   private controller = new AbortController();
+  private retries = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly MAX_RECONNECT_MS = 30_000;
 
-  constructor(url: string, token: string | null) {
+  constructor(
+    url: string,
+    token: string | null,
+    private readonly onReconnect?: () => void,
+  ) {
     this.connect(url, token);
   }
 
+  private scheduleReconnect(url: string, token: string | null): void {
+    if (this.controller.signal.aborted) return;
+    const delay = Math.min(1_000 * 2 ** this.retries, FetchEventSource.MAX_RECONNECT_MS);
+    this.retries++;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (!this.controller.signal.aborted) this.connect(url, token);
+    }, delay);
+  }
+
   private async connect(url: string, token: string | null): Promise<void> {
-    const headers: Record<string, string> = { Accept: "text/event-stream" };
-    if (token) headers["Authorization"] = `Bearer ${token}`;
+    const headers: Record<string, string> = { Accept: `text/event-stream` };
+    if (token) headers[`Authorization`] = `Bearer ${token}`;
 
     try {
       const res = await fetch(url, {
@@ -421,23 +440,29 @@ class FetchEventSource implements EventSourceLike {
         signal: this.controller.signal,
       });
       if (!res.ok || !res.body) {
-        this.onerror?.call({} as EventSource, new Event("error"));
+        this.onerror?.call({} as EventSource, new Event(`error`));
+        this.scheduleReconnect(url, token);
         return;
       }
 
       const reader = res.body.getReader();
+      if (this.retries > 0) this.onReconnect?.();
+      this.retries = 0; // reset backoff on successful stream start
       const decoder = new TextDecoder();
-      let buf = "";
+      let buf = ``;
 
       while (true) {
         const { done, value } = await reader.read();
-        if (done) break;
+        if (done) {
+          this.scheduleReconnect(url, token);
+          break;
+        }
 
         buf += decoder.decode(value, { stream: true });
 
         // SSE events are separated by blank lines (\n\n)
         let boundary: number;
-        while ((boundary = buf.indexOf("\n\n")) !== -1) {
+        while ((boundary = buf.indexOf(`\n\n`)) !== -1) {
           const raw = buf.slice(0, boundary);
           buf = buf.slice(boundary + 2);
           this.dispatchSseEvent(raw);
@@ -445,27 +470,33 @@ class FetchEventSource implements EventSourceLike {
       }
     } catch (err) {
       if ((err as DOMException)?.name === "AbortError") return;
-      this.onerror?.call({} as EventSource, new Event("error"));
+      this.onerror?.call({} as EventSource, new Event(`error`));
+      this.scheduleReconnect(url, token);
     }
   }
 
   /** Parse a single SSE text block and emit onmessage for data lines. */
   private dispatchSseEvent(text: string): void {
-    let data = "";
-    for (const line of text.split("\n")) {
-      if (line.startsWith(":")) continue; // comment / heartbeat
-      if (line.startsWith("data:")) {
+    let data = ``;
+    for (const line of text.split(`
+`)) {
+      if (line.startsWith(`：`)) continue; // comment / heartbeat
+      if (line.startsWith(`data:`)) {
         data += line.slice(5);
       }
     }
     if (!data) return;
     this.onmessage?.call(
       {} as EventSource,
-      new MessageEvent("message", { data }),
+      new MessageEvent(`message`, { data }),
     );
   }
 
   close(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     this.controller.abort();
   }
 }

--- a/frontend/src/lib/design/components/NavBar.svelte
+++ b/frontend/src/lib/design/components/NavBar.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { status, startStatusPolling, stopStatusPolling } from '$stores/status';
+  import { status, refreshStatus } from '$stores/status';
   import Row from './Row.svelte';
 
   $effect(() => {
-    startStatusPolling();
-    return () => stopStatusPolling();
+    void refreshStatus().catch(() => {});
   });
 
   let currentPath = $derived($page.url.pathname);

--- a/frontend/src/lib/presentation/labels.ts
+++ b/frontend/src/lib/presentation/labels.ts
@@ -52,7 +52,7 @@ export function positionSummaryLines(p: Position): string[] {
       const modeLabel = entryModeLabel(p.entry_mode);
       const approvalLabel = p.approval_mode === 'human_confirmation' ? ' · awaiting approval' : '';
       lines.push(label('ARMED', `${modeLabel}${approvalLabel}`));
-      lines.push(label('LEVERAGE', '10x (fixed)'));
+      lines.push(label('LEVERAGE', '1x (fixed)'));
     } else if (state === 'Active') {
       if (isStale) {
         lines.push(label('STALE', 'not present on exchange'));

--- a/frontend/src/lib/stores/status.ts
+++ b/frontend/src/lib/stores/status.ts
@@ -4,7 +4,6 @@ import { robsonApi, type StatusResponse } from '$api/robson';
 export const status = writable<StatusResponse | null>(null);
 
 let refreshInFlight: Promise<StatusResponse | null> | null = null;
-let pollTimer: ReturnType<typeof setInterval> | null = null;
 
 export async function refreshStatus(): Promise<StatusResponse | null> {
   if (refreshInFlight) return refreshInFlight;
@@ -20,19 +19,4 @@ export async function refreshStatus(): Promise<StatusResponse | null> {
     });
 
   return refreshInFlight;
-}
-
-export function startStatusPolling(intervalMs = 10_000): void {
-  if (pollTimer) return;
-
-  void refreshStatus().catch(() => {});
-  pollTimer = setInterval(() => {
-    void refreshStatus().catch(() => {});
-  }, intervalMs);
-}
-
-export function stopStatusPolling(): void {
-  if (!pollTimer) return;
-  clearInterval(pollTimer);
-  pollTimer = null;
 }

--- a/frontend/src/routes/(authed)/dashboard/+page.svelte
+++ b/frontend/src/routes/(authed)/dashboard/+page.svelte
@@ -47,6 +47,7 @@
   let currentStatus = $derived($sharedStatus);
   let approvalTick = $state(Date.now());
   let approvalTickTimer: ReturnType<typeof setInterval> | null = null;
+  let sseRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
   let currentMonth = $derived(currentMonthKey());
   let monthOps = $derived(sortPositionsOldestFirst(monthlyPositions));
@@ -228,6 +229,14 @@
     await Promise.all([loadStatus(), loadHistory()]);
   }
 
+  function scheduleRefresh(): void {
+    if (sseRefreshTimer) clearTimeout(sseRefreshTimer);
+    sseRefreshTimer = setTimeout(() => {
+      sseRefreshTimer = null;
+      void Promise.all([refreshStatus().catch(() => {}), loadHistory().catch(() => {})]);
+    }, 1_500);
+  }
+
   function startSse() {
     stopSse();
     closeSse = connectEventStream(
@@ -236,14 +245,18 @@
         const payload = event.payload as Record<string, unknown>;
         const posId = payload.position_id as string | undefined;
         if (posId && event.event_type === "position.changed") {
-          void Promise.all([
-            refreshStatus().catch(() => {}),
-            loadHistory().catch(() => {}),
-          ]);
+          scheduleRefresh();
+        }
+        if (event.event_type.startsWith("query.")) {
+          scheduleRefresh();
         }
       },
       () => {
         connected = false;
+      },
+      () => {
+        connected = true;
+        void loadStatus();
       },
     );
   }
@@ -252,6 +265,10 @@
     if (closeSse) {
       closeSse();
       closeSse = null;
+    }
+    if (sseRefreshTimer) {
+      clearTimeout(sseRefreshTimer);
+      sseRefreshTimer = null;
     }
   }
 

--- a/frontend/src/routes/(authed)/funding/[id]/+page.svelte
+++ b/frontend/src/routes/(authed)/funding/[id]/+page.svelte
@@ -10,7 +10,7 @@
   // Decimal strings from the backend; format for display only.
   const fmtUsdt = (v: string | number): string => Number(v).toFixed(2);
 
-  const POLL_INTERVAL_MS = 2_000;
+  const POLL_INTERVAL_MS = 5_000;
   const TERMINAL_STATES = new Set(['REFRESHED', 'FAILED']);
 
   let sagaId = $derived($page.params.id ?? '');

--- a/frontend/src/routes/(authed)/operation/[id]/+page.svelte
+++ b/frontend/src/routes/(authed)/operation/[id]/+page.svelte
@@ -22,6 +22,7 @@
   let events = $state<TaggedEvent[]>([]);
   let seq = $state(0);
   let closeSse: (() => void) | null = null;
+  const MAX_OP_EVENTS = 500;
 
   let summaryLines = $derived(position ? positionSummaryLines(position) : []);
   let metaLine = $derived(position ? positionMetaLine(position) : '');
@@ -42,7 +43,10 @@
       const payload = event.payload as Record<string, unknown>;
       if (payload.position_id === operationId) {
         seq += 1;
-        events = [...events, { ...event, _seq: seq }];
+        const tagged: TaggedEvent = { ...event, _seq: seq };
+        events = events.length >= MAX_OP_EVENTS
+          ? [...events.slice(-(MAX_OP_EVENTS - 1)), tagged]
+          : [...events, tagged];
       }
     });
   }

--- a/frontend/tests/unit/labels.test.ts
+++ b/frontend/tests/unit/labels.test.ts
@@ -52,6 +52,7 @@ describe('positionSummaryLines', () => {
     expect(lines[0]).toContain('ARMED');
     expect(lines[0]).toContain('awaiting entry signal');
     expect(lines[1]).toContain('LEVERAGE');
+    expect(lines[1]).toContain('1x (fixed)');
   });
 
   it('Active state with trailing stop', () => {

--- a/frontend/tests/unit/sse.test.ts
+++ b/frontend/tests/unit/sse.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { FetchEventSource } from '$api/robson';
+
+/** Drain microtask queue: needed because vitest fake timers don't flush async chains. */
+async function flush(rounds = 20): Promise<void> {
+  for (let i = 0; i < rounds; i++) await Promise.resolve();
+}
+
+// Minimal stand-in for the EventSourceLike interface
+type SseSource = {
+  onmessage: ((ev: { data: string }) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  close: () => void;
+};
+
+// Helper: build a FetchEventSource wired to a fake fetch
+function buildSource(
+  fetchImpl: typeof fetch,
+  onReconnect?: () => void,
+): SseSource {
+  vi.stubGlobal('fetch', fetchImpl);
+  return new FetchEventSource('http://localhost/events', null, onReconnect) as unknown as SseSource;
+}
+
+describe('FetchEventSource reconnect backoff', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('schedules reconnect after a non-ok response', async () => {
+    let callCount = 0;
+    const fakeFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      return { ok: false, body: null } as unknown as Response;
+    });
+
+    buildSource(fakeFetch);
+
+    // First call fires immediately in constructor
+    await flush();
+    expect(callCount).toBe(1);
+
+    // Advance past first backoff window (1s * 2^0 = 1000ms)
+    await vi.advanceTimersByTimeAsync(1_100);
+    await flush();
+    expect(callCount).toBe(2);
+
+    // Second backoff is 2s
+    await vi.advanceTimersByTimeAsync(2_100);
+    await flush();
+    expect(callCount).toBe(3);
+  });
+
+  it('resets retry counter after a successful stream', async () => {
+    let callCount = 0;
+
+    // First call succeeds (stream body that closes immediately)
+    // Second call fails, then reconnects at 1s (not 4s, because retries were reset)
+    const fakeFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // Simulate a readable stream that closes right away
+        const encoder = new TextEncoder();
+        const chunk = encoder.encode('data: {"event_id":"x"}\n\n');
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(chunk);
+            controller.close();
+          },
+        });
+        return { ok: true, body: stream } as unknown as Response;
+      }
+      return { ok: false, body: null } as unknown as Response;
+    });
+
+    buildSource(fakeFetch);
+
+    await flush();
+    expect(callCount).toBe(1); // first call (succeeds)
+
+    // Stream closed → schedules reconnect at 1s (retries reset to 0)
+    await vi.advanceTimersByTimeAsync(1_100);
+    await flush();
+    expect(callCount).toBe(2); // reconnect (fails)
+
+    // Next reconnect is again 1s * 2^1 = 2s (retries=1 after the failure)
+    await vi.advanceTimersByTimeAsync(2_100);
+    await flush();
+    expect(callCount).toBe(3);
+  });
+
+  it('does not reconnect after close()', async () => {
+    let callCount = 0;
+    const fakeFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      return { ok: false, body: null } as unknown as Response;
+    });
+
+    const src = buildSource(fakeFetch);
+
+    await flush();
+    expect(callCount).toBe(1);
+
+    src.close();
+
+    // Advancing time should NOT trigger another fetch
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flush();
+    expect(callCount).toBe(1);
+  });
+
+  it('fires onerror callback on connection failure', async () => {
+    const fakeFetch = vi.fn().mockImplementation(async () => ({
+      ok: false,
+      body: null,
+    } as unknown as Response));
+
+    const errors: Event[] = [];
+    const src = buildSource(fakeFetch);
+    src.onerror = (e) => errors.push(e);
+
+    await flush();
+    expect(errors).toHaveLength(1);
+
+    src.close();
+  });
+
+
+  it('notifies onReconnect after a recovered stream', async () => {
+    let callCount = 0;
+    const onReconnect = vi.fn();
+    const fakeFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { ok: false, body: null } as unknown as Response;
+      }
+      const encoder = new TextEncoder();
+      const chunk = encoder.encode('data: {"event_id":"x"}\n\n');
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(chunk);
+          controller.close();
+        },
+      });
+      return { ok: true, body: stream } as unknown as Response;
+    });
+
+    buildSource(fakeFetch, onReconnect);
+
+    await flush();
+    expect(callCount).toBe(1);
+    expect(onReconnect).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1_100);
+    await flush();
+    expect(callCount).toBe(2);
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps backoff at 30s', async () => {
+    let callCount = 0;
+    const fakeFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      return { ok: false, body: null } as unknown as Response;
+    });
+
+    const src = buildSource(fakeFetch);
+    await flush();
+
+    // Drive through 6 retries: 1s,2s,4s,8s,16s,32s→capped at 30s
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersByTimeAsync(32_000);
+      await flush();
+    }
+
+    // 7th retry should fire after at most 30s, not 64s
+    const before = callCount;
+    await vi.advanceTimersByTimeAsync(30_100);
+    await flush();
+    expect(callCount).toBeGreaterThan(before);
+
+    src.close();
+  });
+});
+
+// --- Operation page event cap logic ---
+describe('operation page event cap', () => {
+  it('caps event list at MAX_OP_EVENTS entries', () => {
+    const MAX_OP_EVENTS = 500;
+    let events: { _seq: number }[] = [];
+
+    function pushEvent(seq: number) {
+      const tagged = { _seq: seq };
+      events = events.length >= MAX_OP_EVENTS
+        ? [...events.slice(-(MAX_OP_EVENTS - 1)), tagged]
+        : [...events, tagged];
+    }
+
+    for (let i = 1; i <= 600; i++) pushEvent(i);
+
+    expect(events).toHaveLength(500);
+    // Most recent event is at end
+    expect(events[events.length - 1]._seq).toBe(600);
+    // Oldest kept is seq 101 (600 - 499)
+    expect(events[0]._seq).toBe(101);
+  });
+
+  it('does not cap when under the limit', () => {
+    const MAX_OP_EVENTS = 500;
+    let events: { _seq: number }[] = [];
+
+    function pushEvent(seq: number) {
+      const tagged = { _seq: seq };
+      events = events.length >= MAX_OP_EVENTS
+        ? [...events.slice(-(MAX_OP_EVENTS - 1)), tagged]
+        : [...events, tagged];
+    }
+
+    for (let i = 1; i <= 10; i++) pushEvent(i);
+    expect(events).toHaveLength(10);
+    expect(events[9]._seq).toBe(10);
+  });
+
+  it('retains exactly MAX_OP_EVENTS on boundary push', () => {
+    const MAX_OP_EVENTS = 500;
+    let events: { _seq: number }[] = [];
+
+    function pushEvent(seq: number) {
+      const tagged = { _seq: seq };
+      events = events.length >= MAX_OP_EVENTS
+        ? [...events.slice(-(MAX_OP_EVENTS - 1)), tagged]
+        : [...events, tagged];
+    }
+
+    for (let i = 1; i <= 501; i++) pushEvent(i);
+    expect(events).toHaveLength(500);
+    expect(events[0]._seq).toBe(2);
+    expect(events[499]._seq).toBe(501);
+  });
+});

--- a/robson-domain/src/entities.rs
+++ b/robson-domain/src/entities.rs
@@ -155,8 +155,9 @@ impl Position {
 /// **THE GOLDEN RULE**: Position size is DERIVED from technical stop distance.
 ///
 /// ```text
-/// Position Size = Max Risk Amount / Stop Distance
-///               = (Capital × Risk%) / |Entry - Technical Stop|
+/// Risk-sized qty  = Max Risk Amount / Stop Distance
+/// Margin-sized qty = Capital / Entry Price
+/// Position Size   = min(Risk-sized qty, Margin-sized qty)
 /// ```
 ///
 /// # Example
@@ -165,16 +166,18 @@ impl Position {
 /// # use robson_domain::value_objects::{RiskConfig, Price, TechnicalStopDistance};
 /// # use robson_domain::entities::calculate_position_size;
 /// # use rust_decimal_macros::dec;
-/// let config = RiskConfig::new(dec!(10000)).unwrap(); // $10k, 1% risk
+/// let config = RiskConfig::new(dec!(10000)).unwrap(); // $10k, 1% cap
 /// let entry = Price::new(dec!(95000)).unwrap();
 /// let stop = Price::new(dec!(93500)).unwrap();
 /// let tech_stop = TechnicalStopDistance::from_entry_and_stop(entry, stop);
 ///
-/// let size = calculate_position_size(&config, &tech_stop).unwrap();
+/// let size = calculate_position_size(&config, &entry, &tech_stop).unwrap();
 ///
 /// // Max Risk = $10,000 × 1% = $100
 /// // Stop Distance = $1,500
-/// // Position Size = $100 / $1,500 = 0.0666... BTC
+/// // Margin cap = $10,000 / $95,000 = 0.1052... BTC
+/// // Final Position Size = min($100 / $1,500, $10,000 / $95,000)
+/// // = 0.0666... BTC
 /// assert!(size.as_decimal() > dec!(0.066) && size.as_decimal() < dec!(0.067));
 /// ```
 ///
@@ -182,7 +185,7 @@ impl Position {
 ///
 /// - Wide technical stop → Smaller position size
 /// - Tight technical stop → Larger position size
-/// - **Risk amount stays CONSTANT at the configured percentage**
+/// - **Risk amount stays at or below the configured maximum**
 ///
 /// # Errors
 ///
@@ -191,6 +194,7 @@ impl Position {
 /// - Calculated quantity would be <= 0
 pub fn calculate_position_size(
     risk_config: &RiskConfig,
+    entry_price: &Price,
     tech_stop: &TechnicalStopDistance,
 ) -> Result<Quantity, DomainError> {
     // Validate tech stop first
@@ -202,9 +206,17 @@ pub fn calculate_position_size(
         return Err(DomainError::PositionSizingError("Stop distance must be positive".to_string()));
     }
 
-    // Golden Rule: Position Size = Max Risk / Stop Distance
+    let entry = entry_price.as_decimal();
+    if entry <= rust_decimal::Decimal::ZERO {
+        return Err(DomainError::PositionSizingError("Entry price must be positive".to_string()));
+    }
+
+    // Golden Rule: size by stop risk, then cap by available 1x margin.
     let max_risk = risk_config.max_risk_amount();
-    let position_size = max_risk / stop_distance;
+    let risk_sized_qty = max_risk / stop_distance;
+    let margin_sized_qty =
+        (risk_config.capital() * rust_decimal::Decimal::from(RiskConfig::LEVERAGE)) / entry;
+    let position_size = risk_sized_qty.min(margin_sized_qty);
 
     if position_size <= rust_decimal::Decimal::ZERO {
         return Err(DomainError::PositionSizingError(
@@ -1002,7 +1014,7 @@ mod tests {
     // Position Sizing tests (Golden Rule)
     #[test]
     fn test_calculate_position_size_basic() {
-        // Setup: $10,000 capital, 1% risk
+        // Setup: $10,000 capital, 1% cap
         let config = RiskConfig::new(dec!(10000)).unwrap();
 
         // Entry: $95,000, Stop: $93,500 (distance = $1,500)
@@ -1010,7 +1022,7 @@ mod tests {
         let stop = Price::new(dec!(93500)).unwrap();
         let tech_stop = TechnicalStopDistance::from_entry_and_stop(entry, stop);
 
-        let size = calculate_position_size(&config, &tech_stop).unwrap();
+        let size = calculate_position_size(&config, &entry, &tech_stop).unwrap();
 
         // Expected: $100 risk / $1,500 distance = 0.0666... BTC
         // Check it's approximately 0.0666...
@@ -1028,7 +1040,7 @@ mod tests {
         let stop = Price::new(dec!(92000)).unwrap();
         let tech_stop = TechnicalStopDistance::from_entry_and_stop(entry, stop);
 
-        let size = calculate_position_size(&config, &tech_stop).unwrap();
+        let size = calculate_position_size(&config, &entry, &tech_stop).unwrap();
 
         // Expected: $100 / $3,000 = 0.0333... BTC
         let expected = dec!(100) / dec!(3000);
@@ -1036,8 +1048,8 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_position_size_tighter_stop() {
-        // Tighter stop = larger position
+    fn test_calculate_position_size_tighter_stop_is_margin_capped() {
+        // Tighter stop would normally allow a larger position, but 1x margin caps it.
         let config = RiskConfig::new(dec!(10000)).unwrap();
 
         // Tight stop: $500 distance (still valid, ~0.5%)
@@ -1045,22 +1057,24 @@ mod tests {
         let stop = Price::new(dec!(94500)).unwrap();
         let tech_stop = TechnicalStopDistance::from_entry_and_stop(entry, stop);
 
-        let size = calculate_position_size(&config, &tech_stop).unwrap();
+        let size = calculate_position_size(&config, &entry, &tech_stop).unwrap();
 
-        // Expected: $100 / $500 = 0.2 BTC
-        assert_eq!(size.as_decimal(), dec!(0.2));
+        let expected = config.capital() / entry.as_decimal();
+        let loss = size.as_decimal() * dec!(500);
+        assert_eq!(size.as_decimal().round_dp(8), expected.round_dp(8));
+        assert!(loss < config.max_risk_amount());
     }
 
     #[test]
     fn test_calculate_position_size_higher_capital() {
-        // v3: risk is always 1%, but with higher capital ($50k)
+        // v3: risk cap is 1%, but with higher capital ($50k)
         let config = RiskConfig::new(dec!(50000)).unwrap();
 
         let entry = Price::new(dec!(95000)).unwrap();
         let stop = Price::new(dec!(93500)).unwrap();
         let tech_stop = TechnicalStopDistance::from_entry_and_stop(entry, stop);
 
-        let size = calculate_position_size(&config, &tech_stop).unwrap();
+        let size = calculate_position_size(&config, &entry, &tech_stop).unwrap();
 
         // Expected: $500 (1% of 50k) / $1,500 = 0.3333... BTC
         let expected = dec!(500) / dec!(1500);
@@ -1087,16 +1101,17 @@ mod tests {
     }
 
     #[test]
-    fn test_position_sizing_risk_stays_constant() {
+    fn test_position_sizing_risk_stays_within_cap() {
         // This test validates the golden rule:
-        // Regardless of stop distance, the risk amount is always 1% of capital
+        // Regardless of stop distance, the realized risk stays at or below 1% of
+        // capital
         let config = RiskConfig::new(dec!(10000)).unwrap(); // $100 risk
 
         // Test 1: Wide stop ($3,000)
         let entry1 = Price::new(dec!(95000)).unwrap();
         let stop1 = Price::new(dec!(92000)).unwrap();
         let tech_stop1 = TechnicalStopDistance::from_entry_and_stop(entry1, stop1);
-        let size1 = calculate_position_size(&config, &tech_stop1).unwrap();
+        let size1 = calculate_position_size(&config, &entry1, &tech_stop1).unwrap();
         // If stopped out: loss = 0.0333... * $3,000 = $100 ✓
         let loss1 = size1.as_decimal() * dec!(3000);
         // Use round to handle decimal precision
@@ -1106,11 +1121,28 @@ mod tests {
         let entry2 = Price::new(dec!(95000)).unwrap();
         let stop2 = Price::new(dec!(94000)).unwrap();
         let tech_stop2 = TechnicalStopDistance::from_entry_and_stop(entry2, stop2);
-        let size2 = calculate_position_size(&config, &tech_stop2).unwrap();
+        let size2 = calculate_position_size(&config, &entry2, &tech_stop2).unwrap();
         // If stopped out: loss = 0.1 * $1,000 = $100 ✓
         let loss2 = size2.as_decimal() * dec!(1000);
         assert_eq!(loss2, dec!(100));
 
-        // Both positions risk exactly $100 (1% of capital)
+        // Both positions stay within the 1% risk cap.
+    }
+
+    #[test]
+    fn test_calculate_position_size_caps_by_margin() {
+        let config = RiskConfig::new(dec!(351.92170492)).unwrap();
+        let entry = Price::new(dec!(59623.10)).unwrap();
+        let stop = Price::new(dec!(59295.60)).unwrap();
+        let tech_stop = TechnicalStopDistance::from_entry_and_stop(entry, stop);
+
+        let size = calculate_position_size(&config, &entry, &tech_stop).unwrap();
+        let qty = size.as_decimal();
+        let risk_loss = qty * dec!(327.50);
+        let margin_cap = config.capital() / entry.as_decimal();
+
+        assert_eq!(qty.round_dp(8), margin_cap.round_dp(8));
+        assert!(risk_loss < config.max_risk_amount());
+        assert!(risk_loss.round_dp(2) < dec!(3.52));
     }
 }

--- a/robson-domain/src/policy.rs
+++ b/robson-domain/src/policy.rs
@@ -110,9 +110,9 @@ pub enum SignalEvaluationOutcome {
 
 /// Primary trading policy with immutable risk parameters (ADR-0024 Decision 2).
 ///
-/// Risk per trade (1%) and max monthly drawdown (4%) are fixed by product
-/// definition. These values are not configurable via environment variables,
-/// operator API, or any runtime mechanism.
+/// Risk per trade (1% maximum-loss cap) and max monthly drawdown (4%) are fixed
+/// by product definition. These values are not configurable via environment
+/// variables, operator API, or any runtime mechanism.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TradingPolicy {
     /// Risk per trade as percentage of capital. Fixed at 1%.
@@ -122,7 +122,7 @@ pub struct TradingPolicy {
 }
 
 impl TradingPolicy {
-    /// Returns the default policy (1% risk, 4% max drawdown).
+    /// Returns the default policy (1% maximum-loss cap, 4% max drawdown).
     pub fn new() -> Self {
         Self {
             risk_per_trade_pct: Decimal::ONE,

--- a/robson-domain/src/value_objects.rs
+++ b/robson-domain/src/value_objects.rs
@@ -268,8 +268,9 @@ impl fmt::Display for OrderSide {
 
 /// Risk configuration for position sizing (v3 policy)
 ///
-/// Risk per trade is FIXED at 1% of capital. This is a v3 policy decision:
-/// no configuration, no alternative modes, no overrides.
+/// Risk per trade is capped at 1% of capital. This is a v3 policy decision:
+/// no configuration, no alternative modes, no overrides, and actual realized
+/// risk may be lower when the available 1x margin caps the position size.
 ///
 /// Position size is derived from the Golden Rule:
 ///
@@ -298,7 +299,7 @@ impl RiskConfig {
     /// stop-derived sizing.
     pub const LEVERAGE: u8 = 1;
 
-    /// Fixed risk per trade: 1% of capital (v3 policy — non-negotiable)
+    /// Maximum risk per trade: 1% of capital (v3 policy — non-negotiable)
     pub const RISK_PER_TRADE_PCT: Decimal = Decimal::ONE;
 
     /// Create a new RiskConfig with validation
@@ -320,14 +321,14 @@ impl RiskConfig {
         self.capital
     }
 
-    /// Get risk percentage (always 1%)
+    /// Get risk percentage cap (always 1%)
     pub fn risk_per_trade_pct(&self) -> Decimal {
         Self::RISK_PER_TRADE_PCT
     }
 
     /// Calculate max risk amount in quote currency
     ///
-    /// Returns: Capital × 1% (fixed)
+    /// Returns: Capital × 1% (maximum loss cap)
     pub fn max_risk_amount(&self) -> Decimal {
         self.capital * Self::RISK_PER_TRADE_PCT / Decimal::from(100)
     }
@@ -342,7 +343,7 @@ impl fmt::Display for RiskConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "RiskConfig {{ capital: {}, risk: 1% (fixed), leverage: {}x }}",
+            "RiskConfig {{ capital: {}, risk cap: 1% max, leverage: {}x }}",
             self.capital,
             Self::LEVERAGE
         )
@@ -629,7 +630,7 @@ mod tests {
         assert_eq!(Side::Short.exit_action(), OrderSide::Buy);
     }
 
-    // RiskConfig tests (v3: fixed 1% risk)
+    // RiskConfig tests (v3: 1% maximum-loss cap)
     #[test]
     fn test_risk_config_validation() {
         // Valid: positive capital
@@ -649,11 +650,11 @@ mod tests {
         // Risk is always 1%, regardless of capital
         let config = RiskConfig::new(dec!(10000)).unwrap();
         assert_eq!(config.risk_per_trade_pct(), dec!(1));
-        assert_eq!(config.max_risk_amount(), dec!(100)); // 1% of 10000
+        assert_eq!(config.max_risk_amount(), dec!(100)); // 1% max of 10000
 
         let config2 = RiskConfig::new(dec!(50000)).unwrap();
         assert_eq!(config2.risk_per_trade_pct(), dec!(1)); // still 1%
-        assert_eq!(config2.max_risk_amount(), dec!(500)); // 1% of 50000
+        assert_eq!(config2.max_risk_amount(), dec!(500)); // 1% max of 50000
     }
 
     #[test]

--- a/robson-engine/src/lib.rs
+++ b/robson-engine/src/lib.rs
@@ -432,7 +432,7 @@ impl Engine {
         tech_stop.validate().map_err(|e| EngineError::DomainError(e))?;
 
         // 4. Calculate position size (Golden Rule)
-        let quantity = calculate_position_size(&self.risk_config, &tech_stop)
+        let quantity = calculate_position_size(&self.risk_config, &signal.entry_price, &tech_stop)
             .map_err(|e| EngineError::DomainError(e))?;
 
         debug!(

--- a/robson-engine/src/risk.rs
+++ b/robson-engine/src/risk.rs
@@ -413,7 +413,7 @@ impl RiskGate {
         }
 
         // 2. Check physical capital bound. At 1x, stop-derived notional must fit
-        // available margin; tight stops may create a valid 1% risk amount but an
+        // available margin; tight stops may create a valid 1% loss amount but an
         // invalid position size for the account.
         if proposed.initial_margin > context.capital {
             debug!(

--- a/robsond/src/daemon.rs
+++ b/robsond/src/daemon.rs
@@ -775,8 +775,9 @@ impl<E: ExchangePort + 'static, S: Store + 'static> Daemon<E, S> {
         let carried_risk_committed = Self::calculate_carried_risk(&open_positions);
 
         // Armed positions have no measurable committed risk yet, but each will
-        // risk exactly 1% of capital when triggered. Use the previous month's
-        // capital_base to avoid a circular month-boundary calculation.
+        // be sized so the stop loss stays at or below 1% of capital when triggered.
+        // Use the previous month's capital_base to avoid a circular month-boundary
+        // calculation.
         let (prev_year, prev_month_num) = if now.month() == 1 {
             (now.year() - 1, 12u32)
         } else {

--- a/robsond/src/position_manager.rs
+++ b/robsond/src/position_manager.rs
@@ -197,7 +197,7 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
     ///
     /// Called at startup after querying the exchange and whenever the engine's
     /// capital needs to be refreshed. Updates the internal `RiskConfig` while
-    /// preserving the fixed 1% risk-per-trade policy.
+    /// preserving the 1% maximum-loss cap.
     pub fn update_engine_capital(&self, capital: Decimal) {
         use robson_domain::RiskConfig;
         if let Ok(risk_config) = RiskConfig::new(capital) {
@@ -3324,7 +3324,7 @@ mod tests {
         let exchange = Arc::new(StubExchange::new(dec!(95000)));
         let journal = Arc::new(IntentJournal::new());
         let executor = Arc::new(Executor::new(exchange, journal, store.clone()));
-        let risk_config = RiskConfig::new(dec!(10000)).unwrap(); // 1% risk
+        let risk_config = RiskConfig::new(dec!(10000)).unwrap(); // 1% cap
         let engine = Engine::new(risk_config);
 
         Arc::new(
@@ -3379,7 +3379,7 @@ mod tests {
     }
 
     fn create_test_risk_config() -> RiskConfig {
-        RiskConfig::new(dec!(10000)).unwrap() // 1% risk
+        RiskConfig::new(dec!(10000)).unwrap() // 1% cap
     }
 
     fn create_test_candles() -> Vec<Candle> {
@@ -3809,8 +3809,7 @@ mod tests {
             .await
             .unwrap();
 
-        // 8% stop — passes risk gate (≥6.67% threshold on $10k capital, 1% risk, 15%
-        // max single)
+        // 8% stop — passes risk gate (1% loss cap on $10k capital; margin still fits)
         let signal = DetectorSignal {
             signal_id: Uuid::now_v7(),
             position_id: position.id,

--- a/robsond/src/position_manager.rs
+++ b/robsond/src/position_manager.rs
@@ -2167,9 +2167,46 @@ impl<E: ExchangePort + 'static, S: Store + 'static> PositionManager<E, S> {
                     }
                 }
 
-                // Record risk denial in Prometheus metrics
-                if let QueryState::Denied { ref check, .. } = query.state {
+                // Record risk denial in Prometheus metrics.
+                let denied_check = match &query.state {
+                    QueryState::Denied { check, .. } => Some(check.clone()),
+                    _ => None,
+                };
+                if let Some(check) = denied_check.as_deref() {
                     crate::metrics::RISK_DENIALS.with_label_values(&[check]).inc();
+                }
+
+                let entry_policy = self.entry_policy_for_position(position_id).await;
+                if entry_policy.mode == EntryPolicy::Immediate
+                    && denied_check.as_deref() == Some("insufficient_margin")
+                {
+                    info!(
+                        %position_id,
+                        query_id = %query.id,
+                        "Immediate entry denied by margin policy - cancelling Armed position"
+                    );
+                    self.invalidate_pending_approvals_for_position(
+                        position_id,
+                        "immediate entry denied by insufficient margin",
+                    )
+                    .await;
+                    self.kill_detector(position_id).await;
+                    self.execute_and_persist(vec![EngineAction::EmitEvent(
+                        Event::PositionDisarmed {
+                            position_id,
+                            reason: "risk_denied_insufficient_margin".to_string(),
+                            timestamp: chrono::Utc::now(),
+                        },
+                    )])
+                    .await?;
+                    self.event_bus.send(DaemonEvent::PositionStateChanged {
+                        position_id,
+                        previous_state: "Armed".to_string(),
+                        new_state: "Cancelled".to_string(),
+                        timestamp: chrono::Utc::now(),
+                    });
+                    self.entry_policies.write().await.remove(&position_id);
+                    return Ok(());
                 }
 
                 // Re-arm the detector so the Armed position can receive future signals.
@@ -4678,6 +4715,57 @@ mod tests {
         );
         let events = manager.store.events().find_by_position(position.id).await.unwrap();
         assert!(events.iter().any(|event| matches!(event, Event::EntrySignalReceived { .. })));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_arm_immediate_insufficient_margin_cancels_without_rearming() {
+        use robson_domain::{ApprovalPolicy as DomainApprovalPolicy, EntryPolicy};
+
+        let manager = create_test_manager().await;
+        let symbol = Symbol::from_pair("BTCUSDT").unwrap();
+        let arm_policy =
+            EntryPolicyConfig::new(EntryPolicy::ConfirmedTrend, DomainApprovalPolicy::Automatic);
+        let immediate_policy =
+            EntryPolicyConfig::new(EntryPolicy::Immediate, DomainApprovalPolicy::Automatic);
+
+        let position = manager
+            .arm_position_with_policy(
+                symbol.clone(),
+                Side::Long,
+                RiskConfig::new(dec!(100)).unwrap(),
+                None,
+                Uuid::now_v7(),
+                arm_policy,
+            )
+            .await
+            .unwrap();
+        manager.entry_policies.write().await.insert(position.id, immediate_policy);
+
+        let signal = DetectorSignal {
+            signal_id: Uuid::now_v7(),
+            position_id: position.id,
+            symbol,
+            side: Side::Long,
+            entry_price: Price::new(dec!(95000)).unwrap(),
+            stop_loss: Price::new(dec!(94700)).unwrap(),
+            technical_stop_analysis: None,
+            timestamp: chrono::Utc::now(),
+        };
+
+        manager.handle_signal(signal).await.unwrap();
+
+        let position = manager.get_position(position.id).await.unwrap().unwrap();
+        assert!(
+            matches!(position.state, PositionState::Cancelled),
+            "Immediate insufficient-margin denial must cancel, got {:?}",
+            position.state
+        );
+
+        let detectors = manager.detectors.read().await;
+        assert!(
+            !detectors.contains_key(&position.id),
+            "Immediate insufficient-margin denial must not re-arm detector"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary
- Remove redundant navbar polling and keep SSE as the delta path.
- Add SSE reconnect with exponential backoff and explicit resync on recovery.
- Debounce dashboard refreshes, cap operation event growth, and keep funding polling terminal-aware.

## Why
The frontend was doing avoidable background work even though SSE already carries the state change signal. That made the UI feel heavier over time without improving trading semantics.

## Validation
- npm run check
- npm test
- npm run build